### PR TITLE
 GroupAdjacent: Add overloads that allow selecting the return enumerable type

### DIFF
--- a/MoreLinq.Test/GroupAdjacentTest.cs
+++ b/MoreLinq.Test/GroupAdjacentTest.cs
@@ -108,7 +108,10 @@ namespace MoreLinq.Test
                 new { Month = 2, Value = 321 },                 
                 new { Month = 3, Value = 789 },                 
                 new { Month = 3, Value = 456 },                 
-                new { Month = 3, Value = 123 },                 
+                new { Month = 3, Value = 123 },
+                new { Month = 1, Value = 123 },
+                new { Month = 1, Value = 456 },
+                new { Month = 1, Value = 781 },
             };
 
             var groupings = source.GroupAdjacent(e => e.Month, e => e.Value * 2);
@@ -118,6 +121,7 @@ namespace MoreLinq.Test
                 AssertGrouping(reader, 1, 123 * 2, 456 * 2, 789 * 2);
                 AssertGrouping(reader, 2, 987 * 2, 654 * 2, 321 * 2);
                 AssertGrouping(reader, 3, 789 * 2, 456 * 2, 123 * 2);
+                AssertGrouping(reader, 1, 123 * 2, 456 * 2, 781 * 2);
                 reader.ReadEnd();
             }
         }
@@ -135,7 +139,10 @@ namespace MoreLinq.Test
                 new { Month = "FEB", Value = 321 },                 
                 new { Month = "mar", Value = 789 },                 
                 new { Month = "Mar", Value = 456 },                 
-                new { Month = "MAR", Value = 123 },                 
+                new { Month = "MAR", Value = 123 },
+                new { Month = "jan", Value = 123 },
+                new { Month = "Jan", Value = 456 },
+                new { Month = "JAN", Value = 781 },
             };
 
             var groupings = source.GroupAdjacent(e => e.Month, e => e.Value * 2, StringComparer.OrdinalIgnoreCase);
@@ -145,6 +152,7 @@ namespace MoreLinq.Test
                 AssertGrouping(reader, "jan", 123 * 2, 456 * 2, 789 * 2);
                 AssertGrouping(reader, "feb", 987 * 2, 654 * 2, 321 * 2);
                 AssertGrouping(reader, "mar", 789 * 2, 456 * 2, 123 * 2);
+                AssertGrouping(reader, "jan", 123 * 2, 456 * 2, 781 * 2);
                 reader.ReadEnd();
             }
         }
@@ -163,6 +171,9 @@ namespace MoreLinq.Test
                 new { Month = 3, Value = 789 },
                 new { Month = 3, Value = 456 },
                 new { Month = 3, Value = 123 },
+                new { Month = 1, Value = 123 },
+                new { Month = 1, Value = 456 },
+                new { Month = 1, Value = 781 },
             };
 
             var groupings = source.GroupAdjacent(e => e.Month, (key, group) => group.Sum(v => v.Value));
@@ -171,6 +182,7 @@ namespace MoreLinq.Test
                 AssertResult(reader, 123 + 456 + 789);
                 AssertResult(reader, 987 + 654 + 321);
                 AssertResult(reader, 789 + 456 + 123);
+                AssertResult(reader, 123 + 456 + 781);
                 reader.ReadEnd();
             }
         }
@@ -189,6 +201,9 @@ namespace MoreLinq.Test
                 new { Month = "mar", Value = 789 },
                 new { Month = "Mar", Value = 456 },
                 new { Month = "MAR", Value = 123 },
+                new { Month = "jan", Value = 123 },
+                new { Month = "Jan", Value = 456 },
+                new { Month = "JAN", Value = 781 },
             };
 
             var groupings = source.GroupAdjacent(e => e.Month, (key, group) => group.Sum(v => v.Value), StringComparer.OrdinalIgnoreCase);
@@ -197,6 +212,7 @@ namespace MoreLinq.Test
                 AssertResult(reader, 123 + 456 + 789);
                 AssertResult(reader, 987 + 654 + 321);
                 AssertResult(reader, 789 + 456 + 123);
+                AssertResult(reader, 123 + 456 + 781);
                 reader.ReadEnd();
             }
         }

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -166,19 +166,109 @@ namespace MoreLinq
             if (keySelector == null) throw new ArgumentNullException("keySelector");
             if (elementSelector == null) throw new ArgumentNullException("elementSelector");
 
-            return GroupAdjacentImpl(source, keySelector, elementSelector,
+            return GroupAdjacentImpl(source, keySelector, elementSelector, CreateGroupAdjacentGrouping,
                                      comparer ?? EqualityComparer<TKey>.Default);
         }
 
