### PR TITLE
Add StartsWith and EndsWith

### DIFF
--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -1,0 +1,105 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class EndsWithTest
+    {
+        [TestCase(null, null)]
+        [TestCase(null, new[] {1})]
+        [TestCase(new[] {1}, null)]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void EndsWithThrowsIfFirstOrSecondAreNull(IEnumerable<int> first, IEnumerable<int> second)
+        {
+            first.EndsWith(second);
+        }
+
+        [TestCase(new[] {1, 2, 3}, new[] {2, 3}, Result = true)]
+        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, Result = true)]
+        [TestCase(new[] {1, 2, 3}, new[] {0, 1, 2, 3}, Result = false)]
+        public bool EndsWithWithIntegers(IEnumerable<int> first, IEnumerable<int> second)
+        {
+            return first.EndsWith(second);
+        }
+
+        [TestCase(new[] {'1', '2', '3'}, new[] {'2', '3'}, Result = true)]
+        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3'}, Result = true)]
+        [TestCase(new[] {'1', '2', '3'}, new[] {'0', '1', '2', '3'}, Result = false)]
+        public bool EndsWithWithChars(IEnumerable<char> first, IEnumerable<char> second)
+        {
+            return first.EndsWith(second);
+        }
+
+        [TestCase("123", "23", Result = true)]
+        [TestCase("123", "123", Result = true)]
+        [TestCase("123", "0123", Result = false)]
+        public bool EndsWithWithStrings(string first, string second)
+        {
+            // Conflict with String.EndsWith(), which has precedence in this case
+            return MoreEnumerable.EndsWith(first, second);
+        }
+
+        [Test]
+        public void EndsWithReturnsTrueIfBothEmpty()
+        {
+            Assert.True(new int[0].EndsWith(new int[0]));
+        }
+
+        [Test]
+        public void EndsWithReturnsFalseIfOnlyFirstIsEmpty()
+        {
+            Assert.False(new int[0].EndsWith(new[] {1,2,3}));
+        }
+
+        [TestCase("", "", Result = true)]
+        [TestCase("1", "", Result = true)]
+        public bool EndsWithReturnsTrueIfSecondIsEmpty(string first, string second)
+        {
+            // Conflict with String.EndsWith(), which has precedence in this case
+            return MoreEnumerable.EndsWith(first, second);
+        }
+
+        [Test]
+        public void EndsWithDisposesBothSequenceEnumerators()
+        {
+            using (var first = TestingSequence.Of(1,2,3))
+            using (var second = TestingSequence.Of(1))
+            {
+                first.EndsWith(second);
+            }
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "RedundantArgumentDefaultValue")]
+        public void EndsWithUsesSpecifiedEqualityComparerOrDefault()
+        {
+            var first = new[] {1,2,3};
+            var second = new[] {4,5,6};
+
+            Assert.False(first.EndsWith(second));
+            Assert.False(first.EndsWith(second, null));
+            Assert.False(first.EndsWith(second, new EqualityComparerFunc<int>((f, s) => false)));
+            Assert.True(first.EndsWith(second, new EqualityComparerFunc<int>((f, s) => true)));
+        }
+    }
+}

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CartesianTest.cs" />
     <Compile Include="Combinatorics.cs" />
     <Compile Include="ComparerFunc.cs" />
+    <Compile Include="EndsWithTest.cs" />
     <Compile Include="EqualityComparerFunc.cs" />
     <Compile Include="ExcludeTest.cs" />
     <Compile Include="FallbackIfEmptyTest.cs" />

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -65,6 +65,7 @@
     <Compile Include="LagTest.cs" />
     <Compile Include="LeadTest.cs" />
     <Compile Include="NestedLoopTest.cs" />
