### PR TITLE
Remove null arg test redundancies

### DIFF
--- a/MoreLinq.Test/AcquireTest.cs
+++ b/MoreLinq.Test/AcquireTest.cs
@@ -25,13 +25,6 @@ namespace MoreLinq.Test
     public class AcquireTest
     {
         [Test]
-        public void AcquireNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",() =>
-                MoreEnumerable.Acquire<IDisposable>(null));
-        }
-
-        [Test]
         public void AcquireAll()
         {
             Disposable a = null;

--- a/MoreLinq.Test/AggregateRightTest.cs
+++ b/MoreLinq.Test/AggregateRightTest.cs
@@ -27,20 +27,6 @@ namespace MoreLinq.Test
         // Overload 1 Test
 
         [Test]
-        public void AggregateRightWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.AggregateRight<int>(null, (a, b) => a + b));
-        }
-
-        [Test]
-        public void AggregateRightWithNullFunc()
-        {
-            Assert.ThrowsArgumentNullException("func",
-                () => Enumerable.Range(1, 5).AggregateRight(null));
-        }
-
-        [Test]
         public void AggregateRightWithEmptySequence()
         {
             Assert.Throws<InvalidOperationException>(
@@ -68,20 +54,6 @@ namespace MoreLinq.Test
         }
 
         // Overload 2 Test
-
-        [Test]
-        public void AggregateRightSeedWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.AggregateRight<int, int>(null, 1, (a, b) => a + b));
-        }
-
-        [Test]
-        public void AggregateRightSeedWithNullFunc()
-        {
-            Assert.ThrowsArgumentNullException("func",
-                () => Enumerable.Range(1, 5).AggregateRight(6, null));
-        }
 
         [TestCase(5)]
         [TestCase("c")]
@@ -111,27 +83,6 @@ namespace MoreLinq.Test
         }
 
         // Overload 3 Test
-
-        [Test]
-        public void AggregateRightResultorWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.AggregateRight<int, int, bool>(null, 1, (a, b) => a + b, a => a % 2 == 0));
-        }
-
-        [Test]
-        public void AggregateRightResultorWithNullFunc()
-        {
-            Assert.ThrowsArgumentNullException("func",
-                () => Enumerable.Range(1, 5).AggregateRight(6, null, a => a % 2 == 0));
-        }
-
-        [Test]
-        public void AggregateRightResultorWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector",
-                () => Enumerable.Range(1, 5).AggregateRight(6, (a, b) => a + b, (Func<int, bool>)null));
-        }
 
         [TestCase(5)]
         [TestCase("c")]

--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -24,13 +24,6 @@ namespace MoreLinq.Test
     public class AssertCountTest
     {
         [Test]
-        public void AssertCountNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.AssertCount<object>(null, 0));
-        }
-
-        [Test]
         public void AssertCountNegativeCount()
         {
             Assert.ThrowsArgumentOutOfRangeException("count",() =>

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -24,20 +24,6 @@ namespace MoreLinq.Test
     public class AssertTest
     {
         [Test]
-        public void AssertNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Assert<object>(null, delegate { return false; }));
-        }
-
-        [Test]
-        public void AssertNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate",() => 
-                new object[0].Assert(null));
-        }
-
-        [Test]
         public void AssertIsLazy()
         {
             new BreakingSequence<object>().Assert(delegate { throw new NotImplementedException(); });

--- a/MoreLinq.Test/AtLeastTest.cs
+++ b/MoreLinq.Test/AtLeastTest.cs
@@ -24,13 +24,6 @@ namespace MoreLinq.Test
     public class AtLeastTest
     {
         [Test]
-        public void AtLeastWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.AtLeast<int>(null, 1));
-        }
-
-        [Test]
         public void AtLeastWithNegativeCount()
         {
             Assert.ThrowsArgumentOutOfRangeException("count", () =>

--- a/MoreLinq.Test/AtMostTest.cs
+++ b/MoreLinq.Test/AtMostTest.cs
@@ -24,13 +24,6 @@ namespace MoreLinq.Test
     public class AtMostTest
     {
         [Test]
-        public void AtMostWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.AtMost<int>(null, 1));
-        }
-
-        [Test]
         public void AtMostWithNegativeCount()
         {
             Assert.ThrowsArgumentOutOfRangeException("count",

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -25,13 +25,6 @@ namespace MoreLinq.Test
     public class BatchTest
     {
         [Test]
-        public void BatchNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Batch<object>(null, 1));
-        }
-
-        [Test]
         public void BatchZeroSize()
         {
             Assert.ThrowsArgumentOutOfRangeException("size",() =>
@@ -43,13 +36,6 @@ namespace MoreLinq.Test
         {
             Assert.ThrowsArgumentOutOfRangeException("size",() =>
                 new object[0].Batch(-1));
-        }
-
-        [Test]
-        public void BatchWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector",() =>
-                new object[0].Batch<object, object>(1, null));
         }
 
         [Test]

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -21,39 +21,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify applying Cartesian to a <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestCartesianSequenceANullException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("first", () =>
-                sequence.Cartesian(Enumerable.Repeat(1, 10), (a, b) => a + b));
-        }
-
-        /// <summary>
-        /// Verify passing a <c>null</c> second sequence to Cartesian results in an exception
-        /// </summary>
-        [Test]
-        public void TestCartesianSequenceBNullException()
-        {
-            var sequence = Enumerable.Repeat(1, 10);
-            Assert.ThrowsArgumentNullException("second",() =>
-                sequence.Cartesian<int, int, int>(null, (a, b) => a + b));
-        }
-
-        /// <summary>
-        /// Verify that passing a <c>null</c> projection function to Cartesian results in an exception
-        /// </summary>
-        [Test]
-        public void TestCartesianResultSelectorNullException()
-        {
-            var sequence = Enumerable.Repeat(1, 10);
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                sequence.Cartesian(sequence, (Func<int, int, int>)null));
-        }
-
-        /// <summary>
         /// Verify that the Cartesian product of two empty sequences is an empty sequence
         /// </summary>
         [Test]

