### PR TITLE
GroupAdjacent: Do not use Select to project key and element

### DIFF
--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -181,25 +181,25 @@ namespace MoreLinq
             Debug.Assert(elementSelector != null);
             Debug.Assert(comparer != null);
 
-            using (var iterator = source.Select(item => new KeyValuePair<TKey, TElement>(keySelector(item), elementSelector(item)))
-                                        .GetEnumerator())
+            using (var iterator = source.GetEnumerator())
             {
                 var group = default(TKey);
                 var members = (List<TElement>) null;
 
                 while (iterator.MoveNext())
                 {
-                    var item = iterator.Current;
-                    if (members != null && comparer.Equals(group, item.Key))
+                    var key = keySelector(iterator.Current);
+                    var element = elementSelector(iterator.Current);
+                    if (members != null && comparer.Equals(group, key))
                     {
-                        members.Add(item.Value);
+                        members.Add(element);
                     }
                     else
                     {
                         if (members != null)
                             yield return CreateGroupAdjacentGrouping(group, members);
-                        group = item.Key;
-                        members = new List<TElement> { item.Value };
+                        group = key;
+                        members = new List<TElement> { element };
                     }
                 }
 


### PR DESCRIPTION
Do it inside the loop. Also, avoid allocating a new KeyValuePair element, as it is not needed.

On a simple naive test like `longList.GroupAdjacent(i => i.Key).Consume();`, it achieves a 30% performance improvement in my system. Real-World effect will probably be lower (as selector are more complicated and are not consumed in a tight loop), but I still think it is a worthwhile improvement. 

