### PR TITLE
Null checks

### DIFF
--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -39,10 +39,9 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void MaxByNullComparer()
         {
-            SampleData.Strings.MaxBy(x => x.Length, null);
+            Assert.AreEqual("hello", SampleData.Strings.MaxBy(x => x.Length, null));
         }
 
         [Test]

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -39,10 +39,9 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
         public void MinByNullComparer()
         {
-            SampleData.Strings.MinBy(x => x.Length, null);
+            Assert.AreEqual("ax", SampleData.Strings.MinBy(x => x.Length, null));
         }
 
         [Test]

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -110,14 +110,14 @@ namespace MoreLinq.Test
 
         private bool CanBeNull(ParameterInfo parameter)
         {
-            var type = parameter.ParameterType;
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof (IEqualityComparer<>)) return true;
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof (IComparer<>)) return true;
-            if (parameter.Member.Name == "ToDataTable" && parameter.Name == "expressions") return true;
-            if (parameter.Member.Name == "ToDelimitedString" && parameter.Name == "delimiter") return true;
-            if (parameter.Member.Name == "Trace" && parameter.Name == "format") return true;
+            var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
+            var nullableParameters = new[] { "ToDataTable.expressions", "ToDelimitedString.delimiter", "Trace.format" };
 
-            return false;
+            var type = parameter.ParameterType;
+            type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+            var param = parameter.Member.Name + "." + parameter.Name;
+
+            return nullableTypes.Contains(type) || nullableParameters.Contains(param);
         }
 
         private object CreateInstance(Type type)

--- a/MoreLinq/CanBeNullAttribute.cs
+++ b/MoreLinq/CanBeNullAttribute.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace MoreLinq
-{
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
-    internal class CanBeNullAttribute : Attribute
-    {
-    }
-}

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -68,7 +68,7 @@ namespace MoreLinq
         /// comparing them by the specified key projection.</returns>
         
         public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector, [CanBeNull] IEqualityComparer<TKey> comparer)
+            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -73,7 +73,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector,
-            [CanBeNull] IEqualityComparer<TKey> keyComparer)
+            IEqualityComparer<TKey> keyComparer)
         {
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -83,7 +83,7 @@ namespace MoreLinq
         public static IEnumerable<IGrouping<TKey, TSource>> GroupAdjacent<TSource, TKey>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
-            [CanBeNull] IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey> comparer)
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
@@ -160,7 +160,7 @@ namespace MoreLinq
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
-            [CanBeNull] IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey> comparer)
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -43,7 +43,7 @@ namespace MoreLinq
         public static TSource MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
-            return source.MaxBy(selector, Comparer<TKey>.Default);
+            return source.MaxBy(selector, null);
         }
 
         /// <summary>
@@ -52,8 +52,7 @@ namespace MoreLinq
         /// </summary>
         /// <remarks>
         /// If more than one element has the maximal projected value, the first
-        /// one encountered will be returned. This overload uses the default comparer
-        /// for the projected type. This operator uses immediate execution, but
+        /// one encountered will be returned. This operator uses immediate execution, but
         /// only buffers a single result (the current maximal element).
         /// </remarks>
         /// <typeparam name="TSource">Type of the source sequence</typeparam>
@@ -71,7 +70,8 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException("source");
             if (selector == null) throw new ArgumentNullException("selector");
-            if (comparer == null) throw new ArgumentNullException("comparer");
+            comparer = comparer ?? Comparer<TKey>.Default;
+
             using (var sourceIterator = source.GetEnumerator())
             {
                 if (!sourceIterator.MoveNext())

--- a/MoreLinq/MinBy.cs
+++ b/MoreLinq/MinBy.cs
@@ -43,7 +43,7 @@ namespace MoreLinq
         public static TSource MinBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
-            return source.MinBy(selector, Comparer<TKey>.Default);
+            return source.MinBy(selector, null);
         }
 
         /// <summary>
@@ -52,8 +52,7 @@ namespace MoreLinq
         /// </summary>
         /// <remarks>
         /// If more than one element has the minimal projected value, the first
-        /// one encountered will be returned. This overload uses the default comparer
-        /// for the projected type. This operator uses immediate execution, but
+        /// one encountered will be returned. This operator uses immediate execution, but
         /// only buffers a single result (the current minimal element).
         /// </remarks>
         /// <typeparam name="TSource">Type of the source sequence</typeparam>
@@ -71,7 +70,8 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException("source");
             if (selector == null) throw new ArgumentNullException("selector");
-            if (comparer == null) throw new ArgumentNullException("comparer");
+            comparer = comparer ?? Comparer<TKey>.Default;
+
             using (var sourceIterator = source.GetEnumerator())
             {
                 if (!sourceIterator.MoveNext())

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -65,7 +65,6 @@
     <Compile Include="Batch.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
-    <Compile Include="CanBeNullAttribute.cs" />
     <Compile Include="Concat.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -49,7 +49,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CanBeNullAttribute.cs" />
     <Compile Include="Fold.g.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -59,7 +59,7 @@ namespace MoreLinq
         public static IEnumerable<T> OrderedMerge<T>(
             this IEnumerable<T> first,
             IEnumerable<T> second,
-            [CanBeNull] IComparer<T> comparer)
+            IComparer<T> comparer)
         {
             return OrderedMerge(first, second, e => e, f => f, s => s, (a, _) => a, comparer);
         }