+    <Compile Include="StartsWithTest.cs" />
     <Compile Include="TopByTest.cs" />
     <Compile Include="TopTest.cs" />
     <Compile Include="OrderByTest.cs" />

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -56,6 +56,7 @@
     <Compile Include="AcquireTest.cs" />
     <Compile Include="AssertTest.cs" />
     <Compile Include="AssertUtil.cs" />
+    <Compile Include="EndsWithTest.cs" />
     <Compile Include="StartsWithTest.cs" />
     <Compile Include="AtLeastTest.cs" />
     <Compile Include="FoldTest.cs" />

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -56,6 +56,7 @@
     <Compile Include="AcquireTest.cs" />
     <Compile Include="AssertTest.cs" />
     <Compile Include="AssertUtil.cs" />
+    <Compile Include="StartsWithTest.cs" />
     <Compile Include="AtLeastTest.cs" />
     <Compile Include="FoldTest.cs" />
     <Compile Include="IndexTest.cs" />

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -1,0 +1,105 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class StartsWithTest
+    {
+        [TestCase(null, null)]
+        [TestCase(null, new[] {1})]
+        [TestCase(new[] {1}, null)]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void StartsWithThrowsIfFirstOrSecondAreNull(IEnumerable<int> first, IEnumerable<int> second)
+        {
+            first.StartsWith(second);
+        }
+
+        [TestCase(new[] {1, 2, 3}, new[] {1, 2}, Result = true)]
+        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, Result = true)]
+        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3, 4}, Result = false)]
+        public bool StartsWithWithIntegers(IEnumerable<int> first, IEnumerable<int> second)
+        {
+            return first.StartsWith(second);
+        }
+
+        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2'}, Result = true)]
+        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3'}, Result = true)]
+        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3', '4'}, Result = false)]
+        public bool StartsWithWithChars(IEnumerable<char> first, IEnumerable<char> second)
+        {
+            return first.StartsWith(second);
+        }
+
+        [TestCase("123", "12", Result = true)]
+        [TestCase("123", "123", Result = true)]
+        [TestCase("123", "1234", Result = false)]
+        public bool StartsWithWithStrings(string first, string second)
+        {
+            // Conflict with String.StartsWith(), which has precedence in this case
+            return MoreEnumerable.StartsWith(first, second);
+        }
+
+        [Test]
+        public void StartsWithReturnsTrueIfBothEmpty()
+        {
+            Assert.True(new int[0].StartsWith(new int[0]));
+        }
+
+        [Test]
+        public void StartsWithReturnsFalseIfOnlyFirstIsEmpty()
+        {
+            Assert.False(new int[0].StartsWith(new[] {1,2,3}));
+        }
+
+        [TestCase("", "", Result = true)]
+        [TestCase("1", "", Result = true)]
+        public bool StartsWithReturnsTrueIfSecondIsEmpty(string first, string second)
+        {
+            // Conflict with String.StartsWith(), which has precedence in this case
+            return MoreEnumerable.StartsWith(first, second);
+        }
+
+        [Test]
+        public void StartsWithDisposesBothSequenceEnumerators()
+        {
+            using (var first = TestingSequence.Of(1,2,3))
+            using (var second = TestingSequence.Of(1))
+            {
+                first.StartsWith(second);
+            }
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "RedundantArgumentDefaultValue")]
+        public void StartsWithUsesSpecifiedEqualityComparerOrDefault()
+        {
+            var first = new[] {1,2,3};
+            var second = new[] {4,5,6};
+
+            Assert.False(first.StartsWith(second));
+            Assert.False(first.StartsWith(second, null));
+            Assert.False(first.StartsWith(second, new EqualityComparerFunc<int>((f, s) => false)));
+            Assert.True(first.StartsWith(second, new EqualityComparerFunc<int>((f, s) => true)));
+        }
+    }
+}

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -68,7 +68,8 @@ namespace MoreLinq
         {
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");
-            if (comparer == null) comparer = EqualityComparer<T>.Default;
+
+            comparer = comparer ?? EqualityComparer<T>.Default;
 
             ICollection<T> secondCollection = second as ICollection<T> ?? second.ToList();
             using (var firstIter = first.TakeLast(secondCollection.Count).GetEnumerator())

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -1,0 +1,74 @@
+#region License and Terms
+
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2016 Andreas Gullberg Larsen. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MoreLinq
+{
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        ///     Determines whether the end of <paramref name="first" /> matches <paramref name="second" />.
+        /// </summary>
+        /// <typeparam name="T">Type of elements.</typeparam>
+        /// <param name="first">The sequence to check.</param>
+        /// <param name="second">The sequence to compare to.</param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="first" /> ends with elements equivalent to <paramref name="second" />.
+        /// </returns>
+        /// <remarks>
+        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.EndsWith(string)" /> and
+        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> using <see cref="EqualityComparer{T}.Default" /> on pairs
+        ///     of elements at the same index.
+        /// </remarks>
+        public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            return EndsWith(first, second, EqualityComparer<T>.Default);
+        }
+
+        /// <summary>
+        ///     Determines whether the end of <paramref name="first" /> matches <paramref name="second" />.
+        /// </summary>
+        /// <typeparam name="T">Type of elements.</typeparam>
+        /// <param name="first">The sequence to check.</param>
+        /// <param name="second">The sequence to compare to.</param>
+        /// <param name="comparer">Equality comparer to use.</param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="first" /> ends with elements equivalent to <paramref name="second" />.
+        /// </returns>
+        /// <remarks>
+        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.EndsWith(string)" /> and
+        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs of elements at the same index.
+        /// </remarks>
+        public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer)
+        {
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (comparer == null) comparer = EqualityComparer<T>.Default;
+
+            ICollection<T> secondCollection = second as ICollection<T> ?? second.ToList();
+            using (var firstIter = first.TakeLast(secondCollection.Count).GetEnumerator())
+            {
+                return secondCollection.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
+            }
+        }
+    }
+}

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -24,8 +24,8 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Determines whether the end of <paramref name="first" /> matches
-        /// <paramref name="second" />.
+        /// Determines whether the end of the first sequence is equivalent to
+        /// the second sequence, using the default equality comparer.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
@@ -47,8 +47,8 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Determines whether the end of <paramref name="first" /> matches
-        /// <paramref name="second" />.
+        /// Determines whether the end of the first sequence is equivalent to
+        /// the second sequence, using the specified element equality comparer.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -1,5 +1,4 @@
 #region License and Terms
