### PR TITLE
Refactor private iterator implementations into local functions

### DIFF
--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -65,18 +65,15 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return AssertImpl(source, predicate, errorSelector ?? delegate { return null; });
-        }
-
-        private static IEnumerable<TSource> AssertImpl<TSource>(IEnumerable<TSource> source, 
-            Func<TSource, bool> predicate, Func<TSource, Exception> errorSelector)
-        {
-            foreach (var element in source)
+            return _(); IEnumerable<TSource> _()
             {
-                var success = predicate(element);
-                if (!success)
-                    throw errorSelector(element) ?? new InvalidOperationException("Sequence contains an invalid item.");
-                yield return element;
+                foreach (var element in source)
+                {
+                    var success = predicate(element);
+                    if (!success)
+                        throw errorSelector?.Invoke(element) ?? new InvalidOperationException("Sequence contains an invalid item.");
+                    yield return element;
+                }
             }
         }
     }

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -98,26 +98,23 @@ namespace MoreLinq
                     throw errorSelector(collection.Count.CompareTo(count), count);
                 return source;
             }
-            
-            return ExpectingCountYieldingImpl(source, count, errorSelector);
-        }
 
-        private static IEnumerable<TSource> ExpectingCountYieldingImpl<TSource>(IEnumerable<TSource> source, 
-            int count, Func<int, int, Exception> errorSelector)
-        {
-            var iterations = 0;
-            foreach (var element in source)
+            return _(); IEnumerable<TSource> _()
             {
-                iterations++;
-                if (iterations > count)
+                var iterations = 0;
+                foreach (var element in source)
                 {
-                    throw errorSelector(1, count);
+                    iterations++;
+                    if (iterations > count)
+                    {
+                        throw errorSelector(1, count);
+                    }
+                    yield return element;
                 }
-                yield return element;
-            }
-            if (iterations != count)
-            {
-                throw errorSelector(-1, count);
+                if (iterations != count)
+                {
+                    throw errorSelector(-1, count);
+                }
             }
         }
     }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -58,46 +58,40 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return BatchImpl(source, size, resultSelector);
-        }
 
-        private static IEnumerable<TResult> BatchImpl<TSource, TResult>(this IEnumerable<TSource> source, int size,
-            Func<IEnumerable<TSource>, TResult> resultSelector)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(size > 0);
-            Debug.Assert(resultSelector != null);
-
-            TSource[] bucket = null;
-            var count = 0;
-
-            foreach (var item in source)
+            return _(); IEnumerable<TResult> _()
             {
-                if (bucket == null)
+                TSource[] bucket = null;
+                var count = 0;
+
+                foreach (var item in source)
                 {
-                    bucket = new TSource[size];
+                    if (bucket == null)
+                    {
+                        bucket = new TSource[size];
+                    }
+
+                    bucket[count++] = item;
+
+                    // The bucket is fully buffered before it's yielded
+                    if (count != size)
+                    {
+                        continue;
+                    }
+
+                    // Select is necessary so bucket contents are streamed too
+                    yield return resultSelector(bucket);
+                
+                    bucket = null;
+                    count = 0;
                 }
 
-                bucket[count++] = item;
-
-                // The bucket is fully buffered before it's yielded
-                if (count != size)
+                // Return the last bucket with all remaining elements
+                if (bucket != null && count > 0)
                 {
-                    continue;
+                    Array.Resize(ref bucket, count);
+                    yield return resultSelector(bucket);
                 }
-
-                // Select is necessary so bucket contents are streamed too
-                yield return resultSelector(bucket);
-               
-                bucket = null;
-                count = 0;
-            }
-
-            // Return the last bucket with all remaining elements
-            if (bucket != null && count > 0)
-            {
-                Array.Resize(ref bucket, count);
-                yield return resultSelector(bucket);
             }
         }
     }

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -53,65 +53,59 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return CountByImpl(source, keySelector, comparer);
-        }
-
-        static IEnumerable<KeyValuePair<TKey, int>> CountByImpl<TSource, TKey>(
-            IEnumerable<TSource> source, Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> comparer)
-        {
-            List<TKey> keys;
-            List<int> counts;
-
-            // Avoid the temptation to inline the CountByLoop method, which
-            // exists solely to separate the scope & lifetimes of the locals
-            // needed for the actual looping of the source & production of the
-            // results (that happens once at the start of iteration) from
-            // those needed to simply yield the results. It is harder to reason
-            // about the lifetimes (if the code is inlined) with respect to how
-            // the compiler will rewrite the iterator code as a state machine.
-            // For background, see:
-            // http://blog.stephencleary.com/2010/02/q-should-i-set-variables-to-null-to.html
-
-            CountByLoop(source, keySelector, comparer ?? EqualityComparer<TKey>.Default,
-                        out keys, out counts);
-
-            for (var i = 0; i < keys.Count; i++)
-                yield return new KeyValuePair<TKey, int>(keys[i], counts[i]);
-        }
-
-        static void CountByLoop<TSource, TKey>(IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer,
-            out List<TKey> keys, out List<int> counts)
-        {
-            var dic = new Dictionary<TKey, int>(comparer);
-            keys = new List<TKey>();
-            counts = new List<int>();
-            var havePrevKey = false;
-            var prevKey = default(TKey);
-            var index = 0;
-
-            foreach (var item in source)
+            return _(); IEnumerable<KeyValuePair<TKey, int>> _()
             {
-                var key = keySelector(item);
+                List<TKey> keys;
+                List<int> counts;
 
-                if (// key same as the previous? then re-use the index
-                    (havePrevKey && comparer.GetHashCode(prevKey) == comparer.GetHashCode(key)
-                                  && comparer.Equals(prevKey, key))
-                    // otherwise try & find index of the key
-                    || dic.TryGetValue(key, out index))
-                {
-                    counts[index]++;
-                }
-                else
-                {
-                    dic[key] = keys.Count;
-                    keys.Add(key);
-                    counts.Add(1);
-                }
+                // Avoid the temptation to inline the Loop method, which
+                // exists solely to separate the scope & lifetimes of the
+                // locals needed for the actual looping of the source &
+                // production of the results (that happens once at the start
+                // of iteration) from those needed to simply yield the
+                // results. It is harder to reason about the lifetimes (if the
+                // code is inlined) with respect to how the compiler will
+                // rewrite the iterator code as a state machine. For
+                // background, see:
+                // http://blog.stephencleary.com/2010/02/q-should-i-set-variables-to-null-to.html
 
-                prevKey = key;
-                havePrevKey = true;
+                Loop(comparer ?? EqualityComparer<TKey>.Default);
+
+                for (var i = 0; i < keys.Count; i++)
+                    yield return new KeyValuePair<TKey, int>(keys[i], counts[i]);
+
+                void Loop(IEqualityComparer<TKey> cmp)
+                {
+                    var dic = new Dictionary<TKey, int>(cmp);
+                    keys = new List<TKey>();
+                    counts = new List<int>();
+                    var havePrevKey = false;
+                    var prevKey = default(TKey);
+                    var index = 0;
+
+                    foreach (var item in source)
+                    {
+                        var key = keySelector(item);
+
+                        if (// key same as the previous? then re-use the index
+                            (havePrevKey && cmp.GetHashCode(prevKey) == cmp.GetHashCode(key)
+                                          && cmp.Equals(prevKey, key))
+                            // otherwise try & find index of the key
+                            || dic.TryGetValue(key, out index))
+                        {
+                            counts[index]++;
+                        }
+                        else
+                        {
+                            dic[key] = keys.Count;
+                            keys.Add(key);
+                            counts.Add(1);
+                        }
+
+                        prevKey = key;
+                        havePrevKey = true;
+                    }
+                }
             }
         }
     }

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -67,18 +67,14 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            return DistinctByImpl(source, keySelector, comparer);
-        }
-
-        private static IEnumerable<TSource> DistinctByImpl<TSource, TKey>(IEnumerable<TSource> source,
-            Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-        {
-            var knownKeys = new HashSet<TKey>(comparer);
-            foreach (var element in source)
+            
+            return _(); IEnumerable<TSource> _()
             {
-                if (knownKeys.Add(keySelector(element)))
+                var knownKeys = new HashSet<TKey>(comparer);
+                foreach (var element in source)
                 {
-                    yield return element;
+                    if (knownKeys.Add(keySelector(element)))
+                        yield return element;
                 }
             }
         }

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -78,24 +78,19 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            return ExceptByImpl(first, second, keySelector, keyComparer);
-        }
 
