### PR TITLE
Add FillBackward (next observation carry backward)

### DIFF
--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -1,0 +1,55 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class FillBackwardTest
+    {
+        [Test]
+        public void FillBackwardWithNullSequence()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() => MoreEnumerable.FillBackward<object>(null));
+            Assert.That(e.ParamName, Is.EqualTo("source"));
+        }
+
+        [Test]
+        public void FillBackwardWithNullPredicate()
+        {
+            var e = Assert.Throws<ArgumentNullException>(() => new object[0].FillBackward(null));
+            Assert.That(e.ParamName, Is.EqualTo("predicate"));
+        }
+
+        [Test]
+        public void FillBackwardIsLazy()
+        {
+            new BreakingSequence<object>().FillBackward();
+        }
+
+        [Test]
+        public void FillBackward()
+        {
+            int? na = null;
+            var input = new[] { na, na, 1, 2, na, na, na, 3, 4, na, na };
+            var result = input.FillBackward();
+            Assert.That(result, Is.EquivalentTo(new[] { 1, 1, 1, 2, 3, 3, 3, 3, 4, na, na }));
+        }
+    }
+}

--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -20,6 +20,8 @@ using NUnit.Framework;
 
 namespace MoreLinq.Test
 {
+    using System.Linq;
+
     [TestFixture]
     public class FillBackwardTest
     {
@@ -38,6 +40,27 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void FillBackwardWithFillSelectorButNullSequence()
+        {
+            Assert.ThrowsArgumentNullException("source", () =>
+                MoreEnumerable.FillBackward<object>(null, _ => false, delegate { return null; }));
+        }
+
+        [Test]
+        public void FillBackwardWithFillSelectorButNullPredicate()
+        {
+            Assert.ThrowsArgumentNullException("predicate", () =>
+                new object[0].FillBackward(null, delegate { return null; }));
+        }
+
+        [Test]
+        public void FillBackwardWithNullFillSelector()
+        {
+            Assert.ThrowsArgumentNullException("fillSelector", () =>
+                new object[0].FillBackward(_ => false, null));
+        }
+
+        [Test]
         public void FillBackwardIsLazy()
         {
             new BreakingSequence<object>().FillBackward();
@@ -50,6 +73,31 @@ namespace MoreLinq.Test
             var input = new[] { na, na, 1, 2, na, na, na, 3, 4, na, na };
             var result = input.FillBackward();
             Assert.That(result, Is.EquivalentTo(new[] { 1, 1, 1, 2, 3, 3, 3, 3, 4, na, na }));
+        }
+
+        [Test]
+        public void FillBackwardWithFillSelector()
+        {
+            var xs = new[] { 0, 0, 1, 2, 0, 0, 0, 3, 4, 0, 0 };
+
+            var result =
+                xs.Select(x => new { X = x, Y = x })
+                  .FillBackward(e => e.X == 0, (nm, m) => new { m.X, nm.Y });
+
+            Assert.That(result, Is.EquivalentTo(new[]
+            {
+                new { X = 0, Y = 1 },
+                new { X = 0, Y = 1 },
+                new { X = 1, Y = 1 },
+                new { X = 2, Y = 2 },
+                new { X = 0, Y = 3 },
+                new { X = 0, Y = 3 },
+                new { X = 0, Y = 3 },
+                new { X = 3, Y = 3 },
+                new { X = 4, Y = 4 },
+                new { X = 0, Y = 0 },
+                new { X = 0, Y = 0 },
+            }));
         }
     }
 }

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -68,10 +68,10 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException("source");
             if (predicate == null) throw new ArgumentNullException("predicate");
 
-            return NocbImpl(source, predicate);
+            return FillBackwardImpl(source, predicate);
         }
 
-        static IEnumerable<T> NocbImpl<T>(IEnumerable<T> source, Func<T, bool> predicate)
+        static IEnumerable<T> FillBackwardImpl<T>(IEnumerable<T> source, Func<T, bool> predicate)
         {
             List<T> blanks = null;
 

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -47,7 +47,7 @@ namespace MoreLinq
         /// <summary>
         /// Returns a sequence with each missing element in the source replaced
         /// with the following non-missing element in that sequence. An
-        /// additional parameter specified a function used to determine if an
+        /// additional parameter specifies a function used to determine if an
         /// element is considered missing or not.
         /// </summary>
         /// <param name="source">The source sequence.</param>

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -25,7 +25,7 @@ namespace MoreLinq
         /// <summary>
         /// Returns a sequence with each null reference or value in the source
         /// replaced with the following non-null reference or value in
-        /// that sequence. (NOCB = Next Observation Carry Backward)
+        /// that sequence.
         /// </summary>
         /// <param name="source">The source sequence.</param>
         /// <typeparam name="T">Type of the elements in the source sequence.</typeparam>
@@ -39,17 +39,16 @@ namespace MoreLinq
         /// sequence then they remain null.
         /// </remarks>
 
-        public static IEnumerable<T> Nocb<T>(this IEnumerable<T> source)
+        public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source)
         {
-            return source.Nocb(e => e == null);
+            return source.FillBackward(e => e == null);
         }
 
         /// <summary>
         /// Returns a sequence with each missing element in the source replaced
         /// with the following non-missing element in that sequence. An
         /// additional parameter specified a function used to determine if an