@@ -128,7 +128,7 @@ namespace MoreLinq
             Func<T, TResult> firstSelector,
             Func<T, TResult> secondSelector,
             Func<T, T, TResult> bothSelector,
-            [CanBeNull] IComparer<TKey> comparer)
+            IComparer<TKey> comparer)
         {
             if (keySelector == null) throw new ArgumentNullException("keySelector"); // Argument name changes to 'firstKeySelector'
             return OrderedMerge(first, second, keySelector, keySelector, firstSelector, secondSelector, bothSelector, comparer);
@@ -181,7 +181,7 @@ namespace MoreLinq
             Func<TFirst, TResult> firstSelector,
             Func<TSecond, TResult> secondSelector,
             Func<TFirst, TSecond, TResult> bothSelector,
-            [CanBeNull] IComparer<TKey> comparer)
+            IComparer<TKey> comparer)
         {
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -75,7 +75,7 @@ namespace MoreLinq
         /// </summary>
 
         public static IEnumerable<IEnumerable<TSource>> Split<TSource>(this IEnumerable<TSource> source,
-            TSource separator, [CanBeNull] IEqualityComparer<TSource> comparer)
+            TSource separator, IEqualityComparer<TSource> comparer)
         {
             return Split(source, separator, comparer, int.MaxValue);
         }
@@ -87,7 +87,7 @@ namespace MoreLinq
         /// </summary>
 
         public static IEnumerable<IEnumerable<TSource>> Split<TSource>(this IEnumerable<TSource> source,
-            TSource separator, [CanBeNull] IEqualityComparer<TSource> comparer, int count)
+            TSource separator, IEqualityComparer<TSource> comparer, int count)
         {
             return Split(source, separator, comparer, count, s => s);
         }
@@ -99,7 +99,7 @@ namespace MoreLinq
         /// </summary>
 
         public static IEnumerable<TResult> Split<TSource, TResult>(this IEnumerable<TSource> source,
-            TSource separator, [CanBeNull] IEqualityComparer<TSource> comparer,
+            TSource separator, IEqualityComparer<TSource> comparer,
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {
             return Split(source, separator, comparer, int.MaxValue, resultSelector);
@@ -112,7 +112,7 @@ namespace MoreLinq
         /// </summary>
 
         public static IEnumerable<TResult> Split<TSource, TResult>(this IEnumerable<TSource> source,
-            TSource separator, [CanBeNull] IEqualityComparer<TSource> comparer, int count,
+            TSource separator, IEqualityComparer<TSource> comparer, int count,
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {
             if (source == null) throw new ArgumentNullException("source");

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -179,7 +179,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
         
-        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, [CanBeNull] params Expression<Func<T, object>>[] expressions)
+        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
             where TTable : DataTable
         {
             if (source == null) throw new ArgumentNullException("source");
@@ -244,7 +244,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
        
-        public static DataTable ToDataTable<T>(this IEnumerable<T> source, [CanBeNull] params Expression<Func<T, object>>[] expressions)
+        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object>>[] expressions)
         {
             return ToDataTable(source, new DataTable(), expressions);
         }

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -54,7 +54,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -55,7 +55,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<bool> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
@@ -93,7 +93,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<byte> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<byte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Byte);
@@ -131,7 +131,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<char> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<char> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Char);
@@ -169,7 +169,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<decimal> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
@@ -207,7 +207,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<double> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
@@ -245,7 +245,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<float> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
@@ -283,7 +283,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<int> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<int> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int32);
@@ -321,7 +321,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<long> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<long> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int64);
@@ -359,7 +359,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
         [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<sbyte> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
@@ -397,7 +397,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<short> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
@@ -435,7 +435,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 
-        public static string ToDelimitedString(this IEnumerable<string> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
@@ -473,7 +473,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
         [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<uint> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
@@ -511,7 +511,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
         [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<ulong> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
@@ -549,7 +549,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
         [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<ushort> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -92,7 +92,7 @@ namespace MoreLinq
         /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
         /// the executing thread's current culture's list separator is used.</param>
 <#= attribute #>
-        public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, [CanBeNull] string delimiter)
+        public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.<#= type.Type.Name #>);

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -51,7 +51,7 @@ namespace MoreLinq
         /// <returns>A hash set of the items in the sequence, using the default equality comparer.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
         
-        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, [CanBeNull] IEqualityComparer<TSource> comparer)
+        public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
         {
             if (source == null) throw new ArgumentNullException("source");
             return new HashSet<TSource>(source, comparer);

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -59,7 +59,7 @@ namespace MoreLinq
         /// streams the results.
         /// </remarks>
 
-        public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source, [CanBeNull] string format)
+        public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source, string format)
         {
             if (source == null) throw new ArgumentNullException("source");
 


### PR DESCRIPTION
Removes `[CanBeNull]` and adapts tests.
Changes `MaxBy`/`MinBy` to accept null for `IComparer<T>` and fix docs.
Fixes #111.