-        private static IEnumerable<TSource> ExceptByImpl<TSource, TKey>(this IEnumerable<TSource> first,
-            IEnumerable<TSource> second,
-            Func<TSource, TKey> keySelector,
-            IEqualityComparer<TKey> keyComparer)
-        {
-            var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);
-            foreach (var element in first)
+            return _(); IEnumerable<TSource>_()
             {
-                var key = keySelector(element);
-                if (keys.Contains(key))
+                // TODO Use ToHashSet
+                var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);
+                foreach (var element in first)
                 {
-                    continue;
+                    var key = keySelector(element);
+                    if (keys.Contains(key))
+                        continue;
+                    yield return element;
+                    keys.Add(key);
                 }
-                yield return element;
-                keys.Add(key);
             }
         }
     }

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -37,24 +37,22 @@ namespace MoreLinq
             if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
 
-            return ExcludeImpl(sequence, startIndex, count);
-        }
-
-        private static IEnumerable<T> ExcludeImpl<T>(IEnumerable<T> sequence, int startIndex, int count)
-        {
-            var index = -1;
-            var endIndex = startIndex + count;
-            using (var iter = sequence.GetEnumerator())
+            return _(); IEnumerable<T> _()
             {
-                // yield the first part of the sequence
-                while (iter.MoveNext() && ++index < startIndex)
-                    yield return iter.Current;
-                // skip the next part (up to count items)
-                while (++index < endIndex && iter.MoveNext())
-                    continue;
-                // yield the remainder of the sequence
-                while (iter.MoveNext())
-                    yield return iter.Current;
+                var index = -1;
+                var endIndex = startIndex + count;
+                using (var iter = sequence.GetEnumerator())
+                {
+                    // yield the first part of the sequence
+                    while (iter.MoveNext() && ++index < startIndex)
+                        yield return iter.Current;
+                    // skip the next part (up to count items)
+                    while (++index < endIndex && iter.MoveNext())
+                        continue;
+                    // yield the remainder of the sequence
+                    while (iter.MoveNext())
+                        yield return iter.Current;
+                }
             }
         }
     }

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -88,30 +88,23 @@ namespace MoreLinq
             if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return FullGroupJoinImpl(first, second, firstKeySelector, secondKeySelector, resultSelector, comparer);
-        }
+            return _(); IEnumerable<TResult> _()
+            {
+                comparer = comparer ?? EqualityComparer<TKey>.Default;
 
-        private static IEnumerable<TResult> FullGroupJoinImpl<TFirst, TSecond, TKey, TResult>(IEnumerable<TFirst> first,
-            IEnumerable<TSecond> second,
-            Func<TFirst, TKey> firstKeySelector,
-            Func<TSecond, TKey> secondKeySelector,
-            Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
-            IEqualityComparer<TKey> comparer)
-        {
-            comparer = comparer ?? EqualityComparer<TKey>.Default;
+                var alookup = Lookup<TKey,TFirst>.CreateForJoin(first, firstKeySelector, comparer);
+                var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);
 
-            var alookup = Lookup<TKey,TFirst>.CreateForJoin(first, firstKeySelector, comparer);
-            var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);
-            
-            foreach (var a in alookup) {
-                yield return resultSelector(a.Key, a, blookup[a.Key]);
-            }
+                foreach (var a in alookup) {
+                    yield return resultSelector(a.Key, a, blookup[a.Key]);
+                }
 
-            foreach (var b in blookup) {
-                if (alookup.Contains(b.Key))
-                    continue;
-                // We can skip the lookup because we are iterating over keys not found in the first sequence
-                yield return resultSelector(b.Key, Enumerable.Empty<TFirst>(), b);
+                foreach (var b in blookup) {
+                    if (alookup.Contains(b.Key))
+                        continue;
+                    // We can skip the lookup because we are iterating over keys not found in the first sequence
+                    yield return resultSelector(b.Key, Enumerable.Empty<TFirst>(), b);
+                }
             }
         }
     }

--- a/MoreLinq/Generate.cs
+++ b/MoreLinq/Generate.cs
@@ -44,16 +44,15 @@ namespace MoreLinq
         public static IEnumerable<TResult> Generate<TResult>(TResult initial, Func<TResult, TResult> generator)
         {
             if (generator == null) throw new ArgumentNullException(nameof(generator));
-            return GenerateImpl(initial, generator);
-        }
 
-        private static IEnumerable<TResult> GenerateImpl<TResult>(TResult initial, Func<TResult, TResult> generator)
-        {
-            var current = initial;
-            while (true)
+            return _(); IEnumerable<TResult> _()
             {
-                yield return current;
-                current = generator(current);
+                var current = initial;
+                while (true)
+                {
+                    yield return current;
+                    current = generator(current);
+                }
             }
         }
     }

--- a/MoreLinq/GenerateByIndex.cs
+++ b/MoreLinq/GenerateByIndex.cs
@@ -39,18 +39,17 @@ namespace MoreLinq
             // Would just use Enumerable.Range(0, int.MaxValue).Select(generator) but that doesn't
             // include int.MaxValue. Picky, I know...
             if (generator == null) throw new ArgumentNullException(nameof(generator));
-            return GenerateByIndexImpl(generator);
-        }
 
-        private static IEnumerable<TResult> GenerateByIndexImpl<TResult>(Func<int, TResult> generator)
-        {
-            // Looping over 0...int.MaxValue inclusive is a pain. Simplest is to go exclusive,
-            // then go again for int.MaxValue.
-            for (var i = 0; i < int.MaxValue; i++)
+            return _(); IEnumerable<TResult> _()
             {
-                yield return generator(i);
+                // Looping over 0...int.MaxValue inclusive is a pain. Simplest is to go exclusive,
+                // then go again for int.MaxValue.
+
+                for (var i = 0; i < int.MaxValue; i++)
+                    yield return generator(i);
+
+                yield return generator(int.MaxValue);
             }
-            yield return generator(int.MaxValue);
         }
     }
 }

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -78,74 +78,74 @@ namespace MoreLinq
             if (otherSequences.Any(s => s == null))
                 throw new ArgumentNullException(nameof(otherSequences), "One or more sequences passed to Interleave was null.");
 
