### PR TITLE
Fold: throw InvalidOperationException instead & document exceptions

### DIFF
--- a/MoreLinq.Test/FoldTest.cs
+++ b/MoreLinq.Test/FoldTest.cs
@@ -83,21 +83,21 @@ namespace MoreLinq.Test
         [Test]
         public void FoldWithTooFewItems()
         {
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
                 Enumerable.Range(1, 3).Fold((a, b, c, d) => a + b + c + d));
         }
 
         [Test]
         public void FoldWithEmptySequence()
         {
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
                 Enumerable.Empty<int>().Fold(a => a));
         }
 
         [Test]
         public void FoldWithTooManyItems()
         {
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
                 Enumerable.Range(1, 3).Fold((a, b) => a + b));
         }
 

--- a/MoreLinq.Test/MoreLinq.Test.xproj
+++ b/MoreLinq.Test/MoreLinq.Test.xproj
@@ -15,5 +15,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -58,7 +58,7 @@ namespace MoreLinq
             var message = cmp < 0
                         ? "Sequence contains too few elements when exactly {0} {1} expected."
                         : "Sequence contains too many elements when exactly {0} {1} expected.";
-            return new Exception(string.Format(message, count.ToString("N0"), count == 1 ? "was" : "were"));
+            return new InvalidOperationException(string.Format(message, count.ToString("N0"), count == 1 ? "was" : "were"));
         }
     }
 }

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -35,6 +35,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
         {
@@ -54,6 +57,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
         {
@@ -73,6 +79,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
         {
@@ -92,6 +101,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
         {

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -57,6 +57,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly <#= e.CountElements #></exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<<#= e.Ts #>, TResult> folder)
         {


### PR DESCRIPTION
Do not throw `Exception`, but rather `InvalidOperationException` instead.

Document exceptions thrown.