-        /// element is considered missing or not. (NOCB = Next Observation
-        /// Carry Backward)
+        /// element is considered missing or not.
         /// </summary>
         /// <param name="source">The source sequence.</param>
         /// <param name="predicate">The function used to determine if
@@ -64,7 +63,7 @@ namespace MoreLinq
         /// they remain missing.
         /// </remarks>
 
-        public static IEnumerable<T> Nocb<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
             if (source == null) throw new ArgumentNullException("source");
             if (predicate == null) throw new ArgumentNullException("predicate");

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -68,26 +68,64 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return FillBackwardImpl(source, predicate);
+            return FillBackwardImpl(source, predicate, null);
         }
 
-        static IEnumerable<T> FillBackwardImpl<T>(IEnumerable<T> source, Func<T, bool> predicate)
+        /// <summary>
+        /// Returns a sequence with each missing element in the source replaced
+        /// with the following non-missing element in that sequence. Additional
+        /// parameters specifiy two functions, one used to determine if an
+        /// element is considered missing or not and another to provide the
+        /// replacement for the missing element.
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="predicate">The function used to determine if
+        /// an element in the sequence is considered missing.</param>
+        /// <param name="fillSelector">The function used to produce the element
+        /// that will replace the missing one. It receives the next non-missing
+        /// element as well as the current element considered missing.</param>
+        /// <typeparam name="T">Type of the elements in the source sequence.</typeparam>
+        /// An <see cref="IEnumerable{T}"/> with missing values replaced.
+        /// <remarks>
+        /// This method uses deferred execution semantics and streams its
+        /// results. If elements are missing at the end of the sequence then
+        /// they remain missing.
+        /// </remarks>
+
+        public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (fillSelector == null) throw new ArgumentNullException(nameof(fillSelector));
+
+            return FillBackwardImpl(source, predicate, fillSelector);
+        }
+
+        static IEnumerable<T> FillBackwardImpl<T>(IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
         {
             List<T> blanks = null;
 
             foreach (var item in source)
             {
-                var blank = predicate(item);
-                if (blank)
+                var isBlank = predicate(item);
+                if (isBlank)
                 {
                     (blanks ?? (blanks = new List<T>())).Add(item);
                 }
                 else
                 {
-                    var count = blanks?.Count ?? 0;
-                    blanks?.Clear();
-                    while (count-- >= 0)
-                        yield return item;
+                    if (blanks != null)
+                    {
+                        foreach (var blank in blanks)
+                        {
+                            yield return fillSelector != null
+                                       ? fillSelector(item, blank)
+                                       : item;
+                        }
+
+                        blanks.Clear();
+                    }
+                    yield return item;
                 }
             }
 

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -65,8 +65,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException("source");
-            if (predicate == null) throw new ArgumentNullException("predicate");
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
             return FillBackwardImpl(source, predicate);
         }

--- a/MoreLinq/Nocb.cs
+++ b/MoreLinq/Nocb.cs
@@ -1,0 +1,102 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2016 Atif Aziz. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns a sequence with each null reference or value in the source
+        /// replaced with the following non-null reference or value in
+        /// that sequence. (NOCB = Next Observation Carry Backward)
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <typeparam name="T">Type of the elements in the source sequence.</typeparam>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> with null references or values
+        /// replaced.
+        /// </returns>
+        /// <remarks>
+        /// This method uses deferred execution semantics and streams its
+        /// results. If references or values are null at the end of the
+        /// sequence then they remain null.
+        /// </remarks>
+
+        public static IEnumerable<T> Nocb<T>(this IEnumerable<T> source)
+        {
+            return source.Nocb(e => e == null);
+        }
+
+        /// <summary>
+        /// Returns a sequence with each missing element in the source replaced
+        /// with the following non-missing element in that sequence. An
+        /// additional parameter specified a function used to determine if an
+        /// element is considered missing or not. (NOCB = Next Observation
+        /// Carry Backward)
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="predicate">The function used to determine if
+        /// an element in the sequence is considered missing.</param>
+        /// <typeparam name="T">Type of the elements in the source sequence.</typeparam>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> with missing values replaced.
+        /// </returns>
+        /// <remarks>
+        /// This method uses deferred execution semantics and streams its
+        /// results. If elements are missing at the end of the sequence then
+        /// they remain missing.
+        /// </remarks>
+
+        public static IEnumerable<T> Nocb<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (predicate == null) throw new ArgumentNullException("predicate");
+
+            return NocbImpl(source, predicate);
+        }
+
+        static IEnumerable<T> NocbImpl<T>(IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            List<T> blanks = null;
+
+            foreach (var item in source)
+            {
+                var blank = predicate(item);
+                if (blank)
+                {
+                    (blanks ?? (blanks = new List<T>())).Add(item);
+                }
+                else
+                {
+                    var count = blanks?.Count ?? 0;
+                    blanks?.Clear();
+                    while (count-- >= 0)
+                        yield return item;
+                }
+            }
+
+            if (blanks?.Count > 0)
+            {
+                foreach (var blank in blanks)
+                    yield return blank;
+            }
+        }
+    }
+}