-
 // MoreLINQ - Extensions to LINQ to Objects
 // Copyright (c) 2016 Andreas Gullberg Larsen. All rights reserved.
 //
@@ -14,30 +13,33 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #endregion
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace MoreLinq
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
     static partial class MoreEnumerable
     {
         /// <summary>
-        ///     Determines whether the end of <paramref name="first" /> matches <paramref name="second" />.
+        /// Determines whether the end of <paramref name="first" /> matches
+        /// <paramref name="second" />.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
         /// <param name="second">The sequence to compare to.</param>
         /// <returns>
-        ///     <c>true</c> if <paramref name="first" /> ends with elements equivalent to <paramref name="second" />.
+        /// <c>true</c> if <paramref name="first" /> ends with elements
+        /// equivalent to <paramref name="second" />.
         /// </returns>
         /// <remarks>
-        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.EndsWith(string)" /> and
-        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> using <see cref="EqualityComparer{T}.Default" /> on pairs
-        ///     of elements at the same index.
+        /// This is the <see cref="IEnumerable{T}" /> equivalent of
+        /// <see cref="string.EndsWith(string)" /> and
+        /// it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> using
+        /// <see cref="EqualityComparer{T}.Default" /> on pairs of elements at
+        /// the same index.
         /// </remarks>
         public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
         {
@@ -45,18 +47,22 @@ namespace MoreLinq
         }
 
         /// <summary>
-        ///     Determines whether the end of <paramref name="first" /> matches <paramref name="second" />.
+        /// Determines whether the end of <paramref name="first" /> matches
+        /// <paramref name="second" />.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
         /// <param name="second">The sequence to compare to.</param>
         /// <param name="comparer">Equality comparer to use.</param>
         /// <returns>
-        ///     <c>true</c> if <paramref name="first" /> ends with elements equivalent to <paramref name="second" />.
+        /// <c>true</c> if <paramref name="first" /> ends with elements
+        /// equivalent to <paramref name="second" />.
         /// </returns>
         /// <remarks>
-        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.EndsWith(string)" /> and
-        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs of elements at the same index.
+        /// This is the <see cref="IEnumerable{T}" /> equivalent of
+        /// <see cref="string.EndsWith(string)" /> and it calls
+        /// <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs of
+        /// elements at the same index.
         /// </remarks>
         public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer)
         {

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -71,7 +71,7 @@ namespace MoreLinq
 
             comparer = comparer ?? EqualityComparer<T>.Default;
 
-            ICollection<T> secondCollection = second as ICollection<T> ?? second.ToList();
+            var secondCollection = second as ICollection<T> ?? second.ToList();
             using (var firstIter = first.TakeLast(secondCollection.Count).GetEnumerator())
             {
                 return secondCollection.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
         /// </remarks>
         public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
         {
-            return EndsWith(first, second, EqualityComparer<T>.Default);
+            return EndsWith(first, second, null);
         }
 
         /// <summary>

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -83,6 +83,9 @@
     <Compile Include="DistinctBy.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="EndsWith.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="EquiZip.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -213,6 +213,9 @@
     <Compile Include="Split.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="StartsWith.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="Subsets.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -55,6 +55,9 @@
     <Compile Include="AtLeast.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="EndsWith.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="FallbackIfEmpty.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -146,6 +146,9 @@
     <Compile Include="Slice.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="StartsWith.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="Top.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -68,7 +68,8 @@ namespace MoreLinq
         {
             if (first == null) throw new ArgumentNullException("first");
             if (second == null) throw new ArgumentNullException("second");
-            if (comparer == null) comparer = EqualityComparer<T>.Default;
+
+            comparer = comparer ?? EqualityComparer<T>.Default;
 
             using (var firstIter = first.GetEnumerator())
             {

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -24,8 +24,9 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Determines whether the beginning of <paramref name="first" />
-        /// matches <paramref name="second" />.
+        /// Determines whether the beginning of the first sequence is
+        /// equivalent to the second sequence, using the default equality
+        /// comparer.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
@@ -47,8 +48,9 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Determines whether the beginning of <paramref name="first" />
-        /// matches <paramref name="second" />.
+        /// Determines whether the beginning of the first sequence is
+        /// equivalent to the second sequence, using the specified element
+        /// equality comparer.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -24,17 +24,22 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        ///     Determines whether the beginning of <paramref name="first" /> matches <paramref name="second" />.
+        /// Determines whether the beginning of <paramref name="first" />
+        /// matches <paramref name="second" />.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
         /// <param name="second">The sequence to compare to.</param>
         /// <returns>
-        ///     <c>true</c> if <paramref name="first" /> begins with elements equivalent to <paramref name="second" />.
+        /// <c>true</c> if <paramref name="first" /> begins with elements
+        /// equivalent to <paramref name="second" />.
         /// </returns>
         /// <remarks>
-        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.StartsWith(string)" /> and
-        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> using <see cref="EqualityComparer{T}.Default"/> on pairs of elements at the same index.
+        /// This is the <see cref="IEnumerable{T}" /> equivalent of 
+        /// <see cref="string.StartsWith(string)" /> and it calls
+        /// <see cref="IEqualityComparer{T}.Equals(T,T)" /> using 
+        /// <see cref="EqualityComparer{T}.Default"/> on pairs of elements at
+        /// the same index.
         /// </remarks>
         public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
         {
@@ -42,18 +47,22 @@ namespace MoreLinq
         }
 
         /// <summary>
-        ///     Determines whether the beginning of <paramref name="first" /> matches <paramref name="second" />.
+        /// Determines whether the beginning of <paramref name="first" />
+        /// matches <paramref name="second" />.
         /// </summary>
         /// <typeparam name="T">Type of elements.</typeparam>
         /// <param name="first">The sequence to check.</param>
         /// <param name="second">The sequence to compare to.</param>
         /// <param name="comparer">Equality comparer to use.</param>
         /// <returns>
-        ///     <c>true</c> if <paramref name="first" /> begins with elements equivalent to <paramref name="second" />.
+        /// <c>true</c> if <paramref name="first" /> begins with elements
+        /// equivalent to <paramref name="second" />.
         /// </returns>
         /// <remarks>
-        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.StartsWith(string)" /> and
-        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs of elements at the same index.
+        /// This is the <see cref="IEnumerable{T}" /> equivalent of 
+        /// <see cref="string.StartsWith(string)" /> and
+        /// it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs
+        /// of elements at the same index.
         /// </remarks>
         public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer)
         {

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -1,0 +1,70 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2016 Andreas Gullberg Larsen. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        ///     Determines whether the beginning of <paramref name="first" /> matches <paramref name="second" />.
+        /// </summary>
+        /// <typeparam name="T">Type of elements.</typeparam>
+        /// <param name="first">The sequence to check.</param>
+        /// <param name="second">The sequence to compare to.</param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="first" /> begins with elements equivalent to <paramref name="second" />.
+        /// </returns>
+        /// <remarks>
+        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.StartsWith(string)" /> and
+        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> using <see cref="EqualityComparer{T}.Default"/> on pairs of elements at the same index.
+        /// </remarks>
+        public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            return StartsWith(first, second, EqualityComparer<T>.Default);
+        }
+
+        /// <summary>
+        ///     Determines whether the beginning of <paramref name="first" /> matches <paramref name="second" />.
+        /// </summary>
+        /// <typeparam name="T">Type of elements.</typeparam>
+        /// <param name="first">The sequence to check.</param>
+        /// <param name="second">The sequence to compare to.</param>
+        /// <param name="comparer">Equality comparer to use.</param>
+        /// <returns>
+        ///     <c>true</c> if <paramref name="first" /> begins with elements equivalent to <paramref name="second" />.
+        /// </returns>
+        /// <remarks>
+        ///     This is the <see cref="IEnumerable{T}" /> equivalent of <see cref="string.StartsWith(string)" /> and
+        ///     it calls <see cref="IEqualityComparer{T}.Equals(T,T)" /> on pairs of elements at the same index.
+        /// </remarks>
+        public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T> comparer)
+        {
+            if (first == null) throw new ArgumentNullException("first");
+            if (second == null) throw new ArgumentNullException("second");
+            if (comparer == null) comparer = EqualityComparer<T>.Default;
+
+            using (var firstIter = first.GetEnumerator())
+            {
+                return second.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
+            }
+        }
+    }
+}

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -38,7 +38,7 @@ namespace MoreLinq
         /// </remarks>
         public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second)
         {
-            return StartsWith(first, second, EqualityComparer<T>.Default);
+            return StartsWith(first, second, null);
         }
 
         /// <summary>


### PR DESCRIPTION
Similar to `String.StartsWith()` and `.EndsWith()`, except on `IEnumerable<T>`. Can even take strings as arguments, as sequences of chars.

* Add MoreEnumerable.StartsWith()
* Add MoreEnumerable.EndsWith()
* Add 15 test cases for StartsWith
* Add 15 test cases for EndsWith

All tests run OK locally.
I tried to glance through and match the coding conventions, but let me know if you see anything that is off or test cases you would want to add.