### PR TITLE
Support for AtMost method

### DIFF
--- a/MoreLinq.Test/AtMostTest.cs
+++ b/MoreLinq.Test/AtMostTest.cs
@@ -1,0 +1,176 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2016 Jonas Nyrup. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LinqEnumerable = System.Linq.Enumerable;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class AtMostTest
+    {
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AtMostWithNullSequence()
+        {
+            IEnumerable<int> sequence = null;
+            sequence.AtMost(1);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void AtMostWithNegativeCount()
+        {
+            new[] { 1 }.AtMost(-1);
+        }
+
+        private static IEnumerable<int> GetSequence()
+        {
+            return new InfiniteSequence<int>(0);
+        }
+        [Test]
+        public void AtMostWithEmptySequenceHasAtMostZeroElements()
+        {
+            Assert.IsTrue(GetEmptySequence().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithEmptySequenceHasAtMostOneElement()
+        {
+            Assert.IsTrue(GetEmptySequence().AtMost(1));
+        }
+        private static IEnumerable<int> GetEmptySequence()
+        {
+            return LinqEnumerable.Empty<int>();
+        }
+
+        [Test]
+        public void AtMostWithSingleElementHasAtMostZeroElements()
+        {
+            Assert.IsFalse(GetSingleElementSequence().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithSingleElementHasAtMostOneElement()
+        {
+            Assert.IsTrue(GetSingleElementSequence().AtMost(1));
+        }
+        [Test]
+        public void AtMostWithSingleElementHasAtMostTwoElements()
+        {
+            Assert.IsTrue(GetSingleElementSequence().AtMost(2));
+        }
+        private static IEnumerable<int> GetSingleElementSequence()
+        {
+            return GetSequence().Take(1);
+        }
+
+        [Test]
+        public void AtMostWithManyElementsHasAtMostZeroElements()
+        {
+            Assert.IsFalse(GetManyElementSequence().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostOneElement()
+        {
+            Assert.IsFalse(GetManyElementSequence().AtMost(1));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostThreeElements()
+        {
+            Assert.IsTrue(GetManyElementSequence().AtMost(3));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostManyElements()
+        {
+            Assert.IsTrue(GetManyElementSequence().AtMost(4));
+        }
+        private static IEnumerable<int> GetManyElementSequence()
+        {
+            return GetSequence().Take(3);
+        }
+
+        //ICollection<T> Optimization Tests
+        [Test]
+        public void AtMostWithEmptySequenceHasAtMostZeroElementsForCollections()
+        {
+            Assert.IsTrue(GetEmptyArray().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithEmptySequenceHasAtMostOneElementForCollections()
+        {
+            Assert.IsTrue(GetEmptyArray().AtMost(1));
+        }
+        private static IEnumerable<int> GetEmptyArray()
+        {
+            return new int[] { };
+        }
+
+        [Test]
+        public void AtMostWithSingleElementHasAtMostZeroElementsForCollections()
+        {
+            Assert.IsFalse(GetSingleElementArray().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithSingleElementHasAtMostOneElementForCollections()
+        {
+            Assert.IsTrue(GetSingleElementArray().AtMost(1));
+        }
+        [Test]
+        public void AtMostWithSingleElementHasAtMostManyElementsForCollections()
+        {
+            Assert.IsTrue(GetSingleElementArray().AtMost(2));
+        }
+        private static IEnumerable<int> GetSingleElementArray()
+        {
+            return GetSingleElementSequence().ToArray();
+        }
+
+        [Test]
+        public void AtMostWithManyElementsHasAtMostZeroElementsForCollections()
+        {
+            Assert.IsFalse(GetManyElementArray().AtMost(0));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostOneElementForCollections()
+        {
+            Assert.IsFalse(GetManyElementArray().AtMost(1));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostThreeElementsForCollections()
+        {
+            Assert.IsTrue(GetManyElementArray().AtMost(3));
+        }
+        [Test]
+        public void AtMostWithManyElementsHasAtMostManyElementsForCollections()
+        {
+            Assert.IsTrue(GetManyElementArray().AtMost(4));
+        }
+        private static IEnumerable<int> GetManyElementArray()
+        {
+            return GetManyElementSequence().ToArray();
+        }
+
+        [Test]
+        public void AtMostShouldBeNotEnumerateSequenceForImplementersOfICollection()
+        {
+            var sequence = new UnenumerableList<int>();
+            sequence.AtMost(3);
+        }
+    }
+}

--- a/MoreLinq.Test/MoreLinq.Portable.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Portable.Test.csproj
@@ -50,6 +50,7 @@
     <Compile Include="AssertTest.cs" />
     <Compile Include="AssertUtil.cs" />
     <Compile Include="AtLeastTest.cs" />
+    <Compile Include="AtMostTest.cs" />
     <Compile Include="CartesianTest.cs" />
     <Compile Include="Combinatorics.cs" />
     <Compile Include="ComparerFunc.cs" />

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="EndsWithTest.cs" />
     <Compile Include="StartsWithTest.cs" />
     <Compile Include="AtLeastTest.cs" />
+    <Compile Include="AtMostTest.cs" />
     <Compile Include="FoldTest.cs" />
     <Compile Include="IndexTest.cs" />
     <Compile Include="KeyValuePair.cs" />

--- a/MoreLinq/AtMost.cs
+++ b/MoreLinq/AtMost.cs
@@ -26,15 +26,14 @@ namespace MoreLinq
         /// <summary>
         /// Returns true when the number of elements in the given sequence is smaller than
         /// or equal to the given integer.
-        /// This method throws an exception if the given integer is negative.
         /// </summary>
         /// <remarks>
-        /// The number of items streamed will be less than or equal to the given integer
-        /// plus one.
+        /// The number of items pulled from the sequence will be less than or equal to 
+        /// the given integer plus one.
         /// </remarks>
         /// <typeparam name="TSource">Element type of sequence</typeparam>
         /// <param name="source">The source sequence</param>
-        /// <param name="count">The maximum number of items a sequence must have for this
+        /// <param name="count">The maximum number of items the sequence must have for this
         /// function to return true</param>
         /// <exception cref="ArgumentNullException">source is null</exception>
         /// <exception cref="ArgumentOutOfRangeException">count is negative</exception>
@@ -42,8 +41,8 @@ namespace MoreLinq
         /// or equal to the given integer or <c>false</c> otherwise.</returns>
         /// <example>
         /// <code>
-        /// var numbers = { 123, 456, 789 };
-        /// var result = numbers.AtMost(4);
+        /// int[] numbers = { 123, 456, 789 };
+        /// bool result = numbers.AtMost(4);
         /// </code>
         /// The <c>result</c> variable will contain <c>true</c>.
         /// </example>

--- a/MoreLinq/AtMost.cs
+++ b/MoreLinq/AtMost.cs
@@ -1,0 +1,64 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2016 Jonas Nyrup. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns true when the number of elements in the given sequence is smaller than
+        /// or equal to the given integer.
+        /// This method throws an exception if the given integer is negative.
+        /// </summary>
+        /// <remarks>
+        /// The number of items streamed will be less than or equal to the given integer
+        /// plus one.
+        /// </remarks>
+        /// <typeparam name="TSource">Element type of sequence</typeparam>
+        /// <param name="source">The source sequence</param>
+        /// <param name="count">The maximum number of items a sequence must have for this
+        /// function to return true</param>
+        /// <exception cref="ArgumentNullException">source is null</exception>
+        /// <exception cref="ArgumentOutOfRangeException">count is negative</exception>
+        /// <returns><c>true</c> if the number of elements in the sequence is smaller than
+        /// or equal to the given integer or <c>false</c> otherwise.</returns>
+        /// <example>
+        /// <code>
+        /// var numbers = { 123, 456, 789 };
+        /// var result = numbers.AtMost(4);
+        /// </code>
+        /// The <c>result</c> variable will contain <c>true</c>.
+        /// </example>
+        public static bool AtMost<TSource>(this IEnumerable<TSource> source, int count)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (count < 0) throw new ArgumentOutOfRangeException("count", "The count must not be negative.");
+
+            var collection = source as ICollection<TSource>;
+            if (collection != null)
+            {
+                return collection.Count <= count;
+            }
+
+            return source.Take(count + 1).Count() <= count;
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.Portable.csproj
+++ b/MoreLinq/MoreLinq.Portable.csproj
@@ -68,6 +68,9 @@
     <Compile Include="AtLeast.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="AtMost.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="Batch.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -55,6 +55,9 @@
     <Compile Include="AtLeast.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>
+    <Compile Include="AtMost.cs">
+      <DependentUpon>MoreEnumerable.cs</DependentUpon>
+    </Compile>
     <Compile Include="EndsWith.cs">
       <DependentUpon>MoreEnumerable.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
As `AtLeast` is already implemented and there is another PR for `Exactly` I thought that `AtMost` was missing as I find it much more readable than `!AtLeast(count + 1)`.

I'm sorry for the many commits, but I struggled to cope with LF vs CRLF from my Linux machine and tried to fix it from within the GitHub interface. 
Please let me know if is an unacceptable mess.
