### PR TITLE
Added reference to Documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ keeps to the spirit of LINQ.
 MoreLINQ is available for download and installation as
 [NuGet packages](https://www.nuget.org/packages/morelinq/).
 
+Documentation for the stable and beta releases can be found at [morelinq.github.io](http://morelinq.github.io/).
+
+
 ## Overview of Operators
 
 Operator             | Summary


### PR DESCRIPTION
As indicated by issue #179 some developers might not be aware of morelinq.github.io, which is why I added a mention of it in the README.md.