### PR TITLE
Ability to create batches based on a first and last match predicate

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -103,5 +103,61 @@ namespace MoreLinq.Test
         {
             new BreakingSequence<object>().Batch(1);
         }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void BatchNullSequenceBasedOnPredicates()
+        {
+            Func<int, bool> firstMatch = i => i == 1;
+            Func<int, bool> lastMatch = i => i == 3;
+            MoreEnumerable.Batch(null, firstMatch, lastMatch).Consume();
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void BatchSequenceBasedOnNullFirstMatchPredicate()
+        {
+            var source = new[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 };
+            Func<int, bool> lastMatch = i => i == 3;
+            source.Batch(null, lastMatch).Consume();
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void BatchSequenceBasedOnNullLastMatchPredicate()
+        {
+            var source = new[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 };
+            Func<int, bool> firstMatch = i => i == 1;
+            source.Batch(firstMatch, null).Consume();
+        }
+
+        [Test]
+        public void BatchSequenceBasedOnPredicateSimple()
+        {
+            Func<int, bool> firstMatch = i => i == 1;
+            Func<int, bool> lastMatch = i => i == 3;
+            var result = new[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 }.Batch(firstMatch, lastMatch);
+            using (var reader = result.Read())
+            {
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.ReadEnd();
+            }
+        }
+
+        [Test]
+        public void BatchSequenceBasedOnPredicateSkipUnmatched()
+        {
+            Func<int, bool> firstMatch = i => i == 1;
+            Func<int, bool> lastMatch = i => i == 3;
+            var result = new[] { 1, 2, 1, 2, 3, 1, 2, 3 }.Batch(firstMatch, lastMatch);
+            using (var reader = result.Read())
+            {
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.ReadEnd();
+            }
+        }
     }
 }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -64,6 +64,21 @@ namespace MoreLinq
             return BatchImpl(source, size, resultSelector);
         }
 
+        /// <summary>
+        /// Batches the sequence based on the first and last match predicates.
+        /// </summary>
+        /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+        /// <param name="source">The source sequence</param>
+        /// <param name="firstMatchPredicate">Predicate to identify the first element of the result sequence</param>
+        /// <param name="lastMatchPredicate">Predicate to identify the last element of the result sequence</param>
+        /// <returns>A sequence where the first element satisfies the firstMatchPredicate and the last element matches the lastMatchPredicate. Elements in between should not satisfy the predicates.</returns>
+        public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source,
+                                                                       Func<TSource, bool> firstMatchPredicate,
+                                                                       Func<TSource, bool> lastMatchPredicate)
+        {
+            throw new NotImplementedException();
+        }
+
         private static IEnumerable<TResult> BatchImpl<TSource, TResult>(this IEnumerable<TSource> source, int size,
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -130,35 +130,28 @@ namespace MoreLinq
             Debug.Assert(firstMatchPredicate != null);
             Debug.Assert(lastMatchPredicate != null);
 
-            var currentBatch = new List<TSource>();
-            using (var iter = source.GetEnumerator())
+            var currentBatch = new List<TSource>();            
+            foreach (var item in source)
             {
-                while (iter.MoveNext())
+                var firstMatched = firstMatchPredicate(item);
+                if (firstMatched)
                 {
-                    var item = iter.Current;
-                    var itemConsidered = false;
-
-                    var firstMatched = firstMatchPredicate(item);
-                    if (firstMatched)
-                    {
-                        currentBatch.Clear();
-                        currentBatch.Add(item);
-                        itemConsidered = true;
-                    }
-
-                    var lastMatched = !itemConsidered && lastMatchPredicate(item);
-                    if (lastMatched)
-                    {
-                        currentBatch.Add(item);
-                        yield return currentBatch;
-
-                        itemConsidered = true;
-                        currentBatch = new List<TSource>();
-                    }
-
-                    if (!itemConsidered)
-                        currentBatch.Add(item);
+                    currentBatch.Clear();
+                    currentBatch.Add(item);
+                    continue;
                 }
+
+                var lastMatched = lastMatchPredicate(item);
+                if (lastMatched)
+                {
+                    currentBatch.Add(item);
+                    yield return currentBatch;
+
+                    currentBatch = new List<TSource>();
+                    continue;
+                }
+
+                currentBatch.Add(item);
             }
         }
     }


### PR DESCRIPTION
Hello,

To begin with MoreLINQ is an awesome idea and is really helpful! Regarding this pull request, I had to create a method that would batch a list of items based on a "first" match and "last" match, where other items in between does not satisfy either of the matches. After I wrote this method, I thought it would be a good addition to the MoreLINQ repository! 

Here is an example of how this could be put in to use:

```csharp
public class Activity
{
    public int Id { get; set; }
    public string Name { get; set; }
    public bool IsEnabled { get; set; }
}

public class BatchTester
{
    public static void Main(string[] args)
    {
        // Generate 9 entries w/ Name Activity 1, Activity 2, Activity 3,... and so on
        var activities = Enumerable.Range(0, 9)
                                   .Select(
                                        i => new Activity
                                              {
                                                  Id = i, 
                                                  Name = "Activity " + ((i%3) + 1), 
                                                  IsEnabled = true
                                              });
        Func<Activity, bool> firstMatch = activity => activity.Name.EndsWith("1");
        Func<Activity, bool> lastMatch = activity => activity.Name.EndsWith("3");
        var batches = activities.Batch(firstMatch, lastMatch);
        foreach (var batch in batches)
        {
            var combined = string.Join(", ", batch.Select(b => b.Name));
            // This would print Activtiy 1, Activity 2, Activity 3
            Console.WriteLine(combined);
        }
     }
}
```

Do check this out (test & implementation) and let me know your thoughts! Thanks for the opportunity!!