-            return InterleaveImpl(new[] { sequence }.Concat(otherSequences), imbalanceStrategy);
-        }
-
-        private static IEnumerable<T> InterleaveImpl<T>(IEnumerable<IEnumerable<T>> sequences, ImbalancedInterleaveStrategy imbalanceStrategy)
-        {
-            // produce an iterator collection for all IEnumerable<T> instancess passed to us
-            var iterators = sequences.Select(e => e.GetEnumerator()).Acquire();
-            List<IEnumerator<T>> iteratorList = null;
-
-            try
+            return _(); IEnumerable<T> _()
             {
-                iteratorList = new List<IEnumerator<T>>(iterators);
-                iterators = null;
-                var shouldContinue = true;
-                var consumedIterators = 0;
-                var iterCount = iteratorList.Count;
+                var sequences = new[] { sequence }.Concat(otherSequences);
 
-                while (shouldContinue)
+                // produce an iterator collection for all IEnumerable<T> instancess passed to us
+                var iterators = sequences.Select(e => e.GetEnumerator()).Acquire();
+                List<IEnumerator<T>> iteratorList = null;
+
+                try
                 {
-                    // advance every iterator and verify a value exists to be yielded
-                    for (var index = 0; index < iterCount; index++)
+                    iteratorList = new List<IEnumerator<T>>(iterators);
+                    iterators = null;
+                    var shouldContinue = true;
+                    var consumedIterators = 0;
+                    var iterCount = iteratorList.Count;
+
+                    while (shouldContinue)
                     {
-                        if (!iteratorList[index].MoveNext())
-                        {
-                            // check if all iterators have been consumed and we can terminate
-                            // or if the imbalance strategy informs us that we MUST terminate
-                            if (++consumedIterators == iterCount || imbalanceStrategy == ImbalancedInterleaveStrategy.Stop)
-                            {
-                                shouldContinue = false;
-                                break;
-                            }
-
-                            iteratorList[index].Dispose(); // dispose the iterator sice we no longer need it
-
-                            // otherwise, apply the imbalance strategy
-                            switch (imbalanceStrategy)
-                            {
-                                case ImbalancedInterleaveStrategy.Pad:
-                                    var newIter = iteratorList[index] = Generate(default(T), x => default(T)).GetEnumerator();
-                                    newIter.MoveNext();
-                                    break;
-
-                                case ImbalancedInterleaveStrategy.Skip:
-                                    iteratorList.RemoveAt(index); // no longer visit this particular iterator
-                                    --iterCount; // reduce the expected number of iterators to visit
-                                    --index; // decrement iterator index to compensate for index shifting
-                                    --consumedIterators; // decrement consumer iterator count to stay in balance
-                                    break;
-                            }
-
-                        }
-                    }
-
-                    if (shouldContinue) // only if all iterators could be advanced
-                    {
-                        // yield the values of each iterator's current position
+                        // advance every iterator and verify a value exists to be yielded
                         for (var index = 0; index < iterCount; index++)
                         {
-                            yield return iteratorList[index].Current;
+                            if (!iteratorList[index].MoveNext())
+                            {
+                                // check if all iterators have been consumed and we can terminate
+                                // or if the imbalance strategy informs us that we MUST terminate
+                                if (++consumedIterators == iterCount || imbalanceStrategy == ImbalancedInterleaveStrategy.Stop)
+                                {
+                                    shouldContinue = false;
+                                    break;
+                                }
+
+                                iteratorList[index].Dispose(); // dispose the iterator sice we no longer need it
+
+                                // otherwise, apply the imbalance strategy
+                                switch (imbalanceStrategy)
+                                {
+                                    case ImbalancedInterleaveStrategy.Pad:
+                                        var newIter = iteratorList[index] = Generate(default(T), x => default(T)).GetEnumerator();
+                                        newIter.MoveNext();
+                                        break;
+
+                                    case ImbalancedInterleaveStrategy.Skip:
+                                        iteratorList.RemoveAt(index); // no longer visit this particular iterator
+                                        --iterCount; // reduce the expected number of iterators to visit
+                                        --index; // decrement iterator index to compensate for index shifting
+                                        --consumedIterators; // decrement consumer iterator count to stay in balance
+                                        break;
+                                }
+
+                            }
+                        }
+
+                        if (shouldContinue) // only if all iterators could be advanced
+                        {
+                            // yield the values of each iterator's current position
+                            for (var index = 0; index < iterCount; index++)
+                            {
+                                yield return iteratorList[index].Current;
+                            }
                         }
                     }
                 }
-            }
-            finally
-            {
-                Debug.Assert(iteratorList != null || iterators != null);
-                foreach (var iter in (iteratorList ?? (IList<IEnumerator<T>>) iterators))
-                    iter.Dispose();
+                finally
+                {
+                    Debug.Assert(iteratorList != null || iterators != null);
+                    foreach (var iter in (iteratorList ?? (IList<IEnumerator<T>>) iterators))
+                        iter.Dispose();
+                }
             }
         }
 

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -62,31 +62,27 @@ namespace MoreLinq
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
             if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            return LeadImpl(source, offset, defaultLeadValue, resultSelector);
-        }
-
-        private static IEnumerable<TResult> LeadImpl<TSource, TResult>(IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
-        {
-            var leadQueue = new Queue<TSource>();
-            using (var iter = source.GetEnumerator())
+            return _(); IEnumerable<TResult> _()
             {
-                bool hasMore;
-                // first, prefetch and populate the lead queue with the next step of
-                // items to be streamed out to the consumer of the sequence
-                while ((hasMore = iter.MoveNext()) && leadQueue.Count < offset)
-                    leadQueue.Enqueue(iter.Current);
-                // next, while the source sequence has items, yield the result of
-                // the projection function applied to the top of queue and current item
-                while (hasMore)
+                var leadQueue = new Queue<TSource>();
+                using (var iter = source.GetEnumerator())
                 {
-                    yield return resultSelector(leadQueue.Dequeue(), iter.Current);
-                    leadQueue.Enqueue(iter.Current);
-                    hasMore = iter.MoveNext();
-                }
-                // yield the remaining values in the lead queue with the default lead value
-                while (leadQueue.Count > 0)
-                {
-                    yield return resultSelector(leadQueue.Dequeue(), defaultLeadValue);
+                    bool hasMore;
+                    // first, prefetch and populate the lead queue with the next step of
+                    // items to be streamed out to the consumer of the sequence
+                    while ((hasMore = iter.MoveNext()) && leadQueue.Count < offset)
+                        leadQueue.Enqueue(iter.Current);
+                    // next, while the source sequence has items, yield the result of
+                    // the projection function applied to the top of queue and current item
+                    while (hasMore)
+                    {
+                        yield return resultSelector(leadQueue.Dequeue(), iter.Current);
+                        leadQueue.Enqueue(iter.Current);
+                        hasMore = iter.MoveNext();
+                    }
+                    // yield the remaining values in the lead queue with the default lead value
+                    while (leadQueue.Count > 0)
+                        yield return resultSelector(leadQueue.Dequeue(), defaultLeadValue);
                 }
             }
         }

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
 
     static partial class MoreEnumerable
     {
@@ -53,24 +52,20 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return PairwiseImpl(source, resultSelector);
-        }
 
-        private static IEnumerable<TResult> PairwiseImpl<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TSource, TResult> resultSelector)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(resultSelector != null);
-
-            using (var e = source.GetEnumerator())
+            return _(); IEnumerable<TResult> _()
             {
-                if (!e.MoveNext())
-                    yield break;
-
-                var previous = e.Current;
-                while (e.MoveNext())
+                using (var e = source.GetEnumerator())
                 {
-                    yield return resultSelector(previous, e.Current);
-                    previous = e.Current;
+                    if (!e.MoveNext())
+                        yield break;
+
+                    var previous = e.Current;
+                    while (e.MoveNext())
+                    {
+                        yield return resultSelector(previous, e.Current);
+                        previous = e.Current;
+                    }
                 }
             }
         }

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -210,15 +210,13 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 
-            return PermutationsImpl(sequence);
-        }
-
-        private static IEnumerable<IList<T>> PermutationsImpl<T>(IEnumerable<T> sequence)
-        {
-            using (var iter = new PermutationEnumerator<T>(sequence))
+            return _(); IEnumerable<IList<T>> _()
             {
-                while (iter.MoveNext())
-                    yield return iter.Current;
+                using (var iter = new PermutationEnumerator<T>(sequence))
+                {
+                    while (iter.MoveNext())
+                        yield return iter.Current;
+                }
             }
         }
     }

