### PR TITLE
Improve/Fix ExcludeTest

### DIFF
--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -60,7 +60,7 @@ namespace MoreLinq.Test
         public void TestExcludeSequenceHead()
         {
             const int count = 10;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(0, count / 2);
 
             Assert.IsTrue(result.SequenceEqual(sequence.Skip(count / 2)));
@@ -73,7 +73,7 @@ namespace MoreLinq.Test
         public void TestExcludeSequenceTail()
         {
             const int count = 10;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(count / 2, count);
 
             Assert.IsTrue(result.SequenceEqual(sequence.Take(count / 2)));
@@ -88,7 +88,7 @@ namespace MoreLinq.Test
             const int count = 10;
             const int startIndex = 3;
             const int excludeCount = 5;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(startIndex, excludeCount);
 
             Assert.IsTrue(result.SequenceEqual(sequence.Take(startIndex).Concat(sequence.Skip(startIndex + excludeCount))));
@@ -101,7 +101,7 @@ namespace MoreLinq.Test
         public void TestExcludeEntireSequence()
         {
             const int count = 10;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(0, count);
 
             Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
@@ -114,7 +114,7 @@ namespace MoreLinq.Test
         public void TestExcludeCountGreaterThanSequenceLength()
         {
             const int count = 10;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(1, count * 10);
 
             Assert.IsTrue(result.SequenceEqual(sequence.Take(1)));
@@ -127,7 +127,7 @@ namespace MoreLinq.Test
         public void TestExcludeStartIndexGreaterThanSequenceLength()
         {
             const int count = 10;
-            var sequence = Enumerable.Repeat(1, count);
+            var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(count + 5, count);
 
             Assert.IsTrue(result.SequenceEqual(sequence));


### PR DESCRIPTION
The tests were using sequences where all elements are equals, what dont let us to check if the right elements were exclude. 

So the tests were, in fact, only testing if the function had exclude the right number of elements.