### PR TITLE
Issue63 IntersectBy and ExceptBy overloads v2

### DIFF
--- a/MoreLinq.Test/ExceptAllByTest.cs
+++ b/MoreLinq.Test/ExceptAllByTest.cs
@@ -1,0 +1,129 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class ExceptAllByTest
+    {
+        [Test]
+        public void SimpleExceptAllBy()
+        {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            string[] second = { "xx", "y" };
+            var result = first.ExceptAllBy(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "dddd");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullFirstSequence()
+        {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.ExceptAllBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullSecondSequence()
+        {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.ExceptAllBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullKeySelector()
+        {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.ExceptAllBy(second, (Func<string, string>)null);
+        }
+        
+        [Test]
+        public void ExceptAllByIsLazy()
+        {
+            new BreakingSequence<string>().ExceptAllBy(new string[0], x => x.Length);
+        }
+
+        [Test]
+        public void ExceptAllByRepeatsSourceElementsWithDuplicateKeys()
+        {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            string[] second = { "xx" };
+            var result = first.ExceptAllBy(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "c", "a", "b", "c", "dddd");
+        }
+
+        [Test]
+        public void ExceptAllByWithComparer()
+        {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.ExceptBy(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("second", "fourth");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullFirstSequenceWithComparer()
+        {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullSecondSequenceWithComparer()
+        {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.ExceptAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllByNullKeySelectorWithComparer()
+        {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.ExceptAllBy(second, null, EqualityComparer<string>.Default);
+        }
+
+        [Test]
+        public void ExceptAllByNullComparer()
+        {
+            string[] first = { "aaa", "bb", "bb", "c", "dddd", "dddd" };
+            string[] second = { "xx", "y" };
+            var result = first.ExceptAllBy(second, x => x.Length, null);
+            result.AssertSequenceEqual("aaa", "dddd", "dddd");
+        }
+
+        [Test]
+        public void ExceptAllByIsLazyWithComparer()
+        {
+            new BreakingSequence<string>().ExceptAllBy(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/ExceptAllKeysTest.cs
+++ b/MoreLinq.Test/ExceptAllKeysTest.cs
@@ -1,0 +1,129 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class ExceptAllKeysTest
+    {
+        [Test]
+        public void SimpleExceptAllKeys()
+        {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.ExceptAllKeys(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "dddd");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullFirstSequence()
+        {
+            string[] first = null;
+            int[] second = { 1 };
+            first.ExceptAllKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullSecondSequence()
+        {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.ExceptAllKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullKeySelector()
+        {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.ExceptAllKeys(second, (Func<string, int>)null);
+        }
+        
+        [Test]
+        public void ExceptAllKeysIsLazy()
+        {
+            new BreakingSequence<string>().ExceptAllKeys(new int[0], x => x.Length);
+        }
+
+        [Test]
+        public void ExceptAllKeysRepeatsSourceElementsWithDuplicateKeys()
+        {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            int[] second = { 2 };
+            var result = first.ExceptAllKeys(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "c", "a", "b", "c", "dddd");
+        }
+
+        [Test]
+        public void ExceptAllKeysWithComparer()
+        {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST" , "thiRD", "FIFTH" };
+            var result = first.ExceptAllKeys(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("second", "fourth");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullFirstSequenceWithComparer()
+        {
+            string[] first = null;
+            int[] second = { 1 };
+            first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullSecondSequenceWithComparer()
+        {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.ExceptAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptAllKeysNullKeySelectorWithComparer()
+        {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.ExceptAllKeys(second, null, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        public void ExceptAllKeysNullComparer()
+        {
+            string[] first = { "aaa", "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.ExceptAllKeys(second, x => x.Length, null);
+            result.AssertSequenceEqual("aaa", "aaa", "dddd");
+        }
+
+        [Test]
+        public void ExceptAllKeysIsLazyWithComparer()
+        {
+            new BreakingSequence<string>().ExceptAllKeys(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/ExceptKeysTest.cs
+++ b/MoreLinq.Test/ExceptKeysTest.cs
@@ -1,0 +1,129 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class ExceptKeysTest
+    {
+        [Test]
+        public void SimpleExceptKeys()
+        {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.ExceptKeys(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "dddd");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullFirstSequence()
+        {
+            string[] first = null;
+            int[] second = { 1 };
+            first.ExceptKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullSecondSequence()
+        {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.ExceptKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullKeySelector()
+        {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.ExceptKeys(second, (Func<string, int>)null);
+        }
+        
+        [Test]
+        public void ExceptKeysIsLazy()
+        {
+            new BreakingSequence<string>().ExceptKeys(new int[0], x => x.Length);
+        }
+
+        [Test]
+        public void ExceptKeysDoesNotRepeatSourceElementsWithDuplicateKeys()
+        {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            int[] second = { 2 };
+            var result = first.ExceptKeys(second, x => x.Length);
+            result.AssertSequenceEqual("aaa", "c", "dddd");
+        }
+
+        [Test]
+        public void ExceptKeysWithComparer()
+        {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST" , "thiRD", "FIFTH" };
+            var result = first.ExceptKeys(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("second", "fourth");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullFirstSequenceWithComparer()
+        {
+            string[] first = null;
+            int[] second = { 1 };
+            first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullSecondSequenceWithComparer()
+        {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.ExceptKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ExceptKeysNullKeySelectorWithComparer()
+        {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.ExceptKeys(second, null, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        public void ExceptKeysNullComparer()
+        {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.ExceptKeys(second, x => x.Length, null);
+            result.AssertSequenceEqual("aaa", "dddd");
+        }
+
+        [Test]
+        public void ExceptKeysIsLazyWithComparer()
+        {
+            new BreakingSequence<string>().ExceptKeys(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/IntersectAllByTest.cs
+++ b/MoreLinq.Test/IntersectAllByTest.cs
@@ -1,0 +1,115 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test {
+    [TestFixture]
+    public class IntersectAllByTest {
+        [Test]
+        public void SimpleIntersectAllBy() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            string[] second = { "bb", "c" };
+            var result = first.IntersectAllBy(second, x => x.Length);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullFirstSequence() {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.IntersectAllBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullSecondSequence() {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.IntersectAllBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullKeySelector() {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.IntersectAllBy<string, string>(second, (Func<string, string>)null);
+        }
+
+        [Test]
+        public void IntersectAllByIsLazy() {
+            new BreakingSequence<string>().IntersectAllBy(new string[0], x => x.Length);
+        }
+
+        [Test]
+        public void IntersectAllByRepeatsSourceElementsWithDuplicateKeys() {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            string[] second = { "c" };
+            var result = first.IntersectAllBy(second, x => x.Length);
+            result.AssertSequenceEqual("c", "a", "b", "c");
+        }
+
+        [Test]
+        public void IntersectAllByWithComparer() {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.IntersectAllBy(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("first", "third");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullFirstSequenceWithComparer() {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullSecondSequenceWithComparer() {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.IntersectAllBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllByNullKeySelectorWithComparer() {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.IntersectAllBy(second, null, EqualityComparer<string>.Default);
+        }
+
+        [Test]
+        public void IntersectAllByNullComparer() {
+            string[] first = { "aaa", "bb", "bb", "c", "dddd" };
+            string[] second = { "xx", "y" };
+            var result = first.IntersectAllBy(second, x => x.Length, null);
+            result.AssertSequenceEqual("bb","bb", "c");
+        }
+
+        [Test]
+        public void IntersectAllByIsLazyWithComparer() {
+            new BreakingSequence<string>().IntersectAllBy(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/IntersectAllKeysTest.cs
+++ b/MoreLinq.Test/IntersectAllKeysTest.cs
@@ -1,0 +1,115 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test {
+    [TestFixture]
+    public class IntersectAllKeysTest {
+        [Test]
+        public void SimpleIntersectAllKeys() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.IntersectAllKeys(second, x => x.Length);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullFirstSequence() {
+            string[] first = null;
+            int[] second = { 1 };
+            first.IntersectAllKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullSecondSequence() {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.IntersectAllKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullKeySelector() {
+            string[] first = { "aaa" };
+            int[] second = { 3 };
+            first.IntersectAllKeys<string, int>(second, (Func<string, int>)null);
+        }
+
+        [Test]
+        public void IntersectAllKeysIsLazy() {
+            new BreakingSequence<string>().IntersectAllKeys(new int[0], x => x.Length);
+        }
+
+        [Test]
+        public void IntersectAllKeysRepeatsSourceElementsWithDuplicateKeys() {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            int[] second = { 1 };
+            var result = first.IntersectAllKeys(second, x => x.Length);
+            result.AssertSequenceEqual("c", "a", "b", "c");
+        }
+
+        [Test]
+        public void IntersectAllKeysWithComparer() {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.IntersectAllKeys(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("first", "third");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullFirstSequenceWithComparer() {
+            string[] first = null;
+            int[] second = { 1 };
+            first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullSecondSequenceWithComparer() {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.IntersectAllKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectAllKeysNullKeySelectorWithComparer() {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.IntersectAllKeys(second, null, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        public void IntersectAllKeysNullComparer() {
+            string[] first = { "aaa", "bb", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.IntersectAllKeys(second, x => x.Length, null);
+            result.AssertSequenceEqual("bb", "bb", "c");
+        }
+
+        [Test]
+        public void IntersectAllKeysIsLazyWithComparer() {
+            new BreakingSequence<string>().IntersectAllKeys(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/IntersectByTest.cs
+++ b/MoreLinq.Test/IntersectByTest.cs
@@ -1,0 +1,115 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test {
+    [TestFixture]
+    public class IntersectByTest {
+        [Test]
+        public void SimpleIntersectBy() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            string[] second = { "bb", "c" };
+            var result = first.IntersectBy(second, x => x.Length);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullFirstSequence() {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.IntersectBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullSecondSequence() {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.IntersectBy(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullKeySelector() {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.IntersectBy<string, string>(second, (Func<string, string>)null);
+        }
+
+        [Test]
+        public void IntersectByIsLazy() {
+            new BreakingSequence<string>().IntersectBy(new string[0], x => x.Length);
+        }
+
+        [Test]
+        public void IntersectByDoesNotRepeatSourceElementsWithDuplicateKeys() {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            string[] second = { "c" };
+            var result = first.IntersectBy(second, x => x.Length);
+            result.AssertSequenceEqual("c");
+        }
+
+        [Test]
+        public void IntersectByWithComparer() {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.IntersectBy(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("first", "third");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullFirstSequenceWithComparer() {
+            string[] first = null;
+            string[] second = { "aaa" };
+            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullSecondSequenceWithComparer() {
+            string[] first = { "aaa" };
+            string[] second = null;
+            first.IntersectBy(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectByNullKeySelectorWithComparer() {
+            string[] first = { "aaa" };
+            string[] second = { "aaa" };
+            first.IntersectBy(second, null, EqualityComparer<string>.Default);
+        }
+
+        [Test]
+        public void IntersectByNullComparer() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            string[] second = { "xx", "y" };
+            var result = first.IntersectBy(second, x => x.Length, null);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        public void IntersectByIsLazyWithComparer() {
+            new BreakingSequence<string>().IntersectBy(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/IntersectKeysTest.cs
+++ b/MoreLinq.Test/IntersectKeysTest.cs
@@ -1,0 +1,115 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test {
+    [TestFixture]
+    public class IntersectKeysTest {
+        [Test]
+        public void SimpleIntersectKeys() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.IntersectKeys(second, x => x.Length);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullFirstSequence() {
+            string[] first = null;
+            int[] second = { 1 };
+            first.IntersectKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullSecondSequence() {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.IntersectKeys(second, x => x.Length);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullKeySelector() {
+            string[] first = { "aaa" };
+            int[] second = { 3 };
+            first.IntersectKeys<string, int>(second, (Func<string, int>)null);
+        }
+
+        [Test]
+        public void IntersectKeysIsLazy() {
+            new BreakingSequence<string>().IntersectKeys(new int[0], x => x.Length);
+        }
+
+        [Test]
+        public void IntersectKeysDoesNotRepeatSourceElementsWithDuplicateKeys() {
+            string[] first = { "aaa", "bb", "c", "a", "b", "c", "dddd" };
+            int[] second = { 1 };
+            var result = first.IntersectKeys(second, x => x.Length);
+            result.AssertSequenceEqual("c");
+        }
+
+        [Test]
+        public void IntersectKeysWithComparer() {
+            string[] first = { "first", "second", "third", "fourth" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
+            var result = first.IntersectKeys(second, word => word, StringComparer.OrdinalIgnoreCase);
+            result.AssertSequenceEqual("first", "third");
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullFirstSequenceWithComparer() {
+            string[] first = null;
+            int[] second = { 1 };
+            first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullSecondSequenceWithComparer() {
+            string[] first = { "aaa" };
+            int[] second = null;
+            first.IntersectKeys(second, x => x.Length, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IntersectKeysNullKeySelectorWithComparer() {
+            string[] first = { "aaa" };
+            int[] second = { 1 };
+            first.IntersectKeys(second, null, EqualityComparer<int>.Default);
+        }
+
+        [Test]
+        public void IntersectKeysNullComparer() {
+            string[] first = { "aaa", "bb", "c", "dddd" };
+            int[] second = { 1, 2 };
+            var result = first.IntersectKeys(second, x => x.Length, null);
+            result.AssertSequenceEqual("bb", "c");
+        }
+
+        [Test]
+        public void IntersectKeysIsLazyWithComparer() {
+            new BreakingSequence<string>().IntersectKeys(new string[0], x => x, StringComparer.Ordinal);
+        }
+    }
+}

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -54,6 +54,9 @@
     <Compile Include="Combinatorics.cs" />
     <Compile Include="ComparerFunc.cs" />
     <Compile Include="EqualityComparerFunc.cs" />
+    <Compile Include="ExceptAllByTest.cs" />
+    <Compile Include="ExceptAllKeysTest.cs" />
+    <Compile Include="ExceptKeysTest.cs" />
     <Compile Include="ExcludeTest.cs" />
     <Compile Include="FallbackIfEmptyTest.cs" />
     <Compile Include="FoldTest.cs" />
@@ -62,6 +65,7 @@
     <Compile Include="InfiniteSequence.cs" />
     <Compile Include="InterleaveTest.cs" />
     <Compile Include="IntersectByTest.cs" />
+    <Compile Include="IntersectKeysTest.cs" />
     <Compile Include="KeyValuePair.cs" />
     <Compile Include="LagTest.cs" />
     <Compile Include="LeadTest.cs" />

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IndexTest.cs" />
     <Compile Include="InfiniteSequence.cs" />
     <Compile Include="InterleaveTest.cs" />
+    <Compile Include="IntersectByTest.cs" />
     <Compile Include="KeyValuePair.cs" />
     <Compile Include="LagTest.cs" />
     <Compile Include="LeadTest.cs" />
@@ -126,6 +127,9 @@
       <Project>{72c49b06-715d-4423-ad0a-78517f71d7b9}</Project>
       <Name>Portable.MoreLinq</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -57,11 +57,15 @@
     <Compile Include="AssertTest.cs" />
     <Compile Include="AssertUtil.cs" />
     <Compile Include="AtLeastTest.cs" />
+    <Compile Include="ExceptAllByTest.cs" />
+    <Compile Include="ExceptAllKeysTest.cs" />
     <Compile Include="ExceptKeysTest.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="FoldTest.cs" />
     <Compile Include="IndexTest.cs" />
+    <Compile Include="IntersectAllByTest.cs" />
+    <Compile Include="IntersectAllKeysTest.cs" />
     <Compile Include="IntersectKeysTest.cs" />
     <Compile Include="IntersectByTest.cs" />
     <Compile Include="KeyValuePair.cs" />

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -57,8 +57,13 @@
     <Compile Include="AssertTest.cs" />
     <Compile Include="AssertUtil.cs" />
     <Compile Include="AtLeastTest.cs" />
+    <Compile Include="ExceptKeysTest.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="FoldTest.cs" />
     <Compile Include="IndexTest.cs" />
+    <Compile Include="IntersectKeysTest.cs" />
+    <Compile Include="IntersectByTest.cs" />
     <Compile Include="KeyValuePair.cs" />
     <Compile Include="NullArgumentTest.cs" />
     <Compile Include="FallbackIfEmptyTest.cs" />
@@ -137,6 +142,9 @@
       <Project>{8642E81B-3414-4C13-914F-05A4E600FE49}</Project>
       <Name>MoreLinq</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MoreLinq/ExceptAll.cs
+++ b/MoreLinq/ExceptAll.cs
@@ -1,0 +1,199 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable {
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which aren't
+        /// in the second sequence.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="System.Linq.Enumerable.Except{TSource}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource})"/>; 
+        /// if multiple elements in <paramref name="first"/> are equal, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of elements from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate values in <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements of the input sequences.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of elements which may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="comparer">The element comparer. If <c>null</c>, uses the default equality comparer for <typeparamref name="TSource"/>.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> that are not in <paramref name="second"/>, 
+        /// including duplicate values from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/> or <paramref name="second"/> is <c>null</c>. 
+        /// If <paramref name="comparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> ExceptAll<TSource>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            IEqualityComparer<TSource> comparer) {
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+
+            return ExceptAllKeysImpl(first, second, x => x, comparer);
+        }
+        
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which aren't
+        /// in the second sequence, according to a given key selector.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.ExceptBy{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements of the input sequences.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key was not also a key for
+        /// any element in <paramref name="second"/>, including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
+        public static IEnumerable<TSource> ExceptAllBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector) {
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+             
+            return ExceptAllKeysImpl(first, second.Select(keySelector), keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which aren't
+        /// in the second sequence, according to a given key selector and equality comparer.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.ExceptBy{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>;  
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements in the input sequences.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
+        /// If null, the default equality comparer for <c>TSource</c> is used.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key was not also a key for
+        /// any element in <paramref name="second"/>, including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> ExceptAllBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptAllKeysImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence,
+        /// whose keys are not in the second sequence, according to a given key selector.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.ExceptKeys{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TKey}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of keys which may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key is not in <paramref name="second"/>, 
+        /// including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
+        public static IEnumerable<TSource> ExceptAllKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptAllKeysImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements from the first collection,
+        /// whose keys are not in the second collection, according to a given key selector and equality comparer.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.ExceptKeys{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TKey}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of keys which may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key is not in <paramref name="second"/>, 
+        /// including values with duplicate keys from <paramref name="first"/>.</returns>   
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> ExceptAllKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptAllKeysImpl(first, second, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<TSource> ExceptAllKeysImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (var element in first) {
+                var key = keySelector(element);
+                if (!keys.Contains(key))
+                    yield return element;
+            }
+        }
+    }
+}

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -23,50 +23,58 @@ namespace MoreLinq {
     static partial class MoreEnumerable {
 
         /// <summary>
-        /// Returns the set of elements in the first sequence which aren't
+        /// Returns the set of distinct elements in the first sequence which aren't
         /// in the second sequence, according to a given key selector.
         /// </summary>
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
         /// <typeparam name="TSource">The type of the elements in the input sequences.</typeparam>
-        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of elements whose keys may prevent elements in
-        /// <paramref name="first"/> from being returned.</param>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, and used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of elements whose keys may prevent elements in <paramref name="first"/> from being returned.</param>
         /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <returns>A sequence of elements from <paramref name="first"/> whose key was not also a key for
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key was not also a key for
         /// any element in <paramref name="second"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
         public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector) {
-            return ExceptBy(first, second, keySelector, null);
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptKeysImpl(first, second.Select(keySelector), keySelector, null);
         }
 
         /// <summary>
-        /// Returns the set of elements in the first sequence which aren't
-        /// in the second sequence, according to a given key selector.
+        /// Returns the set of distinct elements in the first sequence which aren't
+        /// in the second sequence, according to a given key selector and equality comparer.
         /// </summary>
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
         /// <typeparam name="TSource">The type of the elements in the input sequences.</typeparam>
-        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of elements whose keys may prevent elements in
-        /// <paramref name="first"/> from being returned.</param>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of elements whose keys may prevent elements in <paramref name="first"/> from being returned.</param>
         /// <param name="keySelector">The mapping from source element to key.</param>
         /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
         /// If null, the default equality comparer for <c>TSource</c> is used.</param>
-        /// <returns>A sequence of elements from <paramref name="first"/> whose key was not also a key for
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key was not also a key for
         /// any element in <paramref name="second"/>.</returns>
-
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
         public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector,
@@ -79,25 +87,24 @@ namespace MoreLinq {
         }
 
         /// <summary>
-        /// Returns the set of elements in the first sequence,
+        /// Returns the set of distinct elements in the first sequence,
         /// whose keys are not in the second sequence, according to a given key selector.
         /// </summary>
-        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of keys which may prevent elements in
-        /// <paramref name="first"/> from being returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <returns>
-        /// Distinct set of elements from first sequence,
-        /// whose keys are not in second sequence.
-        /// </returns>  
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of keys which may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is not in <paramref name="second"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
         public static IEnumerable<TSource> ExceptKeys<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector) {
@@ -110,26 +117,27 @@ namespace MoreLinq {
         }
 
         /// <summary>
-        /// Returns the set of elements from the first collection,
-        /// whose keys are not in the second collection, according to a given key selector.
+        /// Returns the set of distinct elements in the first sequence,
+        /// whose keys are not in the second sequence, according to a given key selector and equality comparer.
         /// </summary>
-        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of keys which may prevent elements in
-        /// <paramref name="first"/> from being returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
-        /// <returns>
-        /// Distinct set of elements from first sequence,
-        /// whose keys are not in second sequence.
-        /// </returns>
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of keys which may prevent elements in <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
+        /// If null, the default equality comparer for <c>TSource</c> is used.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is not in <paramref name="second"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
         public static IEnumerable<TSource> ExceptKeys<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector,
@@ -150,11 +158,8 @@ namespace MoreLinq {
             var keys = new HashSet<TKey>(second, keyComparer);
             foreach (var element in first) {
                 var key = keySelector(element);
-                if (keys.Contains(key)) {
-                    continue;
-                }
-                yield return element;
-                keys.Add(key);
+                if (keys.Add(key))
+                    yield return element;
             }
         }
     }

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -15,14 +15,13 @@
 // limitations under the License.
 #endregion
 
-namespace MoreLinq
-{
+namespace MoreLinq {
     using System;
     using System.Collections.Generic;
     using System.Linq;
 
-    static partial class MoreEnumerable
-    {
+    static partial class MoreEnumerable {
+
         /// <summary>
         /// Returns the set of elements in the first sequence which aren't
         /// in the second sequence, according to a given key selector.
@@ -41,11 +40,9 @@ namespace MoreLinq
         /// <param name="keySelector">The mapping from source element to key.</param>
         /// <returns>A sequence of elements from <paramref name="first"/> whose key was not also a key for
         /// any element in <paramref name="second"/>.</returns>
-        
         public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
-            Func<TSource, TKey> keySelector)
-        {
+            Func<TSource, TKey> keySelector) {
             return ExceptBy(first, second, keySelector, null);
         }
 
@@ -69,29 +66,91 @@ namespace MoreLinq
         /// If null, the default equality comparer for <c>TSource</c> is used.</param>
         /// <returns>A sequence of elements from <paramref name="first"/> whose key was not also a key for
         /// any element in <paramref name="second"/>.</returns>
-        
+
         public static IEnumerable<TSource> ExceptBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> keyComparer)
-        {
+            IEqualityComparer<TKey> keyComparer) {
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
-            return ExceptByImpl(first, second, keySelector, keyComparer);
+
+            return ExceptKeysImpl(first, second.Select(keySelector), keySelector, keyComparer);
         }
 
-        private static IEnumerable<TSource> ExceptByImpl<TSource, TKey>(this IEnumerable<TSource> first,
-            IEnumerable<TSource> second,
+        /// <summary>
+        /// Returns the set of elements in the first sequence,
+        /// whose keys are not in the second sequence, according to a given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of keys which may prevent elements in
+        /// <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>
+        /// Distinct set of elements from first sequence,
+        /// whose keys are not in second sequence.
+        /// </returns>  
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> ExceptKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptKeysImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the set of elements from the first collection,
+        /// whose keys are not in the second collection, according to a given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of keys which may prevent elements in
+        /// <paramref name="first"/> from being returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
+        /// <returns>
+        /// Distinct set of elements from first sequence,
+        /// whose keys are not in second sequence.
+        /// </returns>
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> ExceptKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> keyComparer)
-        {
-            var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);
-            foreach (var element in first)
-            {
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return ExceptKeysImpl(first, second, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<TSource> ExceptKeysImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (var element in first) {
                 var key = keySelector(element);
-                if (keys.Contains(key))
-                {
+                if (keys.Contains(key)) {
                     continue;
                 }
                 yield return element;

--- a/MoreLinq/IntersectAll.cs
+++ b/MoreLinq/IntersectAll.cs
@@ -1,0 +1,201 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    partial class MoreEnumerable {
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which are also in the second sequence.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="System.Linq.Enumerable.Intersect{TSource}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource})"/>; 
+        /// if multiple elements in <paramref name="first"/> are equal, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of elements from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate values in <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements of the input sequences.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of elements which may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="comparer">The element comparer. If <c>null</c>, uses the default equality comparer for <typeparamref name="TSource"/>.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> that are also in <paramref name="second"/>, 
+        /// including duplicate values from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/> or <paramref name="second"/> is <c>null</c>. 
+        /// If <paramref name="comparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> IntersectAll<TSource>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            IEqualityComparer<TSource> comparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+
+            return IntersectAllKeysImpl(first, second, x => x, comparer);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which are also
+        /// in the second sequence, according to a given key selector.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.IntersectBy{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements of the input sequences.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key was also a key for
+        /// any element in <paramref name="second"/>, including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
+        public static IEnumerable<TSource> IntersectAllBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectAllKeysImpl(first, second.Select(keySelector), keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence which are also
+        /// in the second sequence, according to a given key selector and equality comparer.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.IntersectBy{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TSource}, System.Func{TSource, TKey})"/>;  
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of the elements in the input sequences.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
+        /// If null, the default equality comparer for <c>TSource</c> is used.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key was also a key for
+        /// any element in <paramref name="second"/>, including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> IntersectAllBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectAllKeysImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns the sequence of elements in the first sequence,
+        /// whose keys are in the second sequence, according to a given key selector.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.IntersectKeys{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TKey}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of keys which may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key is in <paramref name="second"/>, 
+        /// including values with duplicate keys from <paramref name="first"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
+        public static IEnumerable<TSource> IntersectAllKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectAllKeysImpl(first, second, keySelector, null);
+        }
+        
+        /// <summary>
+        /// Returns the sequence of elements from the first collection,
+        /// whose keys are in the second collection, according to a given key selector and equality comparer.
+        /// </summary>
+        /// <remarks>
+        /// This is not a set operation like <see cref="MoreLinq.MoreEnumerable.IntersectKeys{TSource, TKey}(
+        /// System.Collections.Generic.IEnumerable{TSource}, System.Collections.Generic.IEnumerable{TKey}, System.Func{TSource, TKey})"/>;  
+        /// if multiple elements in <paramref name="first"/> have equal keys, all such elements are returned.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
+        /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/> and used for comparing values.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The set of keys which may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
+        /// <returns>The sequence of elements from <paramref name="first"/> whose key is in <paramref name="second"/>, 
+        /// including values with duplicate keys from <paramref name="first"/>.</returns>   
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
+        public static IEnumerable<TSource> IntersectAllKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectAllKeysImpl(first, second, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<TSource> IntersectAllKeysImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (TSource element in first) {
+                var k = keySelector(element);
+                if (keys.Contains(k))
+                    yield return element;
+            }
+        }
+    }
+}

--- a/MoreLinq/IntersectBy.cs
+++ b/MoreLinq/IntersectBy.cs
@@ -23,23 +23,25 @@ namespace MoreLinq {
     partial class MoreEnumerable {
 
         /// <summary>
-        /// Returns the set of elements from the first sequence
-        /// which are in the second sequence, according to the given key selector.
+        /// Returns the set of distinct elements from the first sequence which are also 
+        /// in the second sequence, according to the given key selector.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of elements whose keys may allow elements in
-        /// <paramref name="first"/> to be returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <returns>Distinct set of elements from first sequence
-        /// which are in second sequence, according to the given key selector.</returns>
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, and used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of elements whose keys may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is also the key
+        /// of an element in <paramref name="second" />, according to the given key selector.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
         public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector) {
@@ -52,23 +54,28 @@ namespace MoreLinq {
         }
 
         /// <summary>
-        /// Returns the set of elements from the first sequence
-        /// which are in the second sequence, according to the given key selector.
+        /// Returns the set of distinct elements from the first sequence which are also 
+        /// in the second sequence, according to the given key selector and equality comparer.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of elements whose keys may allow elements in
-        /// <paramref name="first"/> to be returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
-        /// <returns>Distinct set of elements from first sequence
-        /// which are in second sequence, according to the given key selector.</returns>
-        /// <remarks>This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, and used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of elements whose keys may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
+        /// If null, the default equality comparer for <c>TSource</c> is used.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is also the key
+        /// of an element in <paramref name="second" />, according to the given key selector.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
         public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TSource> second,
             Func<TSource, TKey> keySelector,
@@ -82,23 +89,24 @@ namespace MoreLinq {
         }
 
         /// <summary>
-        /// Returns the set of elements from the first sequence
-        /// whose keys are in the second sequence, according to the given key selector.
+        /// Returns the set of distinct elements in the first sequence,
+        /// whose keys are in the second sequence, according to a given key selector.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of keys which may allow elements in
-        /// <paramref name="first"/> to be returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <returns>Distinct set of elements from first sequence
-        /// whose keys are in second sequence, according to the given key selector.</returns>
         /// <remarks>
         /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of keys which may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is in <paramref name="second"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.</exception>
         public static IEnumerable<TSource> IntersectKeys<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector) {
@@ -111,23 +119,27 @@ namespace MoreLinq {
         }
 
         /// <summary>
-        /// Returns the set of elements from the first sequence
-        /// whose keys are in the second sequence, according to the given key selector.
+        /// Returns the set of distinct elements in the first sequence,
+        /// whose keys are in the second sequence, according to a given key selector and equality comparer.
         /// </summary>
-        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
-        /// <typeparam name="TKey">The type of the key.</typeparam>
-        /// <param name="first">The sequence of potentially included elements.</param>
-        /// <param name="second">The sequence of keys which may allow elements in
-        /// <paramref name="first"/> to be returned.</param>
-        /// <param name="keySelector">The mapping from source element to key.</param>
-        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
-        /// <returns>Distinct set of elements from first sequence
-        /// whose keys are in second sequence, according to the given key selector.</returns>
-        /// <remarks>This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
         /// equal keys, only the first such element is returned.
-        /// This operator uses deferred execution and streams the results, although
-        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// This operator uses deferred execution and streams results from <paramref name="first"/>,
+        /// but the entire set of keys from <paramref name="second"/> is cached as soon as execution begins.
+        /// Duplicate keys from <paramref name="second"/> are not relevant and are discarded when <paramref name="second"/> is cached.
         /// </remarks>
+        /// <typeparam name="TSource">The type of source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>, used for equality comparison.</typeparam>
+        /// <param name="first">The set of potentially included elements.</param>
+        /// <param name="second">The set of keys which may allow elements in <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The equality comparer to use to determine whether or not keys are equal.
+        /// If null, the default equality comparer for <c>TSource</c> is used.</param>
+        /// <returns>The set of distinct elements from <paramref name="first"/> whose key is in <paramref name="second"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="first"/>, <paramref name="second"/>, or 
+        /// <paramref name="keySelector"/> is <c>null</c>.
+        /// If <paramref name="keyComparer"/> is <c>null</c>, the default equality comparer for <typeparamref name="TSource"/> is used.</exception>
         public static IEnumerable<TSource> IntersectKeys<TSource, TKey>(this IEnumerable<TSource> first,
             IEnumerable<TKey> second,
             Func<TSource, TKey> keySelector,
@@ -146,10 +158,10 @@ namespace MoreLinq {
             IEqualityComparer<TKey> keyComparer) {
 
             var keys = new HashSet<TKey>(second, keyComparer);
-            foreach (var item in first) {
-                var k = keySelector(item);
+            foreach (var element in first) {
+                var k = keySelector(element);
                 if (keys.Contains(k)) {
-                    yield return item;
+                    yield return element;
                     keys.Remove(k);
                 }
             }

--- a/MoreLinq/IntersectBy.cs
+++ b/MoreLinq/IntersectBy.cs
@@ -1,0 +1,158 @@
+﻿#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    partial class MoreEnumerable {
+
+        /// <summary>
+        /// Returns the set of elements from the first sequence
+        /// which are in the second sequence, according to the given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may allow elements in
+        /// <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>Distinct set of elements from first sequence
+        /// which are in second sequence, according to the given key selector.</returns>
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectKeysImpl(first, second.Select(keySelector), keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the set of elements from the first sequence
+        /// which are in the second sequence, according to the given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of elements whose keys may allow elements in
+        /// <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
+        /// <returns>Distinct set of elements from first sequence
+        /// which are in second sequence, according to the given key selector.</returns>
+        /// <remarks>This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> IntersectBy<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectKeysImpl(first, second.Select(keySelector), keySelector, keyComparer);
+        }
+
+        /// <summary>
+        /// Returns the set of elements from the first sequence
+        /// whose keys are in the second sequence, according to the given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of keys which may allow elements in
+        /// <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <returns>Distinct set of elements from first sequence
+        /// whose keys are in second sequence, according to the given key selector.</returns>
+        /// <remarks>
+        /// This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> IntersectKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectKeysImpl(first, second, keySelector, null);
+        }
+
+        /// <summary>
+        /// Returns the set of elements from the first sequence
+        /// whose keys are in the second sequence, according to the given key selector.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source and result elements.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="first">The sequence of potentially included elements.</param>
+        /// <param name="second">The sequence of keys which may allow elements in
+        /// <paramref name="first"/> to be returned.</param>
+        /// <param name="keySelector">The mapping from source element to key.</param>
+        /// <param name="keyComparer">The key comparer. If <c>null</c>, uses the default TKey equality comparer.</param>
+        /// <returns>Distinct set of elements from first sequence
+        /// whose keys are in second sequence, according to the given key selector.</returns>
+        /// <remarks>This is a set operation; if multiple elements in <paramref name="first"/> have
+        /// equal keys, only the first such element is returned.
+        /// This operator uses deferred execution and streams the results, although
+        /// a set of keys from <paramref name="second"/> is immediately selected and retained.
+        /// </remarks>
+        public static IEnumerable<TSource> IntersectKeys<TSource, TKey>(this IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (keySelector == null) throw new ArgumentNullException("keySelector");
+
+            return IntersectKeysImpl(first, second, keySelector, keyComparer);
+        }
+
+        private static IEnumerable<TSource> IntersectKeysImpl<TSource, TKey>(IEnumerable<TSource> first,
+            IEnumerable<TKey> second,
+            Func<TSource, TKey> keySelector,
+            IEqualityComparer<TKey> keyComparer) {
+
+            var keys = new HashSet<TKey>(second, keyComparer);
+            foreach (var item in first) {
+                var k = keySelector(item);
+                if (keys.Contains(k)) {
+                    yield return item;
+                    keys.Remove(k);
+                }
+            }
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -86,6 +86,9 @@
     <Compile Include="EquiZip.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="ExceptAll.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="ExceptBy.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
@@ -127,7 +130,12 @@
     <Compile Include="Interleave.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
-    <Compile Include="IntersectBy.cs" />
+    <Compile Include="IntersectAll.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
+    <Compile Include="IntersectBy.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="Lag.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Interleave.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="IntersectBy.cs" />
     <Compile Include="Lag.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -55,6 +55,9 @@
     <Compile Include="AtLeast.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="ExceptBy.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="FallbackIfEmpty.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
@@ -62,6 +65,9 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Fold.g.tt</DependentUpon>
+    </Compile>
+    <Compile Include="IntersectBy.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.g.cs">
       <AutoGen>True</AutoGen>
@@ -73,9 +79,6 @@
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
     <Compile Include="Cartesian.cs">
-      <DependentUpon>MoreEnumerable.cs</DependentUpon>
-    </Compile>
-    <Compile Include="ExceptBy.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
     <Compile Include="Exclude.cs">
@@ -203,7 +206,8 @@
     <Compile Include="GroupAdjacent.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
-    <Compile Include="MoreEnumerable.cs" />
+    <Compile Include="MoreEnumerable.cs">
+    </Compile>
     <Compile Include="TakeEvery.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
@@ -276,6 +280,7 @@
       <LastGenOutput>AssemblyInfo.g.cs</LastGenOutput>
     </Content>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -55,6 +55,12 @@
     <Compile Include="AtLeast.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="IntersectAll.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
+    <Compile Include="ExceptAll.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="ExceptBy.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
Created IntersectBy operator.
Created similar IntersectKeys and ExceptKeys operators, which take a collection of keys as their second argument.
Created unit tests for IntersectBy, IntersectKeys, ExceptKeys, analogous to existing tests for ExceptBy