--- a/MoreLinq/Pipe.cs
+++ b/MoreLinq/Pipe.cs
@@ -42,15 +42,14 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (action == null) throw new ArgumentNullException(nameof(action));
-            return PipeImpl(source, action);
-        }
 
-        private static IEnumerable<T> PipeImpl<T>(this IEnumerable<T> source, Action<T> action)
-        {
-            foreach (var element in source)
+            return _(); IEnumerable<T> _()
             {
-                action(element);
-                yield return element;
+                foreach (var element in source)
+                {
+                    action(element);
+                    yield return element;
+                }
             }
         }
     }

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -51,26 +51,25 @@ namespace MoreLinq
         /// <param name="transformation">Transformation operation</param>
         /// <param name="identity">Identity element (see remarks)</param>
         /// <returns>The scanned sequence</returns>
-        
+
         public static IEnumerable<TSource> PreScan<TSource>(this IEnumerable<TSource> source,
             Func<TSource, TSource, TSource> transformation, TSource identity)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (transformation == null) throw new ArgumentNullException(nameof(transformation));
-            return PreScanImpl(source, transformation, identity);
-        }
 
-        private static IEnumerable<T> PreScanImpl<T>(IEnumerable<T> source, Func<T, T, T> f, T id)
-        {
-            // special case, the first element is set to the identity
-            var aggregator = id;
-
-            foreach (var i in source)
+            return _(); IEnumerable<TSource> _()
             {
-                yield return aggregator;
+                // special case, the first element is set to the identity
+                var aggregator = identity;
 
-                // aggregate the next element in the sequence
-                aggregator = f(aggregator, i);
+                foreach (var i in source)
+                {
+                    yield return aggregator;
+
+                    // aggregate the next element in the sequence
+                    aggregator = transformation(aggregator, i);
+                }
             }
         }
     }

--- a/MoreLinq/RandomSubset.cs
+++ b/MoreLinq/RandomSubset.cs
@@ -51,39 +51,37 @@ namespace MoreLinq
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
             if (subsetSize < 0) throw new ArgumentOutOfRangeException(nameof(subsetSize));
 
-            return RandomSubsetImpl(sequence, subsetSize, rand);
-        }
-        
-        private static IEnumerable<T> RandomSubsetImpl<T>(IEnumerable<T> sequence, int subsetSize, Random rand)
-        {
-            // The simplest and most efficient way to return a random subet is to perform 
-            // an in-place, partial Fisher-Yates shuffle of the sequence. While we could do 
-            // a full shuffle, it would be wasteful in the cases where subsetSize is shorter
-            // than the length of the sequence.
-            // See: http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
-
-            var seqArray = sequence.ToArray();
-            if (seqArray.Length < subsetSize)
-                throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be <= sequence.Count()");
-
-            var m = 0;                // keeps track of count items shuffled
-            var w = seqArray.Length;  // upper bound of shrinking swap range
-            var g = w - 1;            // used to compute the second swap index
-
-            // perform in-place, partial Fisher-Yates shuffle
-            while (m < subsetSize)
+            return _(); IEnumerable<T> _()
             {
-                var k = g - rand.Next(w);
-                var tmp = seqArray[k];
-                seqArray[k] = seqArray[m];
-                seqArray[m] = tmp;
-                ++m;
-                --w;
-            }
+                // The simplest and most efficient way to return a random subet is to perform
+                // an in-place, partial Fisher-Yates shuffle of the sequence. While we could do
+                // a full shuffle, it would be wasteful in the cases where subsetSize is shorter
+                // than the length of the sequence.
+                // See: http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
 
-            // yield the random subet as a new sequence
-            for (var i = 0; i < subsetSize; i++)
-                yield return seqArray[i];
+                var seqArray = sequence.ToArray();
+                if (seqArray.Length < subsetSize)
+                    throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be <= sequence.Count()");
+
+                var m = 0;                // keeps track of count items shuffled
+                var w = seqArray.Length;  // upper bound of shrinking swap range
+                var g = w - 1;            // used to compute the second swap index
+
+                // perform in-place, partial Fisher-Yates shuffle
+                while (m < subsetSize)
+                {
+                    var k = g - rand.Next(w);
+                    var tmp = seqArray[k];
+                    seqArray[k] = seqArray[m];
+                    seqArray[m] = tmp;
+                    ++m;
+                    --w;
+                }
+
+                // yield the random subet as a new sequence
+                for (var i = 0; i < subsetSize; i++)
+                    yield return seqArray[i];
+            }
         }
     }
 }

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -77,28 +77,27 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return RankByImpl(source, keySelector, comparer ?? Comparer<TKey>.Default);
-        }
-        
-        private static IEnumerable<int> RankByImpl<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
-        {
-            source = source.ToArray(); // avoid enumerating source twice
+            comparer = comparer ?? Comparer<TKey>.Default;
+            return _(); IEnumerable<int> _()
+            {
+                source = source.ToArray(); // avoid enumerating source twice
 
-            var rankDictionary = source.Distinct()
-                                       .OrderByDescending(keySelector, comparer)
-                                       .Index(1)
-                                       .ToDictionary(item => item.Value, 
-                                                     item => item.Key);
+                var rankDictionary = source.Distinct()
+                                           .OrderByDescending(keySelector, comparer)
+                                           .Index(1)
+                                           .ToDictionary(item => item.Value,
+                                                         item => item.Key);
 
-            // The following loop should not be be converted to a query to
-            // keep this RankBy lazy.
+                // The following loop should not be be converted to a query to
+                // keep this RankBy lazy.
 
-            // ReSharper disable LoopCanBeConvertedToQuery
-            
-            foreach (var item in source)
-                yield return rankDictionary[item];
+                // ReSharper disable LoopCanBeConvertedToQuery
 
-            // ReSharper restore LoopCanBeConvertedToQuery
+                foreach (var item in source)
+                    yield return rankDictionary[item];
+
+                // ReSharper restore LoopCanBeConvertedToQuery
+            }
         }
     }
 }

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -50,37 +50,36 @@ namespace MoreLinq
             if (sequence == null)
                 throw new ArgumentNullException(nameof(sequence));
 
-            return RunLengthEncodeImpl(sequence, comparer ?? EqualityComparer<T>.Default);
-        }
-        
-        private static IEnumerable<KeyValuePair<T, int>> RunLengthEncodeImpl<T>(IEnumerable<T> sequence, IEqualityComparer<T> comparer)
-        {
-            // This implementation could also have been written using a foreach loop, 
-            // but it proved to be easier to deal with edge certain cases that occur
-            // (such as empty sequences) using an explicit iterator and a while loop.
-
-            using (var iter = sequence.GetEnumerator())
+            comparer = comparer ?? EqualityComparer<T>.Default;
+            return _(); IEnumerable<KeyValuePair<T, int>> _()
             {
-                if (iter.MoveNext())
+                // This implementation could also have been written using a foreach loop, 
+                // but it proved to be easier to deal with edge certain cases that occur
+                // (such as empty sequences) using an explicit iterator and a while loop.
+
+                using (var iter = sequence.GetEnumerator())
                 {
-                    var prevItem = iter.Current;
-                    var runCount = 1;
-
-                    while (iter.MoveNext())
+                    if (iter.MoveNext())
                     {
-                        if (comparer.Equals(prevItem, iter.Current))
-                        {
-                            ++runCount;
-                        }
-                        else
-                        {
-                            yield return new KeyValuePair<T, int>(prevItem, runCount);
-                            prevItem = iter.Current;
-                            runCount = 1;
-                        }
-                    }
+                        var prevItem = iter.Current;
+                        var runCount = 1;
 
-                    yield return new KeyValuePair<T, int>(prevItem, runCount);
+                        while (iter.MoveNext())
+                        {
+                            if (comparer.Equals(prevItem, iter.Current))
+                            {
+                                ++runCount;
+                            }
+                            else
+                            {
+                                yield return new KeyValuePair<T, int>(prevItem, runCount);
+                                prevItem = iter.Current;
+                                runCount = 1;
+                            }
+                        }
+
+                        yield return new KeyValuePair<T, int>(prevItem, runCount);
+                    }
                 }
             }
         }