--- a/MoreLinq.Test/ConcatTest.cs
+++ b/MoreLinq.Test/ConcatTest.cs
@@ -46,13 +46,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ConcatWithNullTailSequence()
-        {
-            Assert.ThrowsArgumentNullException("tail",() =>
-                MoreEnumerable.Concat("head", null));
-        }
-
-        [Test]
         public void ConcatWithNullHead()
         {
             var tail = new[] { "second", "third" };
@@ -85,13 +78,6 @@ namespace MoreLinq.Test
             var tail = "first";
             var whole = head.Concat(tail);
             whole.AssertSequenceEqual("first");
-        }
-
-        [Test]
-        public void ConcatWithNullHeadSequence()
-        {
-            Assert.ThrowsArgumentNullException("head",() =>
-                MoreEnumerable.Concat(null, "tail"));
         }
 
         [Test]

--- a/MoreLinq.Test/ConsumeTest.cs
+++ b/MoreLinq.Test/ConsumeTest.cs
@@ -24,13 +24,6 @@ namespace MoreLinq.Test
     public class ConsumeTest
     {
         [Test]
-        public void ConsumeWithNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Consume<int>(null));
-        }
-
-        [Test]
         public void ConsumeReallyConsumes()
         {
             var counter = 0;

--- a/MoreLinq.Test/CountBetweenTest.cs
+++ b/MoreLinq.Test/CountBetweenTest.cs
@@ -25,13 +25,6 @@ namespace MoreLinq.Test
     public class CountBetweenTest
     {
         [Test]
-        public void CountBetweenWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.CountBetween<int>(null, 1, 2));
-        }
-
-        [Test]
         public void CountBetweenWithNegativeMin()
         {
             Assert.ThrowsArgumentOutOfRangeException("min", () =>

--- a/MoreLinq.Test/CountByTest.cs
+++ b/MoreLinq.Test/CountByTest.cs
@@ -27,22 +27,6 @@ namespace MoreLinq.Test
     public class CountByTest
     {
         [Test]
-        public void CountByWithNullSequence()
-        {
-            IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.CountBy(x => x % 2 == 0));
-        }
-
-        [Test]
-        public void CountByWithNullProjection()
-        {
-            Func<int, bool> projection = null;
-            Assert.ThrowsArgumentNullException("keySelector",() =>
-                Enumerable.Range(1, 10).CountBy(projection));
-        }
-
-        [Test]
         public void CountBySimpleTest()
         {
             var result = new[] { 1, 2, 3, 4, 5, 6, 1, 2, 3, 1, 1, 2 }.CountBy(c => c);

--- a/MoreLinq.Test/DistinctByTest.cs
+++ b/MoreLinq.Test/DistinctByTest.cs
@@ -32,22 +32,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void DistinctByNullSequence()
-        {
-            string[] source = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                source.DistinctBy(x => x.Length));
-        }
-
-        [Test]
-        public void DistinctByNullKeySelector()
-        {
-            string[] source = { };
-            Assert.ThrowsArgumentNullException("keySelector", () =>
-                source.DistinctBy((Func<string, string>)null));
-        }
-
-        [Test]
         public void DistinctByIsLazy()
         {
             new BreakingSequence<string>().DistinctBy(x => x.Length);
@@ -59,22 +43,6 @@ namespace MoreLinq.Test
             string[] source = { "first", "FIRST", "second", "second", "third" };
             var distinct = source.DistinctBy(word => word, StringComparer.OrdinalIgnoreCase);
             distinct.AssertSequenceEqual("first", "second", "third");
-        }
-
-        [Test]
-        public void DistinctByNullSequenceWithComparer()
-        {
-            string[] source = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                source.DistinctBy(x => x, StringComparer.Ordinal));
-        }
-
-        [Test]
-        public void DistinctByNullKeySelectorWithComparer()
-        {
-            string[] source = { };
-            Assert.ThrowsArgumentNullException("keySelector", () =>
-                source.DistinctBy(null, StringComparer.Ordinal));
         }
 
         [Test]

--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -24,21 +24,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class EndsWithTest
     {
-        [TestCase(null, null)]
-        [TestCase(null, new[] {1})]
-        public void EndsWithThrowsIfFirsIsNull(IEnumerable<int> first, IEnumerable<int> second)
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                first.EndsWith(second));
-        }
-
-        [TestCase(new[] {1}, null)]
-        public void EndsWithThrowsIfSecondIsNull(IEnumerable<int> first, IEnumerable<int> second)
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                first.EndsWith(second));
-        }
-
         [TestCase(new[] {1, 2, 3}, new[] {2, 3}, ExpectedResult = true)]
         [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, ExpectedResult = true)]
         [TestCase(new[] {1, 2, 3}, new[] {0, 1, 2, 3}, ExpectedResult = false)]

