### PR TITLE
ToLookup overloads for key-value pairs & tuples of 2 (#274)

### DIFF
--- a/MoreLinq.Test/ToLookupTest.cs
+++ b/MoreLinq.Test/ToLookupTest.cs
@@ -16,7 +16,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace MoreLinq.Test
@@ -24,13 +23,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class ToLookupTest
     {
-        [Test]
-        public void ToLookupWithNullKeyValuePairSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.ToLookup((IEnumerable<KeyValuePair<object, object>>) null));
-        }
-
         [Test]
         public void ToLookupWithKeyValuePairs()
         {

--- a/MoreLinq.Test/ToLookupTest.cs
+++ b/MoreLinq.Test/ToLookupTest.cs
@@ -1,0 +1,118 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class ToLookupTest
+    {
+        [Test]
+        public void ToLookupWithNullKeyValuePairSequence()
+        {
+            Assert.ThrowsArgumentNullException("source", () =>
+                MoreEnumerable.ToLookup((IEnumerable<KeyValuePair<object, object>>) null));
+        }
+
+        [Test]
+        public void ToLookupWithKeyValuePairs()
+        {
+            var pairs = new[]
+            {
+                KeyValuePair.Create("foo", 1),
+                KeyValuePair.Create("bar", 3),
+                KeyValuePair.Create("baz", 4),
+                KeyValuePair.Create("foo", 2),
+                KeyValuePair.Create("baz", 5),
+                KeyValuePair.Create("baz", 6),
+            };
+
+            var dict = pairs.ToLookup();
+
+            Assert.That(dict.Count, Is.EqualTo(3));
+            Assert.That(dict["foo"], Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(dict["bar"], Is.EquivalentTo(new[] { 3 }));
+            Assert.That(dict["baz"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+        }
+
+        [Test]
+        public void ToLookupWithCouples()
+        {
+            var pairs = new[]
+            {
+                ("foo", 1),
+                ("bar", 3),
+                ("baz", 4),
+                ("foo", 2),
+                ("baz", 5),
+                ("baz", 6),
+            };
+
+            var dict = pairs.ToLookup();
+
+            Assert.That(dict.Count, Is.EqualTo(3));
+            Assert.That(dict["foo"], Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(dict["bar"], Is.EquivalentTo(new[] { 3 }));
+            Assert.That(dict["baz"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+        }
+
+        [Test]
+        public void ToLookupWithKeyValuePairsWithComparer()
+        {
+            var pairs = new[]
+            {
+                KeyValuePair.Create("foo", 1),
+                KeyValuePair.Create("bar", 3),
+                KeyValuePair.Create("baz", 4),
+                KeyValuePair.Create("foo", 2),
+                KeyValuePair.Create("baz", 5),
+                KeyValuePair.Create("baz", 6),
+            };
+
+            var dict = pairs.ToLookup(StringComparer.OrdinalIgnoreCase);
+
+            Assert.That(dict.Count, Is.EqualTo(3));
+            Assert.That(dict["FOO"], Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(dict["BAR"], Is.EquivalentTo(new[] { 3 }));
+            Assert.That(dict["BAZ"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+        }
+
+        [Test]
+        public void ToLookupWithCouplesWithComparer()
+        {
+            var pairs = new[]
+            {
+                ("foo", 1),
+                ("bar", 3),
+                ("baz", 4),
+                ("foo", 2),
+                ("baz", 5),
+                ("baz", 6),
+            };
+
+            var dict = pairs.ToLookup(StringComparer.OrdinalIgnoreCase);
+
+            Assert.That(dict.Count, Is.EqualTo(3));
+            Assert.That(dict["FOO"], Is.EquivalentTo(new[] { 1, 2 }));
+            Assert.That(dict["BAR"], Is.EquivalentTo(new[] { 3 }));
+            Assert.That(dict["BAZ"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>This project enhances LINQ to Objects with the following methods: Acquire, AggregateRight, Assert, AssertCount, AtLeast, AtMost, Batch, Cartesian, CountBetween, CountBy, Concat, Consume, DistinctBy, EquiZip, Exactly, ExceptBy, Exclude, FallbackIfEmpty, FillBackward, FillForward, Fold, ForEach, FullGroupJoin, Generate, GenerateByIndex, GroupAdjacent, Incremental, Index, Interleave, Lag, Lead, MaxBy, MinBy, NestedLoops, OrderBy, OrderedMerge, Pad, Pairwise, PartialSort, PartialSortBy, Permutations, Pipe, Prepend, PreScan, Random, RandomDouble, RandomSubset, Rank, RankBy, Repeat, RunLengthEncode, Scan, Segment, Sequence, SingleOrFallback, SkipLast, SkipUntil, Slice, SortedMerge, Split, Subsets, TagFirstLast, TakeEvery, TakeLast, TakeUntil, ThenBy, ToDataTable, ToDelimitedString, ToDictionary, ToHashSet, Trace, TraverseBreadthFirst, TraverseDepthFirst, Unfold, Windowed, ZipLongest, ZipShortest</Description>
+    <Description>This project enhances LINQ to Objects with the following methods: Acquire, AggregateRight, Assert, AssertCount, AtLeast, AtMost, Batch, Cartesian, CountBetween, CountBy, Concat, Consume, DistinctBy, EquiZip, Exactly, ExceptBy, Exclude, FallbackIfEmpty, FillBackward, FillForward, Fold, ForEach, FullGroupJoin, Generate, GenerateByIndex, GroupAdjacent, Incremental, Index, Interleave, Lag, Lead, MaxBy, MinBy, NestedLoops, OrderBy, OrderedMerge, Pad, Pairwise, PartialSort, PartialSortBy, Permutations, Pipe, Prepend, PreScan, Random, RandomDouble, RandomSubset, Rank, RankBy, Repeat, RunLengthEncode, Scan, Segment, Sequence, SingleOrFallback, SkipLast, SkipUntil, Slice, SortedMerge, Split, Subsets, TagFirstLast, TakeEvery, TakeLast, TakeUntil, ThenBy, ToDataTable, ToDelimitedString, ToDictionary, ToHashSet, ToLookup, Trace, TraverseBreadthFirst, TraverseDepthFirst, Unfold, Windowed, ZipLongest, ZipShortest</Description>
     <Copyright>&#169; 2008 Jonathan Skeet. Portions &#169; 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph. Portions &#169; 2010 Johannes Rudolph, Leopold Bushkin. Portions &#169; 2015 Felipe Sateler, “sholland”. Portions &#169; 2016 Leandro F. Vieira (leandromoh). Portions &#169; Microsoft. All rights reserved.</Copyright>
     <AssemblyTitle>MoreLINQ</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -18,7 +18,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>MoreLinq</PackageId>
     <PackageTags>linq;extensions</PackageTags>
-    <PackageReleaseNotes>Adds new operators: ToDictionary (overloads). See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds new operators: ToDictionary (overloads), ToLookup (overloads). See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.</PackageReleaseNotes>
     <PackageProjectUrl>https://morelinq.github.io/</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/MoreLinq/ToLookup.cs
+++ b/MoreLinq/ToLookup.cs
@@ -1,0 +1,96 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Creates a <see cref="Lookup{TKey,TValue}" /> from a sequence of
+        /// <see cref="KeyValuePair{TKey,TValue}" /> elements.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source sequence of key-value pairs.</param>
+        /// <returns>
+        /// A <see cref="Lookup{TKey, TValue}"/> containing the values
+        /// mapped to their keys.
+        /// </returns>
+
+        public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source) =>
+            source.ToLookup(null);
+
+        /// <summary>
+        /// Creates a <see cref="Lookup{TKey,TValue}" /> from a sequence of
+        /// <see cref="KeyValuePair{TKey,TValue}" /> elements. An additional
+        /// parameter specifies a comparer for keys.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source sequence of key-value pairs.</param>
+        /// <param name="comparer">The comparer for keys.</param>
+        /// <returns>
+        /// A <see cref="Lookup{TKey, TValue}"/> containing the values
+        /// mapped to their keys.
+        /// </returns>
+
+        public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
+            IEqualityComparer<TKey> comparer) =>
+            source.ToLookup(e => e.Key, e => e.Value, comparer);
+
+        #if !NO_VALUE_TUPLES
+
+        /// <summary>
+        /// Creates a <see cref="Lookup{TKey,TValue}" /> from a sequence of
+        /// tuples of 2 where the first item is the key and the second the
+        /// value.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source sequence of tuples of 2.</param>
+        /// <returns>
+        /// A <see cref="Lookup{TKey, TValue}"/> containing the values
+        /// mapped to their keys.
+        /// </returns>
+
+        public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source) =>
+            source.ToLookup(null);
+
+        /// <summary>
+        /// Creates a <see cref="Lookup{TKey,TValue}" /> from a sequence of
+        /// tuples of 2 where the first item is the key and the second the
+        /// value. An additional parameter specifies a comparer for keys.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source sequence of tuples of 2.</param>
+        /// <param name="comparer">The comparer for keys.</param>
+        /// <returns>
+        /// A <see cref="Lookup{TKey, TValue}"/> containing the values
+        /// mapped to their keys.
+        /// </returns>
+
+        public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source,
+            IEqualityComparer<TKey> comparer) =>
+            source.ToLookup(e => e.Key, e => e.Value, comparer);
+
+        #endif
+    }
+}

--- a/README.md
+++ b/README.md
@@ -443,6 +443,13 @@ type.
 
 This method has 2 overloads.
 
+### ToLookup
+
+Creates a [lookup][lookup] from a sequence of [key-value pair][kvp] elements
+or tuples of 2.
+
+This method has 4 overloads.
+
 ### TraverseBreadthFirst
 
 Traverses a tree in a breadth-first fashion, starting at a root node and using
@@ -488,3 +495,4 @@ This method has 3 overloads.
 [#122]: https://github.com/morelinq/MoreLINQ/issues/122
 [dict]: https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.Dictionary-2
 [kvp]: https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.KeyValuePair-2
+[lookup]: https://docs.microsoft.com/en-us/dotnet/api/system.linq.lookup-2


### PR DESCRIPTION
PR for #274

- [x] Implementation
- [x] Unit tests
- [x] Update operators list
- [x] Update release notes
- [x] Add quick description to README