--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -56,24 +56,22 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (transformation == null) throw new ArgumentNullException(nameof(transformation));
-            return ScanImpl(source, transformation);
-        }
-
-        private static IEnumerable<T> ScanImpl<T>(IEnumerable<T> source, Func<T, T, T> f)
-        {
-            using (var i = source.GetEnumerator())
+            return _(); IEnumerable<TSource> _()
             {
-                if (!i.MoveNext())
-                    yield break;
-
-                var aggregator = i.Current;
-
-                while (i.MoveNext())
+                using (var i = source.GetEnumerator())
                 {
+                    if (!i.MoveNext())
+                        yield break;
+
+                    var aggregator = i.Current;
+
+                    while (i.MoveNext())
+                    {
+                        yield return aggregator;
+                        aggregator = transformation(aggregator, i.Current);
+                    }
                     yield return aggregator;
-                    aggregator = f(aggregator, i.Current);
                 }
-                yield return aggregator;
             }
         }
 
@@ -103,21 +101,20 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (transformation == null) throw new ArgumentNullException(nameof(transformation));
-            return ScanImpl(source, seed, transformation);
-        }
 
-        private static IEnumerable<TState> ScanImpl<T, TState>(IEnumerable<T> source, TState seed, Func<TState, T, TState> f)
-        {
-            using (var i = source.GetEnumerator())
+            return _(); IEnumerable<TState> _()
             {
-                var aggregator = seed;
-
-                while (i.MoveNext())
+                using (var i = source.GetEnumerator())
                 {
+                    var aggregator = seed;
+
+                    while (i.MoveNext())
+                    {
+                        yield return aggregator;
+                        aggregator = transformation(aggregator, i.Current);
+                    }
                     yield return aggregator;
-                    aggregator = f(aggregator, i.Current);
                 }
-                yield return aggregator;
             }
         }
     }

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -74,49 +74,47 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (newSegmentPredicate == null) throw new ArgumentNullException(nameof(newSegmentPredicate));
 
-            return SegmentImpl(source, newSegmentPredicate);
-        }
-                
-        private static IEnumerable<IEnumerable<T>> SegmentImpl<T>(IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
-        {
-            var index = -1;
-            using (var iter = source.GetEnumerator())
+            return _(); IEnumerable<IEnumerable<T>> _()
             {
-                var segment = new List<T>();
-                var prevItem = default(T);
-
-                // ensure that the first item is always part
-                // of the first segment. This is an intentional
-                // behavior. Segmentation always begins with
-                // the second element in the sequence.
-                if (iter.MoveNext())
+                var index = -1;
+                using (var iter = source.GetEnumerator())
                 {
-                    ++index;
-                    segment.Add(iter.Current);
-                    prevItem = iter.Current;
-                }
+                    var segment = new List<T>();
+                    var prevItem = default(T);
 
-                while (iter.MoveNext())
-                {
-                    ++index;
-                    // check if the item represents the start of a new segment
-                    var isNewSegment = newSegmentPredicate(iter.Current, prevItem, index);
-                    prevItem = iter.Current;
-
-                    if (!isNewSegment)
+                    // ensure that the first item is always part
+                    // of the first segment. This is an intentional
+                    // behavior. Segmentation always begins with
+                    // the second element in the sequence.
+                    if (iter.MoveNext())
                     {
-                        // if not a new segment, append and continue
+                        ++index;
                         segment.Add(iter.Current);
-                        continue;
+                        prevItem = iter.Current;
                     }
-                    yield return segment; // yield the completed segment
 
-                    // start a new segment...
-                    segment = new List<T> { iter.Current };
+                    while (iter.MoveNext())
+                    {
+                        ++index;
+                        // check if the item represents the start of a new segment
+                        var isNewSegment = newSegmentPredicate(iter.Current, prevItem, index);
+                        prevItem = iter.Current;
+
+                        if (!isNewSegment)
+                        {
+                            // if not a new segment, append and continue
+                            segment.Add(iter.Current);
+                            continue;
+                        }
+                        yield return segment; // yield the completed segment
+
+                        // start a new segment...
+                        segment = new List<T> { iter.Current };
+                    }
+                    // handle the case of the sequence ending before new segment is detected
+                    if (segment.Count > 0)
+                        yield return segment;
                 }
-                // handle the case of the sequence ending before new segment is detected
-                if (segment.Count > 0)
-                    yield return segment;
             }
         }
     }

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -1,13 +1,13 @@
-﻿#region License and Terms
+#region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
 // Copyright (c) 2017 Leandro F. Vieira (leandromoh). All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +32,7 @@ namespace MoreLinq
         /// <returns>
         /// An <see cref="IEnumerable{T}"/> containing the source sequence elements except for the bypassed ones at the end.
         /// </returns>
-		
+
         public static IEnumerable<T> SkipLast<T>(this IEnumerable<T> source, int count)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -40,28 +40,25 @@ namespace MoreLinq
             if (count < 1)
                 return source;
 
-            var col = source as ICollection<T>;
-            if (col != null)
-                return col.Take(col.Count - count);
-
-            return SkipLastImpl(source, count);
-        }
-
-        private static IEnumerable<T> SkipLastImpl<T>(IEnumerable<T> source, int count)
-        {
-            var queue = new Queue<T>(count);
-
-            foreach (var item in source)
-            {
-                if (queue.Count < count)
+            return
+                source is ICollection<T> col
+                ? col.Take(col.Count - count)
+                : _(); IEnumerable<T> _()
                 {
-                    queue.Enqueue(item);
-                    continue;
-                }
+                    var queue = new Queue<T>(count);
 
-                yield return queue.Dequeue();
-                queue.Enqueue(item);
-            }
+                    foreach (var item in source)
+                    {
+                        if (queue.Count < count)
+                        {
+                            queue.Enqueue(item);
+                            continue;
+                        }
+
+                        yield return queue.Dequeue();
+                        queue.Enqueue(item);
+                    }
+                }
         }
     }
 }

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -56,23 +56,18 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            return SkipUntilImpl(source, predicate);
-        }
 
-        private static IEnumerable<TSource> SkipUntilImpl<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-        {
-            using (var iterator = source.GetEnumerator())
+            return _(); IEnumerable<TSource> _()
             {
-                while (iterator.MoveNext())
+                using (var iterator = source.GetEnumerator())
                 {
-                    if (predicate(iterator.Current))
+                    while (iterator.MoveNext())
                     {
-                        break;
+                        if (predicate(iterator.Current))
+                            break;
                     }
-                }
-                while (iterator.MoveNext())
-                {
-                    yield return iterator.Current;
+                    while (iterator.MoveNext())
+                        yield return iterator.Current;
                 }
             }
         }

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -38,7 +38,7 @@ namespace MoreLinq
         /// <param name="startIndex">The zero-based index at which to begin slicing</param>
         /// <param name="count">The number of items to slice out of the index</param>
         /// <returns>A new sequence containing any elements sliced out from the source sequence</returns>