--- a/MoreLinq/project.json
+++ b/MoreLinq/project.json
@@ -1,14 +1,14 @@
 {
   "name": "morelinq",
   "title": "MoreLINQ",
-  "description": "This project enhances LINQ to Objects with the following methods: Acquire, Assert, AssertCount, Batch, Cartesian, CountBy, Concat, Consume, DistinctBy, EquiZip, ExceptBy, Exclude, FillForward, Fold, ForEach, Generate, GenerateByIndex, GroupAdjacent, Incremental, Index, Interleave, Lag, Lead, MaxBy, MinBy, NestedLoops, OrderBy, OrderedMerge, Pad, Pairwise, PartialSort, PartialSortBy, Permutations, Pipe, Prepend, PreScan, Random, RandomDouble, RandomSubset, Rank, RankBy, Repeat, RunLengthEncode, Scan, Segment, SingleOrFallback, SkipUntil, Slice, SortedMerge, Split, Subsets, TagFirstLast, TakeEvery, TakeLast, TakeUntil, ThenBy, ToDataTable, ToDelimitedString, ToHashSet, Trace, TraverseBreadthFirst, TraverseDepthFirst, Windowed, ZipLongest, ZipShortest",
+  "description": "This project enhances LINQ to Objects with the following methods: Acquire, Assert, AssertCount, Batch, Cartesian, CountBy, Concat, Consume, DistinctBy, EquiZip, ExceptBy, Exclude, FillBackward, FillForward, Fold, ForEach, Generate, GenerateByIndex, GroupAdjacent, Incremental, Index, Interleave, Lag, Lead, MaxBy, MinBy, NestedLoops, OrderBy, OrderedMerge, Pad, Pairwise, PartialSort, PartialSortBy, Permutations, Pipe, Prepend, PreScan, Random, RandomDouble, RandomSubset, Rank, RankBy, Repeat, RunLengthEncode, Scan, Segment, SingleOrFallback, SkipUntil, Slice, SortedMerge, Split, Subsets, TagFirstLast, TakeEvery, TakeLast, TakeUntil, ThenBy, ToDataTable, ToDelimitedString, ToHashSet, Trace, TraverseBreadthFirst, TraverseDepthFirst, Windowed, ZipLongest, ZipShortest",
   "language": "en-US",
   "authors": [
     "MoreLINQ Developers."
   ],
   "copyright": "\u00a9 2008 Jonathan Skeet. Portions \u00a9 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph. Portions \u00a9 2010 Johannes Rudolph, Leopold Bushkin. Portions \u00a9 2015 Felipe Sateler, \u201csholland\u201d. Portions \u00a9 2016 Leandro F. Vieira (leandromoh). Portions \u00a9 Microsoft. All rights reserved.",
   "packOptions": {
-    "releaseNotes": "Adds new operators: AtMost, CountBetween, Exactly, FillForward. See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.\nObsolete: Incremental, some overloads of ToDelimitedString, SingleOrFallback (since 2.0)",
+    "releaseNotes": "Adds new operators: AtMost, CountBetween, Exactly, FillBackward, FillForward. See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.\nObsolete: Incremental, some overloads of ToDelimitedString, SingleOrFallback (since 2.0)",
     "summary": "This project enhances LINQ to Objects with extra methods, in a manner which keeps to the spirit of LINQ.",
     "owners": [
       "Jon Skeet",

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ Excludes elements from a sequence starting at a given index
 Returns the elements of a sequence and falls back to another if the original
 sequence is empty.
 
+### FillBackward
+
+Returns a sequence with each null reference or value in the source replaced
+with the following non-null reference or value in that sequence.
+
+This method has 2 overloads.
+
 ### FillForward
 
 Returns a sequence with each null reference or value in the source replaced

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ sequence is empty.
 Returns a sequence with each null reference or value in the source replaced
 with the following non-null reference or value in that sequence.
 
-This method has 2 overloads.
+This method has 3 overloads.
 
 ### FillForward
 


### PR DESCRIPTION
See #217 for background and more. Reviews welcome.

~Tests are pending.~

Note that this complements #177 (PR #213) as both `Locf` & `Nocb` can be used to help each other to fill missing element at the head and the tail of the source sequence.

- [x] Tests
- [x] Add to operators in package description and release notes
- [x] Add to operators list in README