--- a/MoreLinq.Test/EquiZipTest.cs
+++ b/MoreLinq.Test/EquiZipTest.cs
@@ -87,27 +87,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ZipWithNullFirstSequence()
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                MoreEnumerable.EquiZip(null, new[] { 4, 5, 6 }, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipWithNullSecondSequence()
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                new[] { 1, 2, 3 }.EquiZip(null, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                new[] { 1, 2, 3 }.EquiZip<int, int, int>(new[] { 4, 5, 6 }, null));
-        }
-
-        [Test]
         public void ZipIsLazy()
         {
             var bs = new BreakingSequence<int>();

--- a/MoreLinq.Test/ExactlyTest.cs
+++ b/MoreLinq.Test/ExactlyTest.cs
@@ -24,13 +24,6 @@ namespace MoreLinq.Test
     public class ExactlyTest
     {
         [Test]
-        public void ExactlyWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.Exactly<int>(null, 1));
-        }
-
-        [Test]
         public void ExactlyWithNegativeCount()
         {
             Assert.ThrowsArgumentOutOfRangeException("count", () =>

--- a/MoreLinq.Test/ExceptByTest.cs
+++ b/MoreLinq.Test/ExceptByTest.cs
@@ -34,33 +34,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ExceptByNullFirstSequence()
-        {
-            string[] first = null;
-            string[] second = { "aaa" };
-            Assert.ThrowsArgumentNullException("first",() =>
-                first.ExceptBy(second, x => x.Length));
-        }
-
-        [Test]
-        public void ExceptByNullSecondSequence()
-        {
-            string[] first = { "aaa" };
-            string[] second = null;
-            Assert.ThrowsArgumentNullException("second", () =>
-                first.ExceptBy(second, x => x.Length));
-        }
-
-        [Test]
-        public void ExceptByNullKeySelector()
-        {
-            string[] first = { "aaa" };
-            string[] second = { "aaa" };
-            Assert.ThrowsArgumentNullException("keySelector", () =>
-                first.ExceptBy(second, (Func<string, string>)null));
-        }
-        
-        [Test]
         public void ExceptByIsLazy()
         {
             new BreakingSequence<string>().ExceptBy(new string[0], x => x.Length);
@@ -82,33 +55,6 @@ namespace MoreLinq.Test
             string[] second = { "FIRST" , "thiRD", "FIFTH" };
             var result = first.ExceptBy(second, word => word, StringComparer.OrdinalIgnoreCase);
             result.AssertSequenceEqual("second", "fourth");
-        }
-
-        [Test]
-        public void ExceptByNullFirstSequenceWithComparer()
-        {
-            string[] first = null;
-            string[] second = { "aaa" };
-            Assert.ThrowsArgumentNullException("first", () =>
-                first.ExceptBy(second, x => x.Length, EqualityComparer<int>.Default));
-        }
-
-        [Test]
-        public void ExceptByNullSecondSequenceWithComparer()
-        {
-            string[] first = { "aaa" };
-            string[] second = null;
-            Assert.ThrowsArgumentNullException("second", () =>
-                first.ExceptBy(second, x => x.Length, EqualityComparer<int>.Default));
-        }
-
-        [Test]
-        public void ExceptByNullKeySelectorWithComparer()
-        {
-            string[] first = { "aaa" };
-            string[] second = { "aaa" };
-            Assert.ThrowsArgumentNullException("keySelector", () =>
-                first.ExceptBy(second, null, EqualityComparer<string>.Default));
         }
 
         [Test]

--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -20,17 +20,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking exclude on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestExcludeNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                sequence.Exclude(0, 10));
-        }
-
-        /// <summary>
         /// Verify that a negative startIndex parameter results in an exception
         /// </summary>
         [Test]