-        
+
         public static IEnumerable<T> Slice<T>(this IEnumerable<T> sequence, int startIndex, int count)
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
@@ -46,23 +46,15 @@ namespace MoreLinq
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
 
             // optimization for anything implementing IList<T>
-            var asList = sequence as IList<T>;
-            return asList != null
-                ? SliceImpl(asList, startIndex, count)
-                : SliceImpl(sequence, startIndex, count);
-        }
-
-        private static IEnumerable<T> SliceImpl<T>(IEnumerable<T> sequence, int startIndex, int count)
-        {
-            return sequence.Skip(startIndex).Take(count);
-        }
-
-        private static IEnumerable<T> SliceImpl<T>(IList<T> list, int startIndex, int count)
-        {
-            var listCount = list.Count;
-            var index = startIndex;
-            while (index < listCount && count-- > 0)
-                yield return list[index++];
+            return !(sequence is IList<T> list)
+                 ? sequence.Skip(startIndex).Take(count)
+                 : _(count); IEnumerable<T> _(int countdown)
+                 {
+                     var listCount = list.Count;
+                     var index = startIndex;
+                     while (index < listCount && countdown-- > 0)
+                         yield return list[index++];
+                 }
         }
     }
 }

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -83,61 +83,58 @@ namespace MoreLinq
                     : (a, b) => comparer.Compare(b, a) > 0;
 
             // return the sorted merge result
-            return SortedMergeImpl(precedenceFunc, new[] { source }.Concat(otherSequences));
-        }
+            return Impl(new[] { source }.Concat(otherSequences));
 
-        /// <summary>
-        /// Private implementation method that performs a merge of multiple, ordered sequences using
-        /// a precedence function which encodes order-sensitive comparison logic based on the caller's arguments.
-        /// </summary>
-        /// <remarks>
-        /// The algorithm employed in this implementation is not necessarily the most optimal way to merge
-        /// two sequences. A swap-compare version would probably be somewhat more efficient - but at the
-        /// expense of considerably more complexity. One possible optimization would be to detect that only
-        /// a single sequence remains (all other being consumed) and break out of the main while-loop and
-        /// simply yield the items that are part of the final sequence.
-        /// 
-        /// The algorithm used here will perform N*(K1+K2+...Kn-1) comparisons, where <c>N => otherSequences.Count()+1.</c>
-        /// </remarks>
+            // Private implementation method that performs a merge of multiple, ordered sequences using
+            // a precedence function which encodes order-sensitive comparison logic based on the caller's arguments.
+            //
+            // The algorithm employed in this implementation is not necessarily the most optimal way to merge
+            // two sequences. A swap-compare version would probably be somewhat more efficient - but at the
+            // expense of considerably more complexity. One possible optimization would be to detect that only
+            // a single sequence remains (all other being consumed) and break out of the main while-loop and
+            // simply yield the items that are part of the final sequence.
+            //
+            // The algorithm used here will perform N*(K1+K2+...Kn-1) comparisons, where <c>N => otherSequences.Count()+1.</c>
         
-        private static IEnumerable<T> SortedMergeImpl<T>(Func<T, T, bool> precedenceFunc, IEnumerable<IEnumerable<T>> otherSequences)
-        {
-            using (var disposables = new DisposableGroup<T>(otherSequences.Select(e => e.GetEnumerator()).Acquire()))
+            IEnumerable<TSource> Impl(IEnumerable<IEnumerable<TSource>> sequences)
             {
-                var iterators = disposables.Iterators;
-
-                // prime all of the iterators by advancing them to their first element (if any)
-                // NOTE: We start with the last index to simplify the removal of an iterator if
-                //       it happens to be terminal (no items) before we start merging
-                for (var i = iterators.Count - 1; i >= 0; i--)
+                using (var disposables = new DisposableGroup<TSource>(sequences.Select(e => e.GetEnumerator()).Acquire()))
                 {
-                    if (!iterators[i].MoveNext())
-                        disposables.Exclude(i);
-                }
+                    var iterators = disposables.Iterators;
 
-                // while all iterators have not yet been consumed...
-                while (iterators.Count > 0)
-                {
-                    var nextIndex = 0;
-                    var nextValue = disposables[0].Current;
-
-                    // find the next least element to return
-                    for (var i = 1; i < iterators.Count; i++)
+                    // prime all of the iterators by advancing them to their first element (if any)
+                    // NOTE: We start with the last index to simplify the removal of an iterator if
+                    //       it happens to be terminal (no items) before we start merging
+                    for (var i = iterators.Count - 1; i >= 0; i--)
                     {
-                        var anotherElement = disposables[i].Current;
-                        // determine which element follows based on ordering function
-                        if (precedenceFunc(nextValue, anotherElement))
-                        {
-                            nextIndex = i;
-                            nextValue = anotherElement;
-                        }
+                        if (!iterators[i].MoveNext())
+                            disposables.Exclude(i);
                     }
 
-                    yield return nextValue; // next value in precedence order
+                    // while all iterators have not yet been consumed...
+                    while (iterators.Count > 0)
+                    {
+                        var nextIndex = 0;
+                        var nextValue = disposables[0].Current;
 
-                    // advance iterator that yielded element, excluding it when consumed
-                    if (!iterators[nextIndex].MoveNext())
-                        disposables.Exclude(nextIndex);
+                        // find the next least element to return
+                        for (var i = 1; i < iterators.Count; i++)
+                        {
+                            var anotherElement = disposables[i].Current;
+                            // determine which element follows based on ordering function
+                            if (precedenceFunc(nextValue, anotherElement))
+                            {
+                                nextIndex = i;
+                                nextValue = anotherElement;
+                            }
+                        }
+
+                        yield return nextValue; // next value in precedence order
+
+                        // advance iterator that yielded element, excluding it when consumed
+                        if (!iterators[nextIndex].MoveNext())
+                            disposables.Exclude(nextIndex);
+                    }
                 }
             }
         }

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -277,45 +277,37 @@ namespace MoreLinq
             if (separatorFunc == null) throw new ArgumentNullException(nameof(separatorFunc));
             if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return SplitImpl(source, separatorFunc, count, resultSelector);
-        }
 
-        private static IEnumerable<TResult> SplitImpl<TSource, TResult>(IEnumerable<TSource> source,
-            Func<TSource, bool> separatorFunc, int count,
-            Func<IEnumerable<TSource>, TResult> resultSelector)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(separatorFunc != null);
-            Debug.Assert(count >= 0);
-            Debug.Assert(resultSelector != null);
-
-            if (count == 0) // No splits?
+            return _(); IEnumerable<TResult> _()
             {
-                yield return resultSelector(source);
-            }
-            else
-            {
-                List<TSource> items = null;
-
-                foreach (var item in source)
+                if (count == 0) // No splits?
                 {
-                    if (count > 0 && separatorFunc(item))
-                    {
-                        yield return resultSelector(items ?? Enumerable.Empty<TSource>());
-                        count--;
-                        items = null;
-                    }
-                    else
-                    {
-                        if (items == null)
-                            items = new List<TSource>();
-
-                        items.Add(item);
-                    }
+                    yield return resultSelector(source);
                 }
+                else
+                {
+                    List<TSource> items = null;
 
-                if (items != null && items.Count > 0)
-                    yield return resultSelector(items);
+                    foreach (var item in source)
+                    {
+                        if (count > 0 && separatorFunc(item))
+                        {
+                            yield return resultSelector(items ?? Enumerable.Empty<TSource>());
+                            count--;
+                            items = null;
+                        }
+                        else
+                        {
+                            if (items == null)
+                                items = new List<TSource>();
+
+                            items.Add(item);
+                        }
+                    }
+
+                    if (items != null && items.Count > 0)
+                        yield return resultSelector(items);
+                }
             }
         }
     }

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -182,18 +182,8 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return SplitImpl(source, separator, comparer ?? EqualityComparer<TSource>.Default, count, resultSelector);
-        }
 
