### PR TITLE
Append-method as counterpart to the existing prepend-method.

### DIFF
--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void AppendWithEmptyTailSequence()
+        public void AppendWithEmptyHeadSequence()
         {
             string[] head = { };
             var tail = "first";
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void AppendWithNullTailSequence()
+        public void AppendWithNullHeadSequence()
         {
             Assert.ThrowsArgumentNullException("source", () =>
                 MoreEnumerable.Append(null, "tail"));

--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -1,0 +1,65 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Tim Rehm (Timmitry). All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class AppendTest
+    {
+        [Test]
+        public void AppendWithNonEmptyHeadSequence()
+        {
+            string[] head = { "first", "second" };
+            var tail = "third";
+            var whole = head.Append(tail);
+            whole.AssertSequenceEqual("first", "second", "third");
+        }
+
+        [Test]
+        public void AppendWithEmptyTailSequence()
+        {
+            string[] head = { };
+            var tail = "first";
+            var whole = head.Append(tail);
+            whole.AssertSequenceEqual("first");
+        }
+
+        [Test]
+        public void AppendWithNullTailSequence()
+        {
+            Assert.ThrowsArgumentNullException("source", () =>
+                MoreEnumerable.Append(null, "tail"));
+        }
+
+        [Test]
+        public void AppendWithNullTail()
+        {
+            string[] head = { "first", "second" };
+            string tail = null;
+            var whole = head.Append(tail);
+            whole.AssertSequenceEqual("first", "second", null);
+        }
+
+        [Test]
+        public void AppendIsLazyInHeadSequence()
+        {
+            new BreakingSequence<string>().Append("tail");
+        }
+    }
+}

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -1,0 +1,51 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Tim Rehm (Timmitry). All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using LinqEnumerable = System.Linq.Enumerable;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Appends a single value to a sequence.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The sequence to append to.</param>
+        /// <param name="value">The value to append.</param>
+        /// <returns>
+        /// Returns a sequence where a value is appended to it.
+        /// </returns>
+        /// <remarks>
+        /// This operator uses deferred execution and streams its results.
+        /// </remarks>
+        /// <code>
+        /// int[] numbers = { 1, 2, 3 };
+        /// IEnumerable&lt;int&gt; result = numbers.Append(4);
+        /// </code>
+        /// The <c>result</c> variable, when iterated over, will yield 
+        /// 1, 2, 3 and 4, in turn.
+
+        public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource value)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return LinqEnumerable.Concat(source, LinqEnumerable.Repeat(value, 1));
+        }
+    }
+}


### PR DESCRIPTION
I was wondering why there isn't an append-method while the prepend-method is supplied. I created the append-method by mostly copying and pasting the prepend method, including unit tests.