--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -25,22 +25,6 @@ namespace MoreLinq.Test
     public class FallbackIfEmptyTest
     {
         [Test]
-        public void FallbackIfEmptyWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FallbackIfEmpty(null, 1));
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FallbackIfEmpty(null, 1, 2));
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FallbackIfEmpty(null, 1, 2, 3));
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FallbackIfEmpty(null, 1, 2, 3, 4));
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FallbackIfEmpty(null, 1, 2, 3, 4, 5));
-        }
-
-        [Test]
-        public void FallbackIfEmptyWithNullFallbackParams()
-        {
-           Assert.ThrowsArgumentNullException("fallback", () => new[] { 1 }.FallbackIfEmpty(null));
-        }
-
-        [Test]
         public void FallbackIfEmptyWithEmptySequence()
         {
             var source = LinqEnumerable.Empty<int>().Select(x => x);

--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -26,41 +26,6 @@ namespace MoreLinq.Test
     public class FillBackwardTest
     {
         [Test]
-        public void FillBackwardWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",
-                () => MoreEnumerable.FillBackward<object>(null));
-        }
-
-        [Test]
-        public void FillBackwardWithNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate",
-                () => new object[0].FillBackward(null));
-        }
-
-        [Test]
-        public void FillBackwardWithFillSelectorButNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.FillBackward<object>(null, _ => false, delegate { return null; }));
-        }
-
-        [Test]
-        public void FillBackwardWithFillSelectorButNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate", () =>
-                new object[0].FillBackward(null, delegate { return null; }));
-        }
-
-        [Test]
-        public void FillBackwardWithNullFillSelector()
-        {
-            Assert.ThrowsArgumentNullException("fillSelector", () =>
-                new object[0].FillBackward(_ => false, null));
-        }
-
-        [Test]
         public void FillBackwardIsLazy()
         {
             new BreakingSequence<object>().FillBackward();

--- a/MoreLinq.Test/FillForwardTest.cs
+++ b/MoreLinq.Test/FillForwardTest.cs
@@ -25,39 +25,6 @@ namespace MoreLinq.Test
     public class FillForwardTest
     {
         [Test]
-        public void FillForwardWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.FillForward<object>(null));
-        }
-
-        [Test]
-        public void FillForwardWithNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate", () => new object[0].FillForward(null));
-        }
-
-        [Test]
-        public void FillForwardWithFillSelectorButNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.FillForward<object>(null, _ => false, delegate { return null; }));
-        }
-
-        [Test]
-        public void FillForwardWithFillSelectorButNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate", () =>
-                new object[0].FillForward(null, delegate { return null; }));
-        }
-
-        [Test]
-        public void FillForwardWithNullFillSelector()
-        {
-            Assert.ThrowsArgumentNullException("fillSelector", () =>
-                new object[0].FillForward(_ => false, null));
-        }
-
-        [Test]
         public void FillForwardIsLazy()
         {
             new BreakingSequence<object>().FillForward();

--- a/MoreLinq.Test/ForEachTest.cs
+++ b/MoreLinq.Test/ForEachTest.cs
@@ -25,39 +25,11 @@ namespace MoreLinq.Test
     public class ForEachTest
     {
         [Test]
-        public void ForEachNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.ForEach<int>(null, x => { throw new InvalidOperationException(); }));
-        }
-
-        [Test]
-        public void ForEachNullAction()
-        {
-            Assert.ThrowsArgumentNullException("action", () =>
-                new[] { 1, 2, 3 }.ForEach((Action<int>)null));
-        }
-
-        [Test]
         public void ForEachWithSequence()
         {
             var results = new List<int>();
             new[] { 1, 2, 3 }.ForEach(results.Add);
             results.AssertSequenceEqual(1, 2, 3);
-        }
-
-        [Test]
-        public void ForEachIndexedNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.ForEach<int>(null, (x, i) => { throw new InvalidOperationException(); }));
-        }
-
-        [Test]
-        public void ForEachIndexedNullAction()
-        {
-            Assert.ThrowsArgumentNullException("action",() =>
-                new[] { 1, 2, 3 }.ForEach((Action<int, int>)null));
         }
 
         [Test]

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -27,41 +27,6 @@ namespace MoreLinq.Test
     public class FullGroupJoinTest
     {
         [Test]
-        public void FullGroupFirstNull()
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                ((IEnumerable<string>)null).FullGroupJoin(Enumerable.Empty<string>(), x => x, x => x, DummySelector));
-        }
-
-        [Test]
-        public void FullGroupSecondNull()
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                Enumerable.Empty<string>().FullGroupJoin((IEnumerable<string>)null, x => x, x => x, DummySelector));
-        }
-
-        [Test]
-        public void FullGroupFirstKeyNull()
-        {
-            Assert.ThrowsArgumentNullException("firstKeySelector",() =>
-                Enumerable.Empty<string>().FullGroupJoin(Enumerable.Empty<string>(), null, x => x, DummySelector));
-        }
-
-        [Test]
-        public void FullGroupSecondKeyNull()
-        {
-            Assert.ThrowsArgumentNullException("secondKeySelector",() =>
-                Enumerable.Empty<string>().FullGroupJoin(Enumerable.Empty<string>(), x => x, null, DummySelector));
-        }
-
-        [Test]
-        public void FullGroupResultSelectorNull()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                Enumerable.Empty<string>().FullGroupJoin(Enumerable.Empty<string>(), x => x, x => x, (Func<string, IEnumerable<string>, IEnumerable<string>, string>)null));
-        }
-
-        [Test]
         public void FullGroupIsLazy()
         {
             var listA = new BreakingSequence<int>();

--- a/MoreLinq.Test/GenerateTest.cs
+++ b/MoreLinq.Test/GenerateTest.cs
@@ -48,23 +48,9 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void GenerateWithNullGenerator()
-        {
-            Assert.ThrowsArgumentNullException("generator", () =>
-                MoreEnumerable.Generate(0, null));
-        }
-
-        [Test]
         public void GenerateByIndexIsLazy()
         {
             MoreEnumerable.GenerateByIndex(BreakingFunc.Of<int, int>());
-        }
-
-        [Test]
-        public void GenerateByIndexWithNullGenerator()
-        {
-            Assert.ThrowsArgumentNullException("generator",() =>
-                MoreEnumerable.GenerateByIndex<int>(null));
         }
 
         [Test]

--- a/MoreLinq.Test/GroupAdjacentTest.cs
+++ b/MoreLinq.Test/GroupAdjacentTest.cs
@@ -26,20 +26,6 @@ namespace MoreLinq.Test
     public class GroupAdjacentTest
     {
         [Test]
-        public void GroupAdjacentNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.GroupAdjacent<object, object>(null, delegate { return 0; }));
-        }
-
-        [Test]
-        public void GroupAdjacentNullKeySelector()
-        {
-            Assert.ThrowsArgumentNullException("keySelector", () =>
-                new object[0].GroupAdjacent<object, object>(null));
-        }
-
-        [Test]
         public void GroupAdjacentIsLazy()
         {
             var bs = new BreakingSequence<object>();

--- a/MoreLinq.Test/IndexTest.cs
+++ b/MoreLinq.Test/IndexTest.cs
@@ -23,20 +23,6 @@ namespace MoreLinq.Test
     public class IndexTest
     {
         [Test]
-        public void IndexNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Index<object>(null));
-        }
-
-        [Test]
-        public void IndexNullSequenceStartIndex()
-        {
-            Assert.ThrowsArgumentNullException("source",() =>
-                MoreEnumerable.Index<object>(null, 0));
-        }
-
-        [Test]
         public void IndexIsLazy()
         {
             var bs = new BreakingSequence<object>();

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -21,41 +21,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking Interleave on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestInterleaveNullSequenceArgument()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                sequence.Interleave(new int[] { }));
-        }
-
-        /// <summary>
-        /// Verify that invoking Interleave with a <c>null</c> otherSequences parameter results in an exception
-        /// </summary>
-        [Test]
-        public void TestInterleaveNullOtherSequencesArgument()
-        {
-            const int count = 10;
-            var sequence = Enumerable.Range(1, count);
-            Assert.ThrowsArgumentNullException("otherSequences", () =>
-                sequence.Interleave(null));
-        }
-
-        /// <summary>
-        /// Verify that invoking Interleave with a <c>null</c> element in the otherSequences collection results in an exception
-        /// </summary>
-        [Test]
-        public void TestInterleaveNullEntryInOtherSequences()
-        {
-            const int count = 10;
-            var sequence = Enumerable.Range(1, count);
-            Assert.ThrowsArgumentNullException("otherSequences",() =>
-                sequence.Interleave(Enumerable.Range(1, count), null));
-        }
-
-        /// <summary>
         /// Verify that interleaving disposes those enumerators that it managed 
         /// to open successfully
         /// </summary>

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -21,17 +21,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that lag throws an exception if invoked on a <c>null</c> sequence
-        /// </summary>
-        [Test]
-        public void TestLagNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Lag(10, (val, lagVal) => val));
-        }
-
-        /// <summary>
         /// Verify that lagging by a negative offset results in an exception.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -21,17 +21,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that Lead throws an exception if invoked on a <c>null</c> sequence.
-        /// </summary>
-        [Test]
-        public void TestLeadNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Lead(5, (val, leadVal) => val));
-        }
-
-        /// <summary>
         /// Verify that attempting to lead by a negative offset will result in an exception.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -16,7 +16,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace MoreLinq.Test
