### PR TITLE
Add project file to build MoreLinq to .NET Core

### DIFF
--- a/MoreLinq/project.json
+++ b/MoreLinq/project.json
@@ -1,0 +1,28 @@
+﻿{
+    "name": "MoreLinq.Core",
+    "version": "2.0.0-beta04",
+    "buildOptions": {
+        "debugType": "portable",
+        "emitEntryPoint": false,
+        "warningsAsErrors": true,
+        "compile": {
+            "exclude": [
+                "SequenceException.cs",
+                "ToDataTable.cs",
+                "GroupAdjacent.cs",
+                "Trace.cs"
+            ]
+        }
+    },
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
+            },
+            "imports": "dnxcore50"
+        }
+    }
+}


### PR DESCRIPTION
To build MoreLinq with .NET Core, I added a .NET Core project file project.json.
It excluded files in ```["SequenceException.cs", "ToDataTable.cs", "GroupAdjacent.cs", "Trace.cs"] ```and successfully got a release build. 

After dotnet core environment is ready, I ran
```shell
dotnet restore MoreLinq/project.json
dotnet pack -c Release MoreLinq/project.json
```
and got the nuget package.

Now it is configured to only support .NETCoreApp 1.0 platform but we can add more later. 