### PR TITLE
V2 null consistency

### DIFF
--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -59,7 +59,7 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        [ExpectedException(typeof(InvalidOperationException))]
+        [ExpectedException(typeof(NullReferenceException))]
         public void AssertSequenceWithInvalidElementsAndCustomErrorReturningNull()
         {
             new[] { 2, 4, 6, 7, 8, 9 }.Assert(n => n % 2 == 0, _ => null).Consume();

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -128,7 +128,7 @@ namespace MoreLinq.Test
         private static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
-            var nullableParameters = new[] { "ToDataTable.expressions", "ToDelimitedString.delimiter", "Trace.format" };
+            var nullableParameters = new[] { "ToDelimitedString.delimiter", "Trace.format" };
 
             var type = parameter.ParameterType;
             type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -128,13 +128,11 @@ namespace MoreLinq.Test
         private static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
-            var nullableParameters = new string[0];
 
             var type = parameter.ParameterType;
             type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
-            var param = parameter.Member.Name + "." + parameter.Name;
 
-            return nullableTypes.Contains(type) || nullableParameters.Contains(param);
+            return nullableTypes.Contains(type);
         }
 
         private static object CreateInstance(Type type)

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -128,7 +128,7 @@ namespace MoreLinq.Test
         private static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
-            var nullableParameters = new[] { "Assert.errorSelector", "ToDataTable.expressions", "ToDelimitedString.delimiter", "Trace.format" };
+            var nullableParameters = new[] { "ToDataTable.expressions", "ToDelimitedString.delimiter", "Trace.format" };
 
             var type = parameter.ParameterType;
             type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -128,7 +128,7 @@ namespace MoreLinq.Test
         private static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
-            var nullableParameters = new[] { "ToDelimitedString.delimiter" };
+            var nullableParameters = new string[0];
 
             var type = parameter.ParameterType;
             type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -128,7 +128,7 @@ namespace MoreLinq.Test
         private static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes = new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) };
-            var nullableParameters = new[] { "ToDelimitedString.delimiter", "Trace.format" };
+            var nullableParameters = new[] { "ToDelimitedString.delimiter" };
 
             var type = parameter.ParameterType;
             type = type.IsGenericType ? type.GetGenericTypeDefinition() : type;

--- a/MoreLinq.Test/ToDelimitedStringTest.cs
+++ b/MoreLinq.Test/ToDelimitedStringTest.cs
@@ -56,16 +56,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ToDelimitedStringWithNonEmptySequenceAndNullDelimiter()
-        {
-            using (new CurrentThreadCultureScope(new CultureInfo("fr-FR")))
-            {
-                var result = new[] { 1, 2, 3 }.ToDelimitedString(null);
-                Assert.That(result, Is.EqualTo("1;2;3"));
-            }
-        }
-
-        [Test]
         public void ToDelimitedStringWithNonEmptySequenceContainingNulls()
         {
             var result = new object[] { 1, null, "foo", true }.ToDelimitedString(",");

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
         
         public static IEnumerable<TSource> Assert<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            return Assert(source, predicate, null);
+            return Assert(source, predicate, x => null);
         }
 
         /// <summary>
@@ -64,8 +64,9 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException("source");
             if (predicate == null) throw new ArgumentNullException("predicate");
+            if (errorSelector == null) throw new ArgumentNullException("errorSelector");
 
-            return AssertImpl(source, predicate, errorSelector ?? delegate { return null; });
+            return AssertImpl(source, predicate, errorSelector);
         }
 
         private static IEnumerable<TSource> AssertImpl<TSource>(IEnumerable<TSource> source, 

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
         
         public static IEnumerable<TSource> Assert<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            return Assert(source, predicate, x => null);
+            return Assert(source, predicate, x => new InvalidOperationException("Sequence contains an invalid item."));
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace MoreLinq
             {
                 var success = predicate(element);
                 if (!success)
-                    throw errorSelector(element) ?? new InvalidOperationException("Sequence contains an invalid item.");
+                    throw errorSelector(element);
                 yield return element;
             }
         }

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -46,13 +46,13 @@ namespace MoreLinq
             return memberExpression.Member;
         }
 
