### PR TITLE
Scan<TSource>: do not throw on empty sequence

### DIFF
--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -65,7 +65,7 @@ namespace MoreLinq
             using (var i = source.GetEnumerator())
             {
                 if (!i.MoveNext())
-                    throw new InvalidOperationException("Sequence contains no elements.");
+                    yield break;
 
                 var aggregator = i.Current;
 


### PR DESCRIPTION
Instead, yield break and thus return an empty sequence.

Fixes #97