-        private static IEnumerable<IGrouping<TKey, TElement>> GroupAdjacentImpl<TSource, TKey, TElement>(
+        /// <summary>
+        /// Groups the adjacent elements of a sequence according to a 
+        /// specified key selector function. The keys are compared by using 
+        /// a comparer and each group's elements are projected by using a 
+        /// specified function.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of 
+        /// <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by 
+        /// <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the elements in the
+        /// resulting sequence.</typeparam>
+        /// <param name="source">A sequence whose elements to group.</param>
+        /// <param name="keySelector">A function to extract the key for each 
+        /// element.</param>
+        /// <param name="resultSelector">A function to map each key and
+        /// associated source elements to a result object.</param>
+        /// <returns>A collection of elements of type
+        /// <typeparamref name="TResult" /> where each element represents
+        /// a projection over a group and its key.</returns>
+        /// <remarks>
+        /// This method is implemented by using deferred execution and 
+        /// streams the groupings. The grouping elements, however, are 
+        /// buffered. Each grouping is therefore yielded as soon as it 
+        /// is complete and before the next grouping occurs.
+        /// </remarks>
+
+        public static IEnumerable<TResult> GroupAdjacent<TSource, TKey, TResult>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector,
+            Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+            if (resultSelector == null) throw new ArgumentNullException("resultSelector");
+
+            // This should be removed once the target framework is bumped to something that supports covariance
+            Func<TKey, IList<TSource>, TResult> resultSelectorWrapper = (key, group) => resultSelector(key, group);
+
+            return GroupAdjacentImpl(source, keySelector, i => i, resultSelectorWrapper,
+                                     EqualityComparer<TKey>.Default);
+        }
+
+        /// <summary>
+        /// Groups the adjacent elements of a sequence according to a 
+        /// specified key selector function. The keys are compared by using 
+        /// a comparer and each group's elements are projected by using a 
+        /// specified function.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of 
+        /// <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by 
+        /// <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the elements in the
+        /// resulting sequence.</typeparam>
+        /// <param name="source">A sequence whose elements to group.</param>
+        /// <param name="keySelector">A function to extract the key for each 
+        /// element.</param>
+        /// <param name="resultSelector">A function to map each key and
+        /// associated source elements to a result object.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{TKey}"/> to 
+        /// compare keys.</param>
+        /// <returns>A collection of elements of type
+        /// <typeparamref name="TResult" /> where each element represents
+        /// a projection over a group and its key.</returns>
+        /// <remarks>
+        /// This method is implemented by using deferred execution and 
+        /// streams the groupings. The grouping elements, however, are 
+        /// buffered. Each grouping is therefore yielded as soon as it 
+        /// is complete and before the next grouping occurs.
+        /// </remarks>
+
+        public static IEnumerable<TResult> GroupAdjacent<TSource, TKey, TResult>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector,
+            Func<TKey, IEnumerable<TSource>, TResult> resultSelector,
+            IEqualityComparer<TKey> comparer)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+            if (resultSelector == null) throw new ArgumentNullException("resultSelector");
+            
+            // This should be removed once the target framework is bumped to something that supports covariance
+            Func<TKey, IList<TSource>, TResult> resultSelectorWrapper = (key, group) => resultSelector(key, group);
+            return GroupAdjacentImpl(source, keySelector, i => i, resultSelectorWrapper,
+                                     comparer ?? EqualityComparer<TKey>.Default);
+        }
+
+        private static IEnumerable<TResult> GroupAdjacentImpl<TSource, TKey, TElement, TResult>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
+            Func<TKey, IList<TElement>, TResult> resultSelector,
             IEqualityComparer<TKey> comparer)
         {
             Debug.Assert(source != null);
             Debug.Assert(keySelector != null);
             Debug.Assert(elementSelector != null);
+            Debug.Assert(resultSelector != null);
             Debug.Assert(comparer != null);
 
             using (var iterator = source.GetEnumerator())
@@ -197,18 +287,18 @@ namespace MoreLinq
                     else
                     {
                         if (members != null)
-                            yield return CreateGroupAdjacentGrouping(group, members);
+                            yield return resultSelector(group, members);
                         group = key;
                         members = new List<TElement> { element };
                     }
                 }
 
                 if (members != null)
-                    yield return CreateGroupAdjacentGrouping(group, members);
+                    yield return resultSelector(group, members);
             }
         }
 
-        private static Grouping<TKey, TElement> CreateGroupAdjacentGrouping<TKey, TElement>(TKey key, IList<TElement> members)
+        private static IGrouping<TKey, TElement> CreateGroupAdjacentGrouping<TKey, TElement>(TKey key, IList<TElement> members)
         {
             Debug.Assert(members != null);
             return Grouping.Create(key, members.IsReadOnly ? members : new ReadOnlyCollection<TElement>(members));


### PR DESCRIPTION
For parity with the GroupBy overloads
Fixes: #127