@@ -24,20 +23,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class MaxByTest
     {
-        [Test]
-        public void MaxByNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                ((IEnumerable<string>)null).MaxBy(x => x.Length));
-        }
-
-        [Test]
-        public void MaxByNullSelector()
-        {
-            Assert.ThrowsArgumentNullException("selector",() =>
-                SampleData.Strings.MaxBy<string, int>(null));
-        }
-
         [Test]
         public void MaxByNullComparer()
         {

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -16,7 +16,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace MoreLinq.Test
@@ -24,20 +23,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class MinByTest
     {
-        [Test]
-        public void MinByNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                ((IEnumerable<string>)null).MinBy(x => x.Length));
-        }
-
-        [Test]
-        public void MinByNullSelector()
-        {
-            Assert.ThrowsArgumentNullException("selector",() =>
-                SampleData.Strings.MinBy<string, int>(null));
-        }
-
         [Test]
         public void MinByNullComparer()
         {

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -24,6 +24,7 @@
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
     <LangVersion>7</LangVersion>
+    <WarningsNotAsErrors>618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -15,16 +15,6 @@ namespace MoreLinq.Test
         static readonly Action EmptyLoopBody = DoNothing;
 
         /// <summary>
-        /// Verify that passing an empty loop count sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestNullLoopCountsException()
-        {
-            Assert.ThrowsArgumentNullException("loopCounts",() =>
-                EmptyLoopBody.NestedLoops(null));
-        }
-
-        /// <summary>
         /// Verify that passing negative loop counts results in an exception
         /// </summary>
         [Test]

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -23,13 +23,6 @@ namespace MoreLinq.Test
     public class PadTest
     {
         [Test]
-        public void PadNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Pad<object>(null, 0));
-        }
-
-        [Test]
         public void PadNegativeWidth()
         {
             Assert.ThrowsArgumentException("width",() =>

--- a/MoreLinq.Test/PairwiseTest.cs
+++ b/MoreLinq.Test/PairwiseTest.cs
@@ -23,20 +23,6 @@ namespace MoreLinq.Test
     public class PairwiseTest
     {
         [Test]
-        public void PairwiseNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Pairwise<object, object>(null, delegate { return 0; }));
-        }
-
-        [Test]
-        public void PairwiseNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                new object[0].Pairwise<object, object>(null));
-        }
-
-        [Test]
         public void PairwiseIsLazy()
         {
             new BreakingSequence<object>().Pairwise(delegate { return 0; });

--- a/MoreLinq.Test/PartialSortByTest.cs
+++ b/MoreLinq.Test/PartialSortByTest.cs
@@ -26,16 +26,6 @@ namespace MoreLinq.Test
     public class PartialSortByTests
     {
         [Test]
-        public void PartialSortByWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () => 
-                MoreEnumerable.PartialSortBy<object, object>(null, 0, e => e));
-
-            Assert.ThrowsArgumentNullException("source", () => 
-                MoreEnumerable.PartialSortBy<object, object>(null, 0, e => e, Comparer<object>.Default));
-        }
-
-        [Test]
         public void PartialSortBy()
         {
             var ns = MoreEnumerable.RandomDouble().Take(10).ToArray();

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -26,16 +26,6 @@ namespace MoreLinq.Test
     public class PartialSortTests
     {
         [Test]
-        public void PartialSortWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () => 
-                MoreEnumerable.PartialSort<object>(null, 0));
-
-            Assert.ThrowsArgumentNullException("source", () => 
-                MoreEnumerable.PartialSort(null, 0, Comparer<object>.Default));
-        }
-
-        [Test]
         public void PartialSort()
         {
             var sorted = Enumerable.Range(1, 10)

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -157,18 +157,6 @@ namespace MoreLinq.Test
             new BreakingSequence<int>().Permutations();
         }
 
-
-        /// <summary>
-        /// Verify that invoking Permutations() on a <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestPermutationNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                sequence.Permutations());
-        }
-
         /// <summary>
         /// Verify that each permutation produced is a new object, this ensures that callers
         /// can request permutations and cache or store them without them being overwritten.

--- a/MoreLinq.Test/PipeTest.cs
+++ b/MoreLinq.Test/PipeTest.cs
@@ -27,20 +27,6 @@ namespace MoreLinq.Test
     public class PipeTest
     {
         [Test]
-        public void PipeNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Pipe<int>(null, x => { throw new InvalidOperationException(); }));
-        }
-
-        [Test]
-        public void PipeNullAction()
-        {
-            Assert.ThrowsArgumentNullException("action", () =>
-                new[] { 1, 2, 3 }.Pipe(null));
-        }
-
-        [Test]
         public void PipeWithSequence()
         {
             var results = new List<int>();

--- a/MoreLinq.Test/PreScanTest.cs
+++ b/MoreLinq.Test/PreScanTest.cs
@@ -23,20 +23,6 @@ namespace MoreLinq.Test
     public class PreScanTest
     {
         [Test]
-        public void PreScanNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.PreScan(null, SampleData.Plus, 0));
-        }
-
-        [Test]
-        public void PreScanNullOperation()
-        {
-            Assert.ThrowsArgumentNullException("transformation",() =>
-                SampleData.Values.PreScan(null, 0));
-        }
-
-        [Test]
         public void PreScanSum()
         {
             var result = SampleData.Values.PreScan(SampleData.Plus, 0);

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -41,13 +41,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void PrependWithNullTailSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.Prepend(null, "head"));
-        }
-
-        [Test]
         public void PrependWithNullHead()
         {
             string[] tail = { "second", "third" };

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -22,28 +22,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking RandomSubsets on a <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestRandomSubsetNullSequence()
-        {
-            const IEnumerable<int> nullSequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                nullSequence.RandomSubset(10));
-        }
-
-        /// <summary>
-        /// Verify that invoking RandomSubsets on a <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestRandomSubsetNullSequence2()
-        {
-            const IEnumerable<int> nullSequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                nullSequence.RandomSubset(10, new Random()));
-        }
-
-        /// <summary>
         /// Verify that involving RandomSubsets with a subset size less than 0 results in an exception.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/RandomTest.cs
+++ b/MoreLinq.Test/RandomTest.cs
@@ -14,51 +14,6 @@ namespace MoreLinq.Test
         const int RandomTrials = 10000;
 
         /// <summary>