-        private static IEnumerable<MemberInfo> PrepareMemberInfos<T>(ICollection<Expression<Func<T, object>>> expressions)
+        private static IEnumerable<MemberInfo> PrepareMemberInfos<T>(Expression<Func<T, object>>[] expressions)
         {
             //
             // If no lambda expressions supplied then reflect them off the source element type.
             //
 
-            if (expressions == null || expressions.Count == 0)
+            if (expressions.Length == 0)
             {
                 return from m in typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance)
                        where m.MemberType == MemberTypes.Field
@@ -184,6 +184,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException("source");
             if (table == null) throw new ArgumentNullException("table");
+            if (expressions == null) throw new ArgumentNullException("expressions");
 
             var members = PrepareMemberInfos(expressions).ToArray();
             members = BuildOrBindSchema(table, members);
@@ -228,7 +229,7 @@ namespace MoreLinq
         public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table)
             where TTable : DataTable
         {
-            return ToDataTable(source, table, null);
+            return ToDataTable(source, table, new Expression<Func<T, object>>[0]);
         }
 
         /// <summary>

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -26,8 +26,8 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -38,7 +38,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         /// <summary>
@@ -51,21 +51,27 @@ namespace MoreLinq
         /// <typeparam name="TSource">Type of element in the source sequence</typeparam>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
+        }
+
+        // Cannot be a field since we want to respect the (scoped) culture of the current thread.
+        private static string DefaultDelimiter
+        {
+            get { return CultureInfo.CurrentCulture.TextInfo.ListSeparator; }
         }
 
         static string ToDelimitedStringImpl<T>(IEnumerable<T> source, string delimiter, Func<StringBuilder, T, StringBuilder> append)
         {
             Debug.Assert(source != null);
+            Debug.Assert(delimiter != null);
             Debug.Assert(append != null);
 
-            delimiter = delimiter ?? CultureInfo.CurrentCulture.TextInfo.ListSeparator;
             var sb = new StringBuilder();
             var i = 0;
 

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -24,8 +24,8 @@ namespace MoreLinq
     partial class MoreEnumerable
     {
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -35,7 +35,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<bool> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -52,18 +52,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -73,7 +73,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<byte> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -90,18 +90,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<byte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Byte);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -111,7 +111,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<char> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -128,18 +128,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<char> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Char);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -149,7 +149,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<decimal> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -166,18 +166,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -187,7 +187,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<double> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -204,18 +204,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -225,7 +225,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<float> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -242,18 +242,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -263,7 +263,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<int> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -280,18 +280,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<int> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int32);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -301,7 +301,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<long> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -318,18 +318,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<long> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int64);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -339,7 +339,7 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<sbyte> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -356,18 +356,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -377,7 +377,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<short> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -394,18 +394,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -415,7 +415,7 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<string> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -432,18 +432,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 
         public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -453,7 +453,7 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<uint> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -470,18 +470,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -491,7 +491,7 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ulong> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -508,18 +508,18 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
         }
 
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -529,7 +529,7 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ushort> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -546,12 +546,12 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);
         }
 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -61,8 +61,8 @@ namespace MoreLinq
 			}
         #>
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The 
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values. The executing thread's
+        /// current culture's list separator is used as the delimiter.
         /// </summary>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
@@ -72,7 +72,7 @@ namespace MoreLinq
 <#= attribute #>
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source)
         {
-            return ToDelimitedString(source, null);
+            return ToDelimitedString(source, DefaultDelimiter);
         }
 
         static partial class StringBuilderAppenders 
@@ -89,12 +89,12 @@ namespace MoreLinq
         /// </remarks>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
 <#= attribute #>
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (delimiter == null) throw new ArgumentNullException("delimiter");
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.<#= type.Type.Name #>);
         }
 

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -38,7 +38,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source)
         {
-            return Trace(source, (string) null);
+            return Trace(source, "{0}");
         }
 
         /// <summary>
@@ -47,10 +47,7 @@ namespace MoreLinq
         /// </summary>
         /// <typeparam name="TSource">Type of element in the source sequence</typeparam>
         /// <param name="source">Source sequence whose elements to trace.</param>
-        /// <param name="format">
-        /// String to use to format the trace message. If null then the
-        /// element value becomes the traced message.
-        /// </param>
+        /// <param name="format">String to use to format the trace message.</param>
         /// <returns>
         /// Return the source sequence unmodified.
         /// </returns>
@@ -62,11 +59,9 @@ namespace MoreLinq
         public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source, string format)
         {
             if (source == null) throw new ArgumentNullException("source");
+            if (format == null) throw new ArgumentNullException("format");
 
-            return TraceImpl(source, 
-                string.IsNullOrEmpty(format)
-                ? (Func<TSource, string>) (x => x == null ? string.Empty : x.ToString())
-                : (x => string.Format(format, x)));
+            return TraceImpl(source, x => string.Format(format, x));
         }
 
         /// <summary>


### PR DESCRIPTION
Remove "nullable" exceptions (other than `IEqualityComparer` and `IComparer`) for consistency. Refine implementations and update docs.
- Assert(errorSelector): now consistent with AssertCount
- ToDataTable(expressions): params array, so no reason why this should ever be null; there wasn't even a test to cover the null case
- Trace(format): format string should never be null (never computed, fixed per call-site); also simplify implementation (`string.Format(format, args)` handles null just fine)
- ToDelimitedString(delimiter): Make it more explicit what happens; also update docs.