-        private static IEnumerable<TResult> SplitImpl<TSource, TResult>(IEnumerable<TSource> source,
-            TSource separator, IEqualityComparer<TSource> comparer, int count,
-            Func<IEnumerable<TSource>, TResult> resultSelector)
-        {
-            Debug.Assert(source != null);
-            Debug.Assert(comparer != null);
-            Debug.Assert(count >= 0);
-            Debug.Assert(resultSelector != null);
-
+            comparer = comparer ?? EqualityComparer<TSource>.Default;
             return Split(source, item => comparer.Equals(item, separator), count, resultSelector);
         }
 

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -43,9 +43,31 @@ namespace MoreLinq
         
         public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence)
         {
-            if (sequence == null)
-                throw new ArgumentNullException(nameof(sequence));
-            return SubsetsImpl(sequence);
+            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+
+            return _(); IEnumerable<IList<T>> _()
+            {
+                var sequenceAsList = sequence.ToList();
+                var sequenceLength = sequenceAsList.Count;
+
+                // the first subset is the empty set
+                yield return new List<T>();
+
+                // all other subsets are computed using the subset generator
+                // this check also resolves the case of permuting empty sets
+                if (sequenceLength > 0)
+                {
+                    for (var i = 1; i < sequenceLength; i++)
+                    {
+                        // each intermediate subset is a lexographically ordered K-subset
+                        var subsetGenerator = new SubsetGenerator<T>(sequenceAsList, i);
+                        foreach (var subset in subsetGenerator)
+                            yield return subset;
+                    }
+
+                    yield return sequenceAsList; // the last subet is the original set itself
+                }
+            }
         }
 
         /// <summary>
@@ -84,37 +106,6 @@ namespace MoreLinq
             // may change after further thought and review.
 
             return new SubsetGenerator<T>(sequence, subsetSize);
-        }
-
-        /// <summary>
-        /// Underlying implementation for Subsets() overload.
-        /// </summary>
-        /// <typeparam name="T">The type of the elements in the sequence</typeparam>
-        /// <param name="sequence">Sequence for which to produce subsets</param>
-        /// <returns>Sequence of lists representing all subsets of a sequence</returns>
-        
-        private static IEnumerable<IList<T>> SubsetsImpl<T>(IEnumerable<T> sequence)
-        {
-            var sequenceAsList = sequence.ToList();
-            var sequenceLength = sequenceAsList.Count;
-
-            // the first subset is the empty set
-            yield return new List<T>();
-
-            // all other subsets are computed using the subset generator
-            // this check also resolves the case of permuting empty sets
-            if (sequenceLength > 0)
-            {
-                for (var i = 1; i < sequenceLength; i++)
-                {
-                    // each intermediate subset is a lexographically ordered K-subset
-                    var subsetGenerator = new SubsetGenerator<T>(sequenceAsList, i);
-                    foreach (var subset in subsetGenerator)
-                        yield return subset;
-                }
-
-                yield return sequenceAsList; // the last subet is the original set itself
-            }
         }
 
         /// <summary>

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -59,17 +59,16 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return TagFirsLastImpl(source, resultSelector);
-        }
 
-        static IEnumerable<TResult> TagFirsLastImpl<TSource, TResult>(IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
-        {
-            var edge = new[] { new KeyValuePair<bool, TSource>(false, default(TSource)) };
-            return edge.Concat(source.Select(e => new KeyValuePair<bool, TSource>(true, e)))
-                       .Concat(edge)
-                       .Pairwise((a, b) => new { Prev = a, Curr = b })
-                       .Pairwise((a, b) => new { a.Prev, a.Curr, Next = b.Curr })
-                       .Select(e => resultSelector(e.Curr.Value, !e.Prev.Key, !e.Next.Key));
+            return _(); IEnumerable<TResult> _()
+            {
+                var edge = new[] { new KeyValuePair<bool, TSource>(false, default(TSource)) };
+                return edge.Concat(source.Select(e => new KeyValuePair<bool, TSource>(true, e)))
+                           .Concat(edge)
+                           .Pairwise((a, b) => new { Prev = a, Curr = b })
+                           .Pairwise((a, b) => new { a.Prev, a.Curr, Next = b.Curr })
+                           .Select(e => resultSelector(e.Curr.Value, !e.Prev.Key, !e.Next.Key));
+            }
         }
     }
 }

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -49,27 +49,26 @@ namespace MoreLinq
         public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return TakeLastImpl(source, count);
-        }
 
-        private static IEnumerable<T> TakeLastImpl<T>(IEnumerable<T> source, int count)
-        {
-            Debug.Assert(source != null);
-
-            if (count <= 0)
-                yield break;
-
-            var q = new Queue<T>(count);
-
-            foreach (var item in source)
+            return _(); IEnumerable<TSource> _()
             {
-                if (q.Count == count)
-                    q.Dequeue();
-                q.Enqueue(item);
-            }
+                Debug.Assert(source != null);
 
-            foreach (var item in q)
-                yield return item;
-       }
+                if (count <= 0)
+                    yield break;
+
+                var q = new Queue<TSource>(count);
+
+                foreach (var item in source)
+                {
+                    if (q.Count == count)
+                        q.Dequeue();
+                    q.Enqueue(item);
+                }
+
+                foreach (var item in q)
+                    yield return item;
+            }
+        }
     }
 }

--- a/MoreLinq/TakeUntil.cs
+++ b/MoreLinq/TakeUntil.cs
@@ -56,17 +56,14 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            return TakeUntilImpl(source, predicate);
-        }
 
-        private static IEnumerable<TSource> TakeUntilImpl<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
-        {
-            foreach (var item in source)
+            return _(); IEnumerable<TSource> _()
             {
-                yield return item;
-                if (predicate(item))
+                foreach (var item in source)
                 {
-                    yield break;
+                    yield return item;
+                    if (predicate(item))
+                        yield break;
                 }
             }
         }

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -71,21 +71,21 @@ namespace MoreLinq
         public static IEnumerable<T> TraverseDepthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
         {
             if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
-            return TraverseDepthFirstImpl(root, childrenSelector);
-        }
 
-        private static IEnumerable<T> TraverseDepthFirstImpl<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
-        {
-            var stack = new Stack<T>();
-            stack.Push(root);
+            return _(); IEnumerable<T> _()
+            {
+                var stack = new Stack<T>();
+                stack.Push(root);
 
-            while (stack.Count != 0) {
-                var current = stack.Pop();
-                yield return current;
-                // because a stack pops the elements out in LIFO order, we need to push them in reverse
-                // if we want to traverse the returned list in the same order as was returned to us
-                foreach (var child in childrenSelector(current).Reverse())
-                    stack.Push(child);
+                while (stack.Count != 0)
+                {
+                    var current = stack.Pop();
+                    yield return current;
+                    // because a stack pops the elements out in LIFO order, we need to push them in reverse
+                    // if we want to traverse the returned list in the same order as was returned to us
+                    foreach (var child in childrenSelector(current).Reverse())
+                        stack.Push(child);
+                }
             }
         }
     }

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -39,19 +39,19 @@ namespace MoreLinq
         public static IEnumerable<T> TraverseBreadthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
         {
             if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
-            return TraverseBreadthFirstImpl(root, childrenSelector);
-        }
 
