### PR TITLE
Mark non cls compliant methods as such

### DIFF
--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -328,7 +328,7 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<sbyte> source)
         {
             return ToDelimitedString(source, null);
@@ -350,7 +350,7 @@ namespace MoreLinq
         /// simple ToString() conversion.</param>
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
@@ -439,7 +439,7 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<uint> source)
         {
             return ToDelimitedString(source, null);
@@ -461,7 +461,7 @@ namespace MoreLinq
         /// simple ToString() conversion.</param>
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
@@ -476,7 +476,7 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ulong> source)
         {
             return ToDelimitedString(source, null);
@@ -498,7 +498,7 @@ namespace MoreLinq
         /// simple ToString() conversion.</param>
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
@@ -513,7 +513,7 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ushort> source)
         {
             return ToDelimitedString(source, null);
@@ -535,7 +535,7 @@ namespace MoreLinq
         /// simple ToString() conversion.</param>
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
-
+        [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -33,43 +33,6 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
 
-        public static string ToDelimitedString(this IEnumerable<string> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        static partial class StringBuilderAppenders 
-        {
-            public static readonly Func<StringBuilder, string, StringBuilder> String = (sb, e) => sb.Append(e);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values and
-        /// a given delimiter.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
-
-        public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
-        {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-
         public static string ToDelimitedString(this IEnumerable<bool> source)
         {
             return ToDelimitedString(source, null);
@@ -95,43 +58,6 @@ namespace MoreLinq
         public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-
-        public static string ToDelimitedString(this IEnumerable<sbyte> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        static partial class StringBuilderAppenders 
-        {
-            public static readonly Func<StringBuilder, sbyte, StringBuilder> SByte = (sb, e) => sb.Append(e);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values and
-        /// a given delimiter.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
-
-        public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
-        {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
         }
 
         /// <summary>
@@ -218,14 +144,14 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
 
-        public static string ToDelimitedString(this IEnumerable<short> source)
+        public static string ToDelimitedString(this IEnumerable<decimal> source)
         {
             return ToDelimitedString(source, null);
         }
 
         static partial class StringBuilderAppenders 
         {
-            public static readonly Func<StringBuilder, short, StringBuilder> Int16 = (sb, e) => sb.Append(e);
+            public static readonly Func<StringBuilder, decimal, StringBuilder> Decimal = (sb, e) => sb.Append(e);
         }
 
         /// <summary>
@@ -240,9 +166,83 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
         {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values. The 
+        /// delimiter used depends on the current culture of the executing thread.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+
+        public static string ToDelimitedString(this IEnumerable<double> source)
+        {
+            return ToDelimitedString(source, null);
+        }
+
+        static partial class StringBuilderAppenders 
+        {
+            public static readonly Func<StringBuilder, double, StringBuilder> Double = (sb, e) => sb.Append(e);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values and
+        /// a given delimiter.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
+        /// the executing thread's current culture's list separator is used.</param>
+
+        public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
+        {
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values. The 
+        /// delimiter used depends on the current culture of the executing thread.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+
+        public static string ToDelimitedString(this IEnumerable<float> source)
+        {
+            return ToDelimitedString(source, null);
+        }
+
+        static partial class StringBuilderAppenders 
+        {
+            public static readonly Func<StringBuilder, float, StringBuilder> Single = (sb, e) => sb.Append(e);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values and
+        /// a given delimiter.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
+        /// the executing thread's current culture's list separator is used.</param>
+
+        public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
+        {
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
         }
 
         /// <summary>
@@ -329,14 +329,14 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
 
-        public static string ToDelimitedString(this IEnumerable<float> source)
+        public static string ToDelimitedString(this IEnumerable<sbyte> source)
         {
             return ToDelimitedString(source, null);
         }
 
         static partial class StringBuilderAppenders 
         {
-            public static readonly Func<StringBuilder, float, StringBuilder> Single = (sb, e) => sb.Append(e);
+            public static readonly Func<StringBuilder, sbyte, StringBuilder> SByte = (sb, e) => sb.Append(e);
         }
 
         /// <summary>
@@ -351,9 +351,9 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
         }
 
         /// <summary>
@@ -366,14 +366,14 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
 
-        public static string ToDelimitedString(this IEnumerable<double> source)
+        public static string ToDelimitedString(this IEnumerable<short> source)
         {
             return ToDelimitedString(source, null);
         }
 
         static partial class StringBuilderAppenders 
         {
-            public static readonly Func<StringBuilder, double, StringBuilder> Double = (sb, e) => sb.Append(e);
+            public static readonly Func<StringBuilder, short, StringBuilder> Int16 = (sb, e) => sb.Append(e);
         }
 
         /// <summary>
@@ -388,9 +388,9 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
         {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
         }
 
         /// <summary>
@@ -403,14 +403,14 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
 
-        public static string ToDelimitedString(this IEnumerable<decimal> source)
+        public static string ToDelimitedString(this IEnumerable<string> source)
         {
             return ToDelimitedString(source, null);
         }
 
         static partial class StringBuilderAppenders 
         {
-            public static readonly Func<StringBuilder, decimal, StringBuilder> Decimal = (sb, e) => sb.Append(e);
+            public static readonly Func<StringBuilder, string, StringBuilder> String = (sb, e) => sb.Append(e);
         }
 
         /// <summary>
@@ -425,46 +425,9 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
         {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-
-        public static string ToDelimitedString(this IEnumerable<ushort> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        static partial class StringBuilderAppenders 
-        {
-            public static readonly Func<StringBuilder, ushort, StringBuilder> UInt16 = (sb, e) => sb.Append(e);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values and
-        /// a given delimiter.
-        /// </summary>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
-
-        public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
-        {
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
         }
 
         /// <summary>
@@ -539,6 +502,43 @@ namespace MoreLinq
         public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values. The 
+        /// delimiter used depends on the current culture of the executing thread.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+
+        public static string ToDelimitedString(this IEnumerable<ushort> source)
+        {
+            return ToDelimitedString(source, null);
+        }
+
+        static partial class StringBuilderAppenders 
+        {
+            public static readonly Func<StringBuilder, ushort, StringBuilder> UInt16 = (sb, e) => sb.Append(e);
+        }
+
+        /// <summary>
+        /// Creates a delimited string from a sequence of values and
+        /// a given delimiter.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses immediate execution and effectively buffers the sequence.
+        /// </remarks>
+        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
+        /// simple ToString() conversion.</param>
+        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
+        /// the executing thread's current culture's list separator is used.</param>
+
+        public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
+        {
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);
         }
 
 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -39,11 +39,13 @@ namespace MoreLinq
             where parameters.Length == 1
             select parameters.First().ParameterType into type
             where type.IsValueType || type == typeof(string)
-            select new 
+            let res = new
             {
                 Type = type,
                 Name = cscp.GetTypeOutput(new CodeTypeReference(type)),
-            };
+            }
+            orderby res.Name
+            select res;
         foreach (var type in types) { #>
         /// <summary>
         /// Creates a delimited string from a sequence of values. The 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -46,7 +46,20 @@ namespace MoreLinq
             }
             orderby res.Name
             select res;
-        foreach (var type in types) { #>
+        foreach (var type in types) {
+			string attribute;
+			switch(type.Name.ToLowerInvariant()) {
+			case "sbyte":
+			case "ulong":
+			case "ushort":
+			case "uint":
+				attribute = "        [CLSCompliant(false)]";
+				break;
+			default:
+				attribute = "";
+				break;
+			}
+        #>
         /// <summary>
         /// Creates a delimited string from a sequence of values. The 
         /// delimiter used depends on the current culture of the executing thread.
@@ -56,7 +69,7 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-
+<#= attribute #>
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source)
         {
             return ToDelimitedString(source, null);
@@ -78,7 +91,7 @@ namespace MoreLinq
         /// simple ToString() conversion.</param>
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
-
+<#= attribute #>
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, string delimiter)
         {
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.<#= type.Type.Name #>);


### PR DESCRIPTION
This enables compilation on mono.

The order of the methods was not the same, so I first made the order deterministic. This should minimize diffs in the future.