### PR TITLE
Fix bug on CountBy

### DIFF
--- a/MoreLinq.Test/CountByTest.cs
+++ b/MoreLinq.Test/CountByTest.cs
@@ -61,6 +61,23 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void CountByWithSecondOccurenceImmediatelyAfterFirst()
+        {
+            var result = "jaffer".CountBy(c => c);
+
+            var expectations = new List<KeyValuePair<char, int>>()
+            {
+                { 'j', 1 },
+                { 'a', 1 },
+                { 'f', 2 },
+                { 'e', 1 },
+                { 'r', 1 },
+            };
+
+            result.AssertSequenceEqual(expectations);
+        }
+		
+        [Test]
         public void CountByEvenOddTest()
         {
             var result = Enumerable.Range(1, 100).CountBy(c => c % 2);

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -106,6 +106,7 @@ namespace MoreLinq
                 else
                 {
                     dic[key] = keys.Count;
+                    index = keys.Count;
                     keys.Add(key);
                     counts.Add(1);
                 }


### PR DESCRIPTION
I discovered a bug when testing the function with the string "jaffer". 
The operator tell us that there is 2 chars j instead of 2 f.

Basically we forgot to set `index` when a new key is registered, what present us with a bug that appears in a specific scenario: when second occurrence of an element occurs immediately after first.