-        private static IEnumerable<T> TraverseBreadthFirstImpl<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
-        {
-            var queue = new Queue<T>();
-            queue.Enqueue(root);
+            return _(); IEnumerable<T> _()
+            {
+                var queue = new Queue<T>();
+                queue.Enqueue(root);
 
-            while (queue.Count != 0) {
-                var current = queue.Dequeue();
-                yield return current;
-                foreach (var child in childrenSelector(current))
-                    queue.Enqueue(child);
+                while (queue.Count != 0)
+                {
+                    var current = queue.Dequeue();
+                    yield return current;
+                    foreach (var child in childrenSelector(current))
+                        queue.Enqueue(child);
+                }
             }
         }
 

--- a/MoreLinq/Unfold.cs
+++ b/MoreLinq/Unfold.cs
@@ -61,26 +61,18 @@ namespace MoreLinq
             if (stateSelector == null) throw new ArgumentNullException(nameof(stateSelector));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return UnfoldImpl(state, generator, predicate, stateSelector, resultSelector);
-        }
-
-
-        private static IEnumerable<TResult> UnfoldImpl<TState, T, TResult>(
-            TState state,
-            Func<TState, T> generator,
-            Func<T, bool> predicate,
-            Func<T, TState> stateSelector,
-            Func<T, TResult> resultSelector)
-        {
-            while (true)
+            return _(); IEnumerable<TResult> _()
             {
-                var step = generator(state);
+                while (true)
+                {
+                    var step = generator(state);
 
-                if (!predicate(step))
-                    yield break;
+                    if (!predicate(step))
+                        yield break;
 
-                yield return resultSelector(step);
-                state = stateSelector(step);
+                    yield return resultSelector(step);
+                    state = stateSelector(step);
+                }
             }
         }
     }

--- a/MoreLinq/Windowed.cs
+++ b/MoreLinq/Windowed.cs
@@ -39,36 +39,34 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
-            return WindowedImpl(source, size);
-        }
-
-        private static IEnumerable<IEnumerable<TSource>> WindowedImpl<TSource>(this IEnumerable<TSource> source, int size)
-        {
-            using (var iter = source.GetEnumerator())
+            return _(); IEnumerable<IEnumerable<TSource>> _()
             {
-                // generate the first window of items
-                var window = new TSource[size];
-                int i;
-                for (i = 0; i < size && iter.MoveNext(); i++)
-                    window[i] = iter.Current;
-
-                if (i < size)
-                    yield break;
-
-                // return the first window (whatever size it may be)
-                yield return window;
-
-                // generate the next window by shifting forward by one item
-                while (iter.MoveNext())
+                using (var iter = source.GetEnumerator())
                 {
-                    // NOTE: If we used a circular queue rather than a list, 
-                    //       we could make this quite a bit more efficient.
-                    //       Sadly the BCL does not offer such a collection.
-                    var newWindow = new TSource[size];
-                    Array.Copy(window, 1, newWindow, 0, size - 1);
-                    newWindow[size - 1] = iter.Current;
-                    yield return newWindow;
-                    window = newWindow;
+                    // generate the first window of items
+                    var window = new TSource[size];
+                    int i;
+                    for (i = 0; i < size && iter.MoveNext(); i++)
+                        window[i] = iter.Current;
+
+                    if (i < size)
+                        yield break;
+
+                    // return the first window (whatever size it may be)
+                    yield return window;
+
+                    // generate the next window by shifting forward by one item
+                    while (iter.MoveNext())
+                    {
+                        // NOTE: If we used a circular queue rather than a list, 
+                        //       we could make this quite a bit more efficient.
+                        //       Sadly the BCL does not offer such a collection.
+                        var newWindow = new TSource[size];
+                        Array.Copy(window, 1, newWindow, 0, size - 1);
+                        newWindow[size - 1] = iter.Current;
+                        yield return newWindow;
+                        window = newWindow;
+                    }
                 }
             }
         }

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -59,34 +59,29 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return ZipLongestImpl(first, second, resultSelector);
-        }
-
-        static IEnumerable<TResult> ZipLongestImpl<TFirst, TSecond, TResult>(
-            IEnumerable<TFirst> first,
-            IEnumerable<TSecond> second,
-            Func<TFirst, TSecond, TResult> resultSelector)
-        {
-            using (var e1 = first.GetEnumerator())
-            using (var e2 = second.GetEnumerator())
+            return _(); IEnumerable<TResult> _()
             {
-                while (e1.MoveNext())
+                using (var e1 = first.GetEnumerator())
+                using (var e2 = second.GetEnumerator())
                 {
+                    while (e1.MoveNext())
+                    {
+                        if (e2.MoveNext())
+                        {
+                            yield return resultSelector(e1.Current, e2.Current);
+                        }
+                        else
+                        {
+                            do { yield return resultSelector(e1.Current, default(TSecond)); }
+                            while (e1.MoveNext());
+                            yield break;
+                        }
+                    }
                     if (e2.MoveNext())
                     {
-                        yield return resultSelector(e1.Current, e2.Current);
+                        do { yield return resultSelector(default(TFirst), e2.Current); }
+                        while (e2.MoveNext());
                     }
-                    else
-                    {
-                        do { yield return resultSelector(e1.Current, default(TSecond)); }
-                        while (e1.MoveNext());
-                        yield break;
-                    }
-                }
-                if (e2.MoveNext())
-                {
-                    do { yield return resultSelector(default(TFirst), e2.Current); }
-                    while (e2.MoveNext());
                 }
             }
         }


### PR DESCRIPTION
The purpose of this PR is to refactor the private iterator methods of all operators (where possible) as [local functions (introduced with C# 7)](https://docs.microsoft.com/en-us/dotnet/articles/csharp/whats-new/csharp-7#local-functions). The split was needed up until now in order to have arguments checked eagerly, when the operator method is invoked and not when the iterator is used the first time (which may far from the call site). The same split can now be done via a local function with the added benefit of code simplification as:

- parameters of parent method are in scope so the signature of the actual iterator implementation method becomes simpler since there is no need to pass on all arguments.
- type parameters of parent method are in scope so don't need repeating.
- there is one less top-level method to write.
- iterator body appears in-line to the actual public operator method that uses it.
- there is no need for debug-build assertions for arguments that have already been checked

The following methods will benefit from this:

- [X] `Assert` 
- [x] `AssertCount`
- [X] `Batch` 
- [x] `CountBy` 
- [x] `DistinctBy` 
- [x] `ExceptBy` 
- [x] `Exclude` 
- [x] `FullGroupJoin` 
- [x] `Generate` 
- [x] `GenerateByIndex` 
- [x] `Interleave` 
- [x] `Lag` 
- [x] `Lead` 
- [x] `OrderedMerge` 
- [x] `Pairwise` 
- [x] `Permutations` 
- [x] `Pipe` 
- [x] `PreScan` 
- [x] `RandomSubset` 
- [x] `RankBy` 
- [x] `RunLengthEncode` 
- [x] `Scan` 
- [x] `Segment` 
- [x] `SkipLast` 
- [x] `SkipUntil` 
- [x] `Slice` 
- [x] `SortedMerge` 
- [x] `Split`
- [x] `Subsets` 
- [x] `TagFirsLast` 
- [x] `TakeLast` 
- [x] `TakeUntil` 
- [x] `TraverseBreadthFirst` 
- [x] `TraverseDepthFirst` 
- [x] `Unfold` 
- [x] `Windowed` 
- [x] `ZipLongest` 
