### PR TITLE
Add Evaluate function that evaluates a sequence of functions

### DIFF
--- a/MoreLinq.Test/EvaluateTest.cs
+++ b/MoreLinq.Test/EvaluateTest.cs
@@ -1,0 +1,64 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Felipe Sateler. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+
+namespace MoreLinq.Test
+{
+    using System;
+    using NUnit.Framework;
+
+    class EvaluateTest
+    {
+        [Test]
+        public void TestEvaluateIsLazy()
+        {
+            new BreakingSequence<Func<int>>().Evaluate();
+        }
+
+        [Test]
+        public void TestEvaluateInvokesMethods()
+        {
+            var factories = new Func<int>[]
+            {
+                () => -2,
+                () => 4,
+                () => int.MaxValue,
+                () => int.MinValue,
+            };
+            var results = factories.Evaluate();
+
+            results.AssertSequenceEqual(-2, 4, int.MaxValue, int.MinValue);
+        }
+
+        [Test]
+        public void TestEvaluateInvokesMethodsMultipleTimes()
+        {
+            var evals = 0;
+            var factories = new Func<int>[]
+            {
+                () => { evals++; return -2; },
+            };
+            var results = factories.Evaluate();
+
+            results.Consume();
+            results.Consume();
+            results.Consume();
+
+            Assert.That(evals, Is.EqualTo(3));
+        }
+    }
+}

--- a/MoreLinq.Test/EvaluateTest.cs
+++ b/MoreLinq.Test/EvaluateTest.cs
@@ -15,7 +15,6 @@
 // limitations under the License.
 #endregion
 
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq/Evaluate.cs
+++ b/MoreLinq/Evaluate.cs
@@ -24,23 +24,22 @@ namespace MoreLinq
     partial class MoreEnumerable
     {
         /// <summary>
-        /// Returns a sequence containing the results of invoking each function (in order) in the source sequence of functions.
+        /// Returns a sequence containing the values resulting from invoking (in order) each function in the source sequence of functions.
         /// </summary>
         /// <remarks>
         /// This operator uses deferred execution and streams the results.
         /// If the resulting sequence is enumerated multiple times, the functions will be
-        /// evaluated multiple times too
+        /// evaluated multiple times too.
         /// </remarks>
-        /// <typeparam name="T">The type of the object returned by the functions</typeparam>
-        /// <param name="functions">The functions to evaluate</param>
-        /// <returns>A sequence with the values created for all of the <paramref name="functions"/></returns>
-        /// <exception cref="ArgumentNullException">When <paramref name="functions"/> is <c>null</c></exception>
+        /// <typeparam name="T">The type of the object returned by the functions.</typeparam>
+        /// <param name="functions">The functions to evaluate.</param>
+        /// <returns>A sequence with results from invoking <paramref name="functions"/>.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="functions"/> is <c>null</c>.</exception>
 
         public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)
         {
-            if (functions == null) {
-                throw new ArgumentNullException(nameof(functions));
-            }
+            if (functions == null) throw new ArgumentNullException(nameof(functions));
+
             return from f in functions select f();
         }
     }

--- a/MoreLinq/Evaluate.cs
+++ b/MoreLinq/Evaluate.cs
@@ -1,0 +1,47 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2017 Felipe Sateler. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns a sequence containing the results of invoking each function (in order) in the source sequence of functions.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses deferred execution and streams the results.
+        /// If the resulting sequence is enumerated multiple times, the functions will be
+        /// evaluated multiple times too
+        /// </remarks>
+        /// <typeparam name="T">The type of the object returned by the functions</typeparam>
+        /// <param name="functions">The functions to evaluate</param>
+        /// <returns>A sequence with the values created for all of the <paramref name="functions"/></returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="functions"/> is <c>null</c></exception>
+
+        public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)
+        {
+            if (functions == null) {
+                throw new ArgumentNullException(nameof(functions));
+            }
+            return from f in functions select f();
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #151 


I ended up naming the function `Values` as that was mentioned by @atifaziz on #293 (which I think can also be closed if this is merged). I can rename back to `FromDelegates` or other name if `Values` is not appropriate. I thought about naming the method `Fabricate` or `Manufacture` (because the parameters are factories) but that feels a bit weird.