-        /// Verify that passing an <c>null</c> random generator results in an exception.
-        /// </summary>
-        [Test]
-        public void TestNullGeneratorException1()
-        {
-            Assert.ThrowsArgumentNullException("rand",() =>
-                MoreEnumerable.Random(null));
-        }
-
-        /// <summary>
-        /// Verify that passing an <c>null</c> random generator results in an exception.
-        /// </summary>
-        [Test]
-        public void TestNullGeneratorException2()
-        {
-            const int maxValue = 10;
-            Assert.Greater(maxValue, 0);
-            Assert.ThrowsArgumentNullException("rand", () =>
-                MoreEnumerable.Random(null, maxValue));
-        }
-
-        /// <summary>
-        /// Verify that passing an <c>null</c> random generator results in an exception.
-        /// </summary>
-        [Test]
-        public void TestNullGeneratorException3()
-        {
-            const int minValue = 10;
-            const int maxValue = 100;
-            Assert.LessOrEqual(minValue, maxValue);
-            Assert.ThrowsArgumentNullException("rand", () =>
-                MoreEnumerable.Random(null, minValue, maxValue));
-        }
-
-        /// <summary>
-        /// Verify that passing an <c>null</c> random generator results in an exception.
-        /// </summary>
-        [Test]
-        public void TestNullGeneratorException4()
-        {
-            Assert.ThrowsArgumentNullException("rand", () =>
-                MoreEnumerable.RandomDouble(null));
-        }
-
-        /// <summary>
         /// Verify that passing a negative maximum value yields an exception
         /// </summary>
         [Test]

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -22,32 +22,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that Rank throws an exception when invoked on a <c>null</c> sequence
-        /// </summary>
-        [Test]
-        public void TestRankSequenceNullException()
-        {
-            const IEnumerable<int> sequence = null;
-
-            Assert.ThrowsArgumentNullException("source", () => sequence.Rank());
-            Assert.ThrowsArgumentNullException("source", () => sequence.Rank(Comparer<int>.Default));
-            Assert.ThrowsArgumentNullException("source", () => sequence.RankBy(x => x));
-            Assert.ThrowsArgumentNullException("source", () => sequence.RankBy(x => x, Comparer<int>.Default));
-        }
-
-        /// <summary>
-        /// Verify that Rank throws an exception if the key selector is <c>null</c>
-        /// </summary>
-        [Test]
-        public void TestRankKeySelectorNullException()
-        {
-            var sequence = Enumerable.Repeat(1, 10);
-
-            Assert.ThrowsArgumentNullException("keySelector", () => sequence.RankBy((Func<int, int>)null));
-            Assert.ThrowsArgumentNullException("keySelector", () => sequence.RankBy((Func<int, int>)null, null));
-        }
-
-        /// <summary>
         /// Verify that Rank uses the default comparer when comparer is <c>null</c>
         /// </summary>
         [Test]

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -48,16 +48,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify applying Repeat to a <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestRepeatSequenceANullException()
-        {
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                MoreEnumerable.Repeat<object>(null, 42));
-        }
-
-        /// <summary>
         /// Verify applying Repeat without passing count produces a circular sequence
         /// </summary>
         [Test]
@@ -88,17 +78,6 @@ namespace MoreLinq.Test
                 expectedResult = expectedResult.Concat(sequence);
 
             Assert.That(expectedResult, Is.EquivalentTo(result.Take(takeCount)));
-        }
-
-        /// <summary>
-        /// Verify applying Repeat without passing count to a 
-        /// <c>null</c> sequence results in an exception.
-        /// </summary>
-        [Test]
-        public void TestRepeatForeverSequenceANullException()
-        {
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                MoreEnumerable.Repeat<object>(null));
         }
 
         /// <summary>

--- a/MoreLinq.Test/RunLengthEncodeTest.cs
+++ b/MoreLinq.Test/RunLengthEncodeTest.cs
@@ -22,28 +22,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking RunLengthEncode on an empty sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestRunLengthEncodeNullSequence()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("sequence", () =>
-                sequence.RunLengthEncode());
-        }
-
-        /// <summary>
-        /// Verify that invoking RunLengthEncode on an empty sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestRunLengthEncodeNullSequence2()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("sequence",() =>
-                sequence.RunLengthEncode(EqualityComparer<int>.Default));
-        }
-
-        /// <summary>
         /// Verify that run-length encoding an empty sequence results in an empty sequence.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -23,47 +23,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking Segment on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestSegmentNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Segment(curr => false));
-        }
-
-        /// <summary>
-        /// Verify that invoking Segment on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestSegmentNullSequenceException2()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Segment((curr, index) => false));
-        }
-
-        /// <summary>
-        /// Verify that invoking Segment on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestSegmentNullSequenceException3()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Segment((curr, prev, index) => false));
-        }
-
-        [Test]
-        public void TestSegmentIdentifierNullException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("newSegmentPredicate",() =>
-                sequence.Segment((Func<int, bool>)null));
-        }
-
-        /// <summary>
         /// Verify that segmenting a sequence into a single sequence results in the original sequence.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/SingleOrFallbackTest.cs
+++ b/MoreLinq.Test/SingleOrFallbackTest.cs
@@ -28,20 +28,6 @@ namespace MoreLinq.Test
     public class SingleOrFallbackTest
     {
         [Test]
-        public void SingleOrFallbackWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.SingleOrFallback(null, BreakingFunc.Of<int>()));
-        }
-
-        [Test]
-        public void SingleOrFallbackWithNullFallback()
-        {
-            Assert.ThrowsArgumentNullException("fallback",() =>
-                new[] { 1 }.SingleOrFallback(null));
-        }
-
-        [Test]
         public void SingleOrFallbackWithEmptySequence()
         {
             Assert.AreEqual(5, LinqEnumerable.Empty<int>().Select(x => x).SingleOrFallback(() => 5));

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -23,12 +23,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class SkipLastTest
     {
-        [Test]
-        public void SkipLastWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () => MoreEnumerable.SkipLast<int>(null, 1));
-        }
-
         [TestCase( 0)]
         [TestCase(-1)]
         public void SkipLastWithCountLesserThanOne(int skip)

