### PR TITLE
Add Positions (1-based index seq where a value is found)

### DIFF
--- a/MoreLinq/Positions.cs
+++ b/MoreLinq/Positions.cs
@@ -1,0 +1,86 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Atif Aziz. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns the positions (one-based index) at which the elements
+        /// of a sequence equal a sought value.
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="sought">The sought value.</param>
+        /// <typeparam name="T">Type of elements in the source sequence.</typeparam>
+        /// <returns>
+        /// Return a sequence of positions where the condition matched.
+        /// </returns>
+
+        public static IEnumerable<int> Positions<T>(this IEnumerable<T> source, T sought)
+        {
+            return source.Positions(sought, null);
+        }
+
+        /// <summary>
+        /// Returns the positions (one-based index) at which the elements
+        /// of a sequence equal a sought value. An additional parameter
+        /// specifies how to compare the a sequence element and the sought
+        /// value for equality.
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="sought">The sought value.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> to
+        /// use to compare each element of the sequence for equality
+        /// with <paramref name="sought"/>. If the argument specifies a null
+        /// reference then the default equality comparer is used for
+        /// <typeparamref name="T"/></param>
+        /// <typeparam name="T">Type of elements in the source sequence.</typeparam>
+        /// <returns>
+        /// Return a sequence of positions where the condition matched.
+        /// </returns>
+
+        public static IEnumerable<int> Positions<T>(this IEnumerable<T> source, T sought, IEqualityComparer<T> comparer)
+        {
+            comparer = comparer ?? EqualityComparer<T>.Default;
+            return source.Positions(e => comparer.Equals(e, sought));
+        }
+
+        /// <summary>
+        /// Returns the positions (one-based index) at which the elements
+        /// of a sequence match a user-supplied condition.
+        /// </summary>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="predicate">The condition function.</param>
+        /// <typeparam name="T">Type of elements in the source sequence.</typeparam>
+        /// <returns>
+        /// Return a sequence of positions where the condition matched.
+        /// </returns>
+
+        public static IEnumerable<int> Positions<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (predicate == null) throw new ArgumentNullException("predicate");
+            return from e in source.Index(1)
+                   where predicate(e.Value)
+                   select e.Key;
+        }
+    }
+}


### PR DESCRIPTION
`Positions` looks for a value (and more generally any condition) in a sequence and returns positions of those elements that match the value (or a given condition).

## Examples

```c#
var sentence = "The quick brown fox jumps over the lazy dog";
Console.WriteLine(sentence.Positions('o')
                          .ToDelimitedString(", "));
// Output: 13, 18, 27, 42

var vowels = "aeiou";
Console.WriteLine(sentence.Positions(ch => vowels.IndexOf(ch) >= 0)
                          .ToDelimitedString(", "));
// Output: 3, 6, 7, 13, 18, 22, 27, 29, 34, 37, 42
```

`Positions` can be built entirely on top of existing operators:

```c#
public static IEnumerable<int> Positions<T>(this IEnumerable<T> source, Func<T, bool> predicate) =>
    from e in Enumerable.Range(1, int.MaxValue)
                        .Zip(source, (i, e) => new KeyValuePair<int, T>(i, e))
    where predicate(e.Value)
    select e.Key;
```

In general, I'm against adding operators that can be implemented as a trivial combination of others but for something as simple as getting positions, you need quite a few (`Range`, `Zip`, `Where` and `Select`) and so it's rather non-trivial.

The actual implementation in this PR doesn't use `Range` and `Zip` as we have [`Index`](https://morelinq.github.io/2.0/ref/api/html/M_MoreLinq_MoreEnumerable_Index__1_1.htm).

`Positions` returns 1-based indexes because _positions_ are not generally zero-based _offsets_. One tends to think of positions as 1st, 2nd, 3rd, 4th and so on. Given the method name of `Positions`, I felt compelled to return 1-based indexes but it would be a shame if the 80% use case would require the user to have to combine with `Select` just to get back 0-based indexes/offsets, as in: 

```c#
var sentence = "The quick brown fox jumps over the lazy dog";
Console.WriteLine(sentence.Positions('o')
                          .Select(p => p - 1)
                          .ToDelimitedString(", "));
// Output: 12, 17, 26, 41
```

To return 0-based indexes, one would have to come up with another name than `Positions` (unless I'm overthinking this?). Because we have `Index`, `Indexes` is a no-go. An ideal choice would have been `IndexOf` since `Positions` is basically `IndexOf` _done right_ for sequential types but it conflicts with semantics of existing `IndexOf` implementations like [`String.IndexOf`](https://msdn.microsoft.com/en-us/library/system.string.indexof(v=vs.110).aspx) and [`List<T>.IndexOf`](https://msdn.microsoft.com/en-us/library/e4w08k17(v=vs.110).aspx) that return the index of the _first match only_. Is `Offsets` a better name then?
