### PR TITLE
Add ExceptBy overloads & IntersectBy

### DIFF
--- a/MoreLinq.Test/IntersectByTest.cs
+++ b/MoreLinq.Test/IntersectByTest.cs
@@ -1,4 +1,4 @@
-#region License and Terms
+﻿#region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
 // Copyright (c) 2008 Jonathan Skeet. All rights reserved.
 // 
@@ -19,111 +19,97 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
-namespace MoreLinq.Test
-{
+namespace MoreLinq.Test {
     [TestFixture]
-    public class ExceptByTest
-    {
+    public class IntersectByTest {
         [Test]
-        public void SimpleExceptBy()
-        {
+        public void SimpleIntersectBy() {
             string[] first = { "aaa", "bb", "c", "dddd" };
-            string[] second = { "xx", "y" };
-            var result = first.ExceptBy(second, x => x.Length);
-            result.AssertSequenceEqual("aaa", "dddd");
+            string[] second = { "bb", "c" };
+            var result = first.IntersectBy(second, x => x.Length);
+            result.AssertSequenceEqual("bb", "c");
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullFirstSequence()
-        {
+        public void IntersectByNullFirstSequence() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.ExceptBy(second, x => x.Length);
+            first.IntersectBy(second, x => x.Length);
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullSecondSequence()
-        {
+        public void IntersectByNullSecondSequence() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.ExceptBy(second, x => x.Length);
+            first.IntersectBy(second, x => x.Length);
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullKeySelector()
-        {
+        public void IntersectByNullKeySelector() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.ExceptBy<string>(second, (Func<string, string>)null);
-        }
-        
-        [Test]
-        public void ExceptByIsLazy()
-        {
-            new BreakingSequence<string>().ExceptBy(new string[0], x => x.Length);
+            first.IntersectBy<string>(second, (Func<string, string>)null);
         }
 
         [Test]
-        public void ExceptByDoesNotRepeatSourceElementsWithDuplicateKeys()
-        {
+        public void IntersectByIsLazy() {
+            new BreakingSequence<string>().IntersectBy(new string[0], x => x.Length);
+        }
+
+        [Test]
+        public void IntersectByDoesNotRepeatSourceElementsWithDuplicateKeys() {
             string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
-            string[] second = { "xx" };
-            var result = first.ExceptBy(second, x => x.Length);
-            result.AssertSequenceEqual("aaa", "c", "dddd");
+            string[] second = { "c" };
+            var result = first.IntersectBy(second, x => x.Length);
+            result.AssertSequenceEqual("c");
         }
 
         [Test]
-        public void ExceptByWithComparer()
-        {
+        public void IntersectByWithComparer() {
             string[] first = { "first", "second", "third", "fourth" };
-            string[] second = { "FIRST" , "thiRD", "FIFTH" };
-            var result = first.ExceptBy<string>(second, word => word, StringComparer.OrdinalIgnoreCase);
-            result.AssertSequenceEqual("second", "fourth");
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.IntersectBy<string>(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("first", "third");
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullFirstSequenceWithComparer()
-        {
+        public void IntersectByNullFirstSequenceWithComparer() {
             string[] first = null;
             string[] second = { "aaa" };
-            first.ExceptBy(second, x => x.Length, EqualityComparer<int>.Default);
+            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullSecondSequenceWithComparer()
-        {
+        public void IntersectByNullSecondSequenceWithComparer() {
             string[] first = { "aaa" };
             string[] second = null;
-            first.ExceptBy(second, x => x.Length, EqualityComparer<int>.Default);
+            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
         }
 
         [Test]
         [ExpectedException(typeof(ArgumentNullException))]
-        public void ExceptByNullKeySelectorWithComparer()
-        {
+        public void IntersectByNullKeySelectorWithComparer() {
             string[] first = { "aaa" };
             string[] second = { "aaa" };
-            first.ExceptBy<string>(second, null, EqualityComparer<string>.Default);
+            first.IntersectBy<string>(second, null, EqualityComparer<string>.Default);
         }
 
         [Test]
-        public void ExceptByNullComparer()
-        {
+        public void IntersectByNullComparer() {
             string[] first = { "aaa", "bb", "c", "dddd" };
             string[] second = { "xx", "y" };
-            var result = first.ExceptBy(second, x => x.Length, null);
-            result.AssertSequenceEqual("aaa", "dddd");
+            var result = first.IntersectBy(second, x => x.Length, null);
+            result.AssertSequenceEqual("bb", "c");
         }
 
         [Test]
-        public void ExceptByIsLazyWithComparer()
-        {
-            new BreakingSequence<string>().ExceptBy<string>(new string[0], x => x, StringComparer.Ordinal);
+        public void IntersectByIsLazyWithComparer() {
+            new BreakingSequence<string>().IntersectBy<string>(new string[0], x => x, StringComparer.Ordinal);
         }
     }
 }

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IndexTest.cs" />
     <Compile Include="InfiniteSequence.cs" />
     <Compile Include="InterleaveTest.cs" />
+    <Compile Include="IntersectByTest.cs" />
     <Compile Include="KeyValuePair.cs" />
     <Compile Include="LagTest.cs" />
     <Compile Include="LeadTest.cs" />
@@ -126,6 +127,9 @@
       <Project>{72c49b06-715d-4423-ad0a-78517f71d7b9}</Project>
       <Name>Portable.MoreLinq</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="AtLeastTest.cs" />
     <Compile Include="FoldTest.cs" />
     <Compile Include="IndexTest.cs" />
+    <Compile Include="IntersectByTest.cs" />
     <Compile Include="KeyValuePair.cs" />
     <Compile Include="NullArgumentTest.cs" />
     <Compile Include="FallbackIfEmptyTest.cs" />
@@ -137,6 +138,9 @@
       <Project>{8642E81B-3414-4C13-914F-05A4E600FE49}</Project>
       <Name>MoreLinq</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -24,6 +24,54 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
+        /// Returns a distinct set of elements from the first collection,
+        /// whose keys are not in the second collection.
+        /// </summary>
+        /// <typeparam name="T">The type of source, keys, and result elements.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <returns>
+        /// Distinct set of elements from first collection,
+        /// whose keys are not in second collection.
+        /// </returns>
+        public static IEnumerable<T> ExceptBy<T>(this IEnumerable<T> first,
+            IEnumerable<T> second,
+            Func<T, T> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptByImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns a distinct set of elements from the first collection,
+        /// whose keys are not in the second collection.
+        /// </summary>
+        /// <typeparam name="T">The type of source, keys, and result elements.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyComparer">The key comparer. Defaults to default TKey equality comparer.</param>
+        /// <returns>
+        /// Distinct set of elements from first collection,
+        /// whose keys are not in second collection.
+        /// </returns>
+        public static IEnumerable<T> ExceptBy<T>(this IEnumerable<T> first,
+            IEnumerable<T> second,
+            Func<T, T> keySelector,
+            IEqualityComparer<T> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptByImpl(first, second, keySelector, keyComparer);
+        }
+
+        /// <summary>
         /// Returns the set of elements in the first sequence which aren't
         /// in the second sequence, according to a given key selector.
         /// </summary>
@@ -78,20 +126,69 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptByImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns a distinct set of elements from the first collection,
+        /// whose keys are not in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <returns>
+        /// Distinct set of elements from first collection,
+        /// whose keys are not in second collection.
+        /// </returns>
+        public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptByImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns a distinct set of elements from the first collection,
+        /// whose keys are not in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyComparer">The key comparer. Defaults to default TKey equality comparer.</param>
+        /// <returns>
+        /// Distinct set of elements from first collection,
+        /// whose keys are not in second collection.
+        /// </returns>
+        public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
             return ExceptByImpl(first, second, keySelector, keyComparer);
         }
 
-        private static IEnumerable<TSource> ExceptByImpl<TSource, TKey>(this IEnumerable<TSource> first,
-            IEnumerable<TSource> second,
+        private static IEnumerable<TSource> ExceptByImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> keyComparer)
-        {
-            var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);
-            foreach (var element in first)
-            {
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (var element in first) {
                 var key = keySelector(element);
-                if (keys.Contains(key))
-                {
+                if (keys.Contains(key)) {
                     continue;
                 }
                 yield return element;

--- a/MoreLinq/IntersectBy.cs
+++ b/MoreLinq/IntersectBy.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MoreLinq {
+
+    partial class MoreEnumerable {
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key matches a key of an element in the second collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the source, keys, and result elements.</typeparam>
+        /// <param name="first">The first collection.</param>
+        /// <param name="second">The second collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key matches a key of an element in second collection.</returns>
+        public static IEnumerable<T> IntersectBy<T>(this IEnumerable<T> first,
+            IEnumerable<T> second,
+            Func<T, T> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second.Select(keySelector), keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key matches a key of an element in the second collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the source, keys, and result elements.</typeparam>
+        /// <param name="first">The first collection.</param>
+        /// <param name="second">The second collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyComparer">The key comparer.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key matches a key of an element in second collection.</returns>
+        public static IEnumerable<T> IntersectBy<T>(this IEnumerable<T> first,
+            IEnumerable<T> second,
+            Func<T, T> keySelector,
+            IEqualityComparer<T> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key matches a key of an element in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The first collection.</param>
+        /// <param name="second">The second collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key matches a key of an element in second collection.</returns>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second.Select(keySelector), keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key matches a key of an element in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The first collection.</param>
+        /// <param name="second">The second collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyComparer">The key comparer.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key matches a key of an element in second collection.</returns>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key is not in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key is not in second collection.</returns>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns a collection containing a distinct set of elements from the first collection
+        /// whose key is not in the second collection.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The source collection.</param>
+        /// <param name="second">The key collection.</param>
+        /// <param name="keySelector">The key selector.</param>
+        /// <param name="keyComparer">The key comparer.</param>
+        /// <returns>Collection containing a distinct set of elements from first collection
+        /// whose key is not in second collection.</returns>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectByImpl(first, second, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<TSource> IntersectByImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (var item in first) {
+                var k = keySelector(item);
+                if (keys.Contains(k)) {
+                    yield return item;
+                    keys.Remove(k);
+                }
+            }
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Interleave.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="IntersectBy.cs" />
     <Compile Include="Lag.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -63,6 +63,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Fold.g.tt</DependentUpon>
     </Compile>
+    <Compile Include="IntersectBy.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.g.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -203,7 +206,8 @@
     <Compile Include="GroupAdjacent.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
-    <Compile Include="MoreEnumerable.cs" />
+    <Compile Include="MoreEnumerable.cs">
+    </Compile>
     <Compile Include="TakeEvery.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
@@ -276,6 +280,7 @@
       <LastGenOutput>AssemblyInfo.g.cs</LastGenOutput>
     </Content>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Added overloads to ExceptBy and added IntersectBy.  Modified several
tests in ExceptByTest to avoid generic type ambiguity caused by new
overloads.  Created IntersectByTest, which has test corresponding to
each test in ExceptByTest.

This addresses issue #63, and provides a foundation for addressing issues #124 and #125.