--- a/MoreLinq.Test/SkipUntilTest.cs
+++ b/MoreLinq.Test/SkipUntilTest.cs
@@ -24,20 +24,6 @@ namespace MoreLinq.Test
     public class SkipUntilTest
     {
         [Test]
-        public void SkipUntilNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.SkipUntil<string>(null, x => x.Length == 1));
-        }
-
-        [Test]
-        public void SkipUntilNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("source",() =>
-                MoreEnumerable.SkipUntil<string>(null, x => x.Length == 1));
-        }
-
-        [Test]
         public void SkipUntilPredicateNeverFalse()
         {
             var sequence = Enumerable.Range(0, 5).SkipUntil(x => x != 100);

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -24,29 +24,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that SortedMerge throws an exception if invoked on a <c>null</c> sequence.
-        /// </summary>
-        [Test]
-        public void TestSortedMergeSequenceNullException()
-        {
-            const IEnumerable<int> sequenceA = null;
-            var sequenceB = new BreakingSequence<int>();
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB));
-        }
-
-        /// <summary>
-        /// Verify that SortedMerge throws an exception if invoked with a <c>null</c> <c>otherSequences</c> argument.
-        /// </summary>
-        [Test]
-        public void TestSortedMergeOtherSequencesNullException()
-        {
-            var sequenceA = new BreakingSequence<int>();
-            Assert.ThrowsArgumentNullException("otherSequences",() =>
-                sequenceA.SortedMerge(OrderByDirection.Ascending, (IEnumerable<int>[])null));
-        }
-
-        /// <summary>
         /// Verify that SortedMerge disposes those enumerators that it managed 
         /// to open successfully
         /// </summary>

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -24,21 +24,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class StartsWithTest
     {
-        [TestCase(null, null)]
-        [TestCase(null, new[] {1})]
-        public void StartsWithThrowsIfFirstIsNull(IEnumerable<int> first, IEnumerable<int> second)
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                first.StartsWith(second));
-        }
-
-        [TestCase(new[] {1}, null)]
-        public void StartsWithThrowsIfSecondAIsNull(IEnumerable<int> first, IEnumerable<int> second)
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                first.StartsWith(second));
-        }
-
         [TestCase(new[] {1, 2, 3}, new[] {1, 2}, ExpectedResult = true)]
         [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, ExpectedResult = true)]
         [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3, 4}, ExpectedResult = false)]

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -23,20 +23,6 @@ namespace MoreLinq.Test
     public class TagFirstLastTest
     {
         [Test]
-        public void TagFirstLastNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.TagFirstLast<object, object>(null, delegate { return null; }));
-        }
-
-        [Test]
-        public void TagFirstLastNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                new object[0].TagFirstLast<object, object>(null));
-        }
-
-        [Test]
         public void TagFirstLastIsLazy()
         {
             new BreakingSequence<object>().TagFirstLast(delegate { return 0; });

--- a/MoreLinq.Test/TakeEveryTest.cs
+++ b/MoreLinq.Test/TakeEveryTest.cs
@@ -23,13 +23,6 @@ namespace MoreLinq.Test
     public class TakeEveryTest
     {
         [Test]
-        public void TakeEveryNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.TakeEvery<object>(null, 1));
-        }
-
-        [Test]
         public void TakeEveryNegativeSkip()
         {
             Assert.ThrowsArgumentOutOfRangeException("step",() =>

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -23,13 +23,6 @@ namespace MoreLinq.Test
     public class TakeLastTest
     {
         [Test]
-        public void TakeLastNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.TakeLast<object>(null, 0));
-        }
-
-        [Test]
         public void TakeLast()
         {
             var result = new[]{ 12, 34, 56, 78, 910, 1112 }.TakeLast(3);

--- a/MoreLinq.Test/TakeUntilTest.cs
+++ b/MoreLinq.Test/TakeUntilTest.cs
@@ -24,20 +24,6 @@ namespace MoreLinq.Test
     public class TakeUntilTest
     {
         [Test]
-        public void TakeUntilNullSource()
-        {
-            Assert.ThrowsArgumentNullException("source",() =>
-                MoreEnumerable.TakeUntil<string>(null, x => x.Length == 1));
-        }
-
-        [Test]
-        public void TakeUntilNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.TakeUntil<string>(null, x => x.Length == 1));
-        }
-
-        [Test]
         public void TakeUntilPredicateNeverFalse()
         {
             var sequence = Enumerable.Range(0, 5).TakeUntil(x => x != 100);

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -64,25 +64,6 @@ namespace MoreLinq.Test
                                      .ToArray();
         }
 
-
-        [Test]
-        public void ToDataTableNullSequence()
-        {
-            IEnumerable<TestObject> source = null;
-
-            Assert.ThrowsArgumentNullException("source",() =>
-                source.ToDataTable());
-        }
-
-        [Test]
-        public void ToDataTableNullTable()
-        {
-            DataTable dt = null;
-
-            Assert.ThrowsArgumentNullException("table",() =>
-                _testObjects.ToDataTable(dt));
-        }
-
         [Test]
         public void ToDataTableNullMemberExpressionMethod()
         {

--- a/MoreLinq.Test/ToDelimitedStringTest.cs
+++ b/MoreLinq.Test/ToDelimitedStringTest.cs
@@ -27,13 +27,6 @@ namespace MoreLinq.Test
     public class ToDelimitedStringTest
     {
         [Test]
-        public void ToDelimitedStringWithNullSequence()
-        {
-            Assert.ThrowsArgumentNullException("source",() =>
-                MoreEnumerable.ToDelimitedString<int>(null, ","));
-        }
-
-        [Test]
         public void ToDelimitedStringWithEmptySequence()
         {
             Assert.That(LinqEnumerable.Empty<int>().ToDelimitedString(), Is.Empty);

--- a/MoreLinq.Test/ToDictionaryTest.cs
+++ b/MoreLinq.Test/ToDictionaryTest.cs
@@ -16,7 +16,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace MoreLinq.Test
@@ -24,13 +23,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class ToDictionaryTest
     {
-        [Test]
-        public void ToDictionaryWithNullKeyValuePairSequence()
-        {
-            Assert.ThrowsArgumentNullException("source", () =>
-                MoreEnumerable.ToDictionary((IEnumerable<KeyValuePair<object, object>>) null));
-        }
-
         [Test]
         public void ToDictionaryWithKeyValuePairs()
         {

--- a/MoreLinq.Test/TraverseTest.cs
+++ b/MoreLinq.Test/TraverseTest.cs
@@ -25,20 +25,6 @@ namespace MoreLinq.Test
     public class TraverseTest
     {
         [Test]
-        public void TraverseBreadthFirstNullGenerator()
-        {
-            Assert.ThrowsArgumentNullException("childrenSelector", () =>
-                MoreEnumerable.TraverseBreadthFirst(new object(), null));
-        }
-
-        [Test]
-        public void TraverseDepthFirstNullGenerator()
-        {
-            Assert.ThrowsArgumentNullException("childrenSelector",() =>
-                MoreEnumerable.TraverseDepthFirst(new object(), null));
-        }
-
-        [Test]
         public void TraverseDepthFirstFNullGenerator()
         {
             MoreEnumerable.TraverseDepthFirst(new object(), o => new BreakingSequence<object>());

--- a/MoreLinq.Test/UnfoldTest.cs
+++ b/MoreLinq.Test/UnfoldTest.cs
@@ -1,4 +1,4 @@
-﻿#region License and Terms
+#region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
 // Copyright (c) 2017 Leandro F. Vieira (leandromoh). All rights reserved.
 // 
@@ -17,45 +17,12 @@
 
 using System.Linq;
 using NUnit.Framework;
-using System;
 
 namespace MoreLinq.Test
 {
     [TestFixture]
     public class UnfoldTest
     {
-        [Test]
-        public void UnfoldWithNullGenerator()
-        {
-            Assert.ThrowsArgumentNullException("generator", () =>
-                MoreEnumerable.Unfold(0, (Func<int, (int State, int Result)>) null,
-                                      _ => true, e => e.State, e => e.Result));
-        }
-
-        [Test]
-        public void UnfoldWithNullPredicate()
-        {
-            Assert.ThrowsArgumentNullException("predicate", () =>
-                MoreEnumerable.Unfold(0, e => (e, e + 1), null, e => e.Item1, e => e.Item2));
-        }
-
-        [Test]
-        public void UnfoldWithNullStateSelector()
-        {
-            Assert.ThrowsArgumentNullException("stateSelector", () =>
-                MoreEnumerable.Unfold(0, e => (e, e + 1), _ => true, null, e => e.Item2));
-        }
-
-        [Test]
-        public void UnfoldWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                MoreEnumerable.Unfold(0, e => (e, e + 1),
-                                         _ => true,
-                                         e => e.State,
-                                         (Func<(int Result, int State), int>) null));
-        }
-
         [Test]
         public void UnfoldInfiniteSequence()
         {

--- a/MoreLinq.Test/WindowedTest.cs
+++ b/MoreLinq.Test/WindowedTest.cs
@@ -20,17 +20,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that invoking Windowed on a <c>null</c> sequence results in an exception
-        /// </summary>
-        [Test]
-        public void TestWindowedNullSequenceException()
-        {
-            const IEnumerable<int> sequence = null;
-            Assert.ThrowsArgumentNullException("source", () =>
-                sequence.Windowed(10));
-        }
-
-        /// <summary>
         /// Verify that a negative window size results in an exception
         /// </summary>
         [Test]

--- a/MoreLinq.Test/ZipLongestTest.cs
+++ b/MoreLinq.Test/ZipLongestTest.cs
@@ -69,27 +69,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ZipWithNullFirstSequence()
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                MoreEnumerable.ZipLongest(null, new[] { 4, 5, 6 }, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipWithNullSecondSequence()
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                new[] { 1, 2, 3 }.ZipLongest(null, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector", () =>
-                new[] { 1, 2, 3 }.ZipLongest<int, int, int>(new[] { 4, 5, 6 }, null));
-        }
-
-        [Test]
         public void ZipLongestIsLazy()
         {
             var bs = new BreakingSequence<int>();

--- a/MoreLinq.Test/ZipShortestTest.cs
+++ b/MoreLinq.Test/ZipShortestTest.cs
@@ -69,27 +69,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void ZipShortestWithNullFirstSequence()
-        {
-            Assert.ThrowsArgumentNullException("first", () =>
-                MoreEnumerable.ZipShortest(null, new[] { 4, 5, 6 }, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipShortestWithNullSecondSequence()
-        {
-            Assert.ThrowsArgumentNullException("second", () =>
-                new[] { 1, 2, 3 }.ZipShortest(null, BreakingFunc.Of<int, int, int>()));
-        }
-
-        [Test]
-        public void ZipShortestWithNullResultSelector()
-        {
-            Assert.ThrowsArgumentNullException("resultSelector",() =>
-                new[] { 1, 2, 3 }.ZipShortest<int, int, int>(new[] { 4, 5, 6 }, null));
-        }
-
-        [Test]
         public void ZipShortestIsLazy()
         {
             var bs = new BreakingSequence<int>();


### PR DESCRIPTION
The `NullArgumentTest` fixture renders all null-argument checking tests redundant. It automatically tests those checks through reflection. This PR removes all hand-written null-argument checks that came before the fixture was added (and some even after), for the following benefits:

1. less tests to write
2. less tests to maintain (as a result of 1)
3. more interesting tests in each fixture
4. consistency by virtue of not having to write null-argument checking class of tests at all

The affected fixtures are as follows:

- [x] `Acquire`
- [x] `AggregateRight`
- [x] `Assert`
- [x] `AssertCount`
- [x] `AtLeast`
- [x] `AtMost`
- [x] `Batch`
- [x] `Cartesian`
- [x] `Concat`
- [x] `Consume`
- [x] `CountBetween`
- [x] `CountBy`
- [x] `DistinctBy`
- [x] `EndsWith`
- [x] `EquiZip`
- [x] `Exactly`
- [x] `ExceptBy`
- [x] `Exclude`
- [x] `FallbackIfEmpty`
- [x] `FillBackward`
- [x] `FillForward`
- [x] `FullGroupJoin`
- [x] `Generate`
- [x] `GroupAdjacent`
- [x] `Index`
- [x] `Interleave`
- [x] `Lag`
- [x] `Lead`
- [x] `MaxBy`
- [x] `MinBy`
- [x] `NestedLoop`
- [x] `Pad`
- [x] `Pairwise`
- [x] `PartialSort`
- [x] `PartialSortBy`
- [x] `Permutations`
- [x] `Pipe`
- [x] `Prepend`
- [x] `PreScan`
- [x] `Random`
- [x] `RandomSubset`
- [x] `Rank`
- [x] `Repeat`
- [x] `RunLengthEncode`
- [x] `Segment`
- [x] `SingleOrFallback`
- [x] `SkipLast`
- [x] `SkipUntil`
- [x] `SortedMerge`
- [x] `StartsWith`
- [x] `TagFirstLast`
- [x] `TakeEvery`
- [x] `TakeLast`
- [x] `TakeUntil`
- [x] `ToDataTable`
- [x] `ToDelimitedString`
- [x] `ToDictionary`
- [x] `TraverseBreadthFirst`
- [x] `TraverseDepthFirst`
- [x] `Unfold`
- [x] `Windowed`
- [x] `ZipLongest`
- [x] `ZipShortest`
