### PR TITLE
Prevent accidental testing of duplicate LINQ members 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ install:
   - dotnet restore
 
 script:
+  - if grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' $(ls MoreLinq.Test/*Test.cs); then
+  -     echo "System.Linq import found, failing the build!" >&2
+  -     exit 1
+  - fi
   - ./msbuild.sh /v:m /p:Configuration=$CONFIGURATION
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp1.0/MoreLinq.Test.dll
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp2.0/MoreLinq.Test.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ install:
   - dotnet restore
 
 script:
-  - if grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' $(ls MoreLinq.Test/*Test.cs); then
+  - |
+    if grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' $(ls MoreLinq.Test/*Test.cs); then
         echo "System.Linq import found, failing the build!" >&2
         exit 1
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ install:
 
 script:
   - if grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' $(ls MoreLinq.Test/*Test.cs); then
-  -     echo "System.Linq import found, failing the build!" >&2
-  -     exit 1
-  - fi
+        echo "System.Linq import found, failing the build!" >&2
+        exit 1
+    fi
   - ./msbuild.sh /v:m /p:Configuration=$CONFIGURATION
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp1.0/MoreLinq.Test.dll
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp2.0/MoreLinq.Test.dll

--- a/MoreLinq.Test/AggregateRightTest.cs
+++ b/MoreLinq.Test/AggregateRightTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/AtLeastTest.cs
+++ b/MoreLinq.Test/AtLeastTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class AtLeastTest
@@ -33,19 +32,19 @@ namespace MoreLinq.Test
         [Test]
         public void AtLeastWithEmptySequenceHasAtLeastZeroElements()
         {
-            Assert.IsTrue(LinqEnumerable.Empty<int>().AtLeast(0));
+            Assert.IsTrue(Enumerable.Empty<int>().AtLeast(0));
         }
 
         [Test]
         public void AtLeastWithEmptySequenceHasAtLeastOneElement()
         {
-            Assert.IsFalse(LinqEnumerable.Empty<int>().AtLeast(1));
+            Assert.IsFalse(Enumerable.Empty<int>().AtLeast(1));
         }
 
         [Test]
         public void AtLeastWithEmptySequenceHasAtLeastManyElements()
         {
-            Assert.IsFalse(LinqEnumerable.Empty<int>().AtLeast(2));
+            Assert.IsFalse(Enumerable.Empty<int>().AtLeast(2));
         }
 
         [Test]

--- a/MoreLinq.Test/AtMostTest.cs
+++ b/MoreLinq.Test/AtMostTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class AtMostTest
@@ -33,13 +32,13 @@ namespace MoreLinq.Test
         [Test]
         public void AtMostWithEmptySequenceHasAtMostZeroElements()
         {
-            Assert.IsTrue(LinqEnumerable.Empty<int>().AtMost(0));
+            Assert.IsTrue(Enumerable.Empty<int>().AtMost(0));
         }
 
         [Test]
         public void AtMostWithEmptySequenceHasAtMostOneElement()
         {
-            Assert.IsTrue(LinqEnumerable.Empty<int>().AtMost(1));
+            Assert.IsTrue(Enumerable.Empty<int>().AtMost(1));
         }
 
         [Test]

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/ConcatTest.cs
+++ b/MoreLinq.Test/ConcatTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/ConsumeTest.cs
+++ b/MoreLinq.Test/ConsumeTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class ConsumeTest
@@ -27,7 +26,7 @@ namespace MoreLinq.Test
         public void ConsumeReallyConsumes()
         {
             var counter = 0;
-            var sequence = LinqEnumerable.Range(0, 10).Pipe(x => counter++);
+            var sequence = Enumerable.Range(0, 10).Pipe(x => counter++);
             sequence.Consume();
             Assert.AreEqual(10, counter);
         }

--- a/MoreLinq.Test/CountBetweenTest.cs
+++ b/MoreLinq.Test/CountBetweenTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/CountByTest.cs
+++ b/MoreLinq.Test/CountByTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/Enumerable.cs
+++ b/MoreLinq.Test/Enumerable.cs
@@ -1,0 +1,538 @@
+namespace MoreLinq.Test
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using LinqEnumerable = System.Linq.Enumerable;
+
+    [DebuggerStepThrough]
+    static partial class Enumerable
+    {
+        public static TSource Aggregate<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func) =>
+            LinqEnumerable.Aggregate(source, func);
+
+        public static TAccumulate Aggregate<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func) =>
+            LinqEnumerable.Aggregate(source, seed, func);
+
+        public static TResult Aggregate<TSource, TAccumulate, TResult>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector) =>
+            LinqEnumerable.Aggregate(source, seed, func, resultSelector);
+
+        public static bool All<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.All(source, predicate);
+
+        public static bool Any<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Any(source);
+
+        public static bool Any<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.Any(source, predicate);
+
+        public static IEnumerable<TSource> AsEnumerable<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.AsEnumerable(source);
+
+        public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static decimal? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static float Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static float? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static decimal Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) =>
+            LinqEnumerable.Average(source, selector);
+
+        public static float? Average(this IEnumerable<float?> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double? Average(this IEnumerable<long?> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double? Average(this IEnumerable<int?> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double? Average(this IEnumerable<double?> source) =>
+            LinqEnumerable.Average(source);
+
+        public static decimal? Average(this IEnumerable<decimal?> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double Average(this IEnumerable<long> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double Average(this IEnumerable<int> source) =>
+            LinqEnumerable.Average(source);
+
+        public static double Average(this IEnumerable<double> source) =>
+            LinqEnumerable.Average(source);
+
+        public static float Average(this IEnumerable<float> source) =>
+            LinqEnumerable.Average(source);
+
+        public static decimal Average(this IEnumerable<decimal> source) =>
+            LinqEnumerable.Average(source);
+
+        public static IEnumerable<TResult> Cast<TResult>(this IEnumerable source) =>
+            LinqEnumerable.Cast<TResult>(source);
+
+        public static IEnumerable<TSource> Concat<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
+            LinqEnumerable.Concat(first, second);
+
+        public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value) =>
+            LinqEnumerable.Contains(source, value);
+
+        public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.Contains(source, value, comparer);
+
+        public static int Count<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.Count(source, predicate);
+
+        public static int Count<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Count(source);
+
+        public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.DefaultIfEmpty(source);
+
+        public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue) =>
+            LinqEnumerable.DefaultIfEmpty(source, defaultValue);
+
+        public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Distinct(source);
+
+        public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.Distinct(source, comparer);
+
+        public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, int index) =>
+            LinqEnumerable.ElementAt(source, index);
+
+        public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index) =>
+            LinqEnumerable.ElementAtOrDefault(source, index);
+
+        public static IEnumerable<TResult> Empty<TResult>() =>
+            LinqEnumerable.Empty<TResult>();
+
+        public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
+            LinqEnumerable.Except(first, second);
+
+        public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.Except(first, second, comparer);
+
+        public static TSource First<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.First(source);
+
+        public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.First(source, predicate);
+
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.FirstOrDefault(source);
+
+        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.FirstOrDefault(source, predicate);
+
+        public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.GroupBy(source, keySelector, resultSelector, comparer);
+
+        public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector) =>
+            LinqEnumerable.GroupBy(source, keySelector, resultSelector);
+
+        public static IEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.GroupBy(source, keySelector, elementSelector, comparer);
+
+        public static IEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector) =>
+            LinqEnumerable.GroupBy(source, keySelector, elementSelector, resultSelector);
+
+        public static IEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.GroupBy(source, keySelector, comparer);
+
+        public static IEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.GroupBy(source, keySelector);
+
+        public static IEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+            LinqEnumerable.GroupBy(source, keySelector, elementSelector);
+
+        public static IEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.GroupBy(source, keySelector, elementSelector, resultSelector, comparer);
+
+        public static IEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) =>
+            LinqEnumerable.GroupJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
+
+        public static IEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.GroupJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+
+        public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
+            LinqEnumerable.Intersect(first, second);
+
+        public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.Intersect(first, second, comparer);
+
+        public static IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector) =>
+            LinqEnumerable.Join(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
+
+        public static IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.Join(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
+
+        public static TSource Last<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Last(source);
+
+        public static TSource Last<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.Last(source, predicate);
+
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.LastOrDefault(source);
+
+        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.LastOrDefault(source, predicate);
+
+        public static long LongCount<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.LongCount(source);
+
+        public static long LongCount<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.LongCount(source, predicate);
+
+        public static double Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static int Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static long Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static decimal? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static decimal Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static int? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static long? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static float? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static TResult Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static double? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static TSource Max<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Max(source);
+
+        public static float Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) =>
+            LinqEnumerable.Max(source, selector);
+
+        public static float? Max(this IEnumerable<float?> source) =>
+            LinqEnumerable.Max(source);
+
+        public static long? Max(this IEnumerable<long?> source) =>
+            LinqEnumerable.Max(source);
+
+        public static int? Max(this IEnumerable<int?> source) =>
+            LinqEnumerable.Max(source);
+
+        public static double? Max(this IEnumerable<double?> source) =>
+            LinqEnumerable.Max(source);
+
+        public static decimal? Max(this IEnumerable<decimal?> source) =>
+            LinqEnumerable.Max(source);
+
+        public static long Max(this IEnumerable<long> source) =>
+            LinqEnumerable.Max(source);
+
+        public static int Max(this IEnumerable<int> source) =>
+            LinqEnumerable.Max(source);
+
+        public static double Max(this IEnumerable<double> source) =>
+            LinqEnumerable.Max(source);
+
+        public static decimal Max(this IEnumerable<decimal> source) =>
+            LinqEnumerable.Max(source);
+
+        public static float Max(this IEnumerable<float> source) =>
+            LinqEnumerable.Max(source);
+
+        public static int Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static long Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static decimal? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static TResult Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static float? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static float Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static decimal Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static TSource Min<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Min(source);
+
+        public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) =>
+            LinqEnumerable.Min(source, selector);
+
+        public static float? Min(this IEnumerable<float?> source) =>
+            LinqEnumerable.Min(source);
+
+        public static long? Min(this IEnumerable<long?> source) =>
+            LinqEnumerable.Min(source);
+
+        public static int? Min(this IEnumerable<int?> source) =>
+            LinqEnumerable.Min(source);
+
+        public static double? Min(this IEnumerable<double?> source) =>
+            LinqEnumerable.Min(source);
+
+        public static decimal? Min(this IEnumerable<decimal?> source) =>
+            LinqEnumerable.Min(source);
+
+        public static long Min(this IEnumerable<long> source) =>
+            LinqEnumerable.Min(source);
+
+        public static int Min(this IEnumerable<int> source) =>
+            LinqEnumerable.Min(source);
+
+        public static double Min(this IEnumerable<double> source) =>
+            LinqEnumerable.Min(source);
+
+        public static decimal Min(this IEnumerable<decimal> source) =>
+            LinqEnumerable.Min(source);
+
+        public static float Min(this IEnumerable<float> source) =>
+            LinqEnumerable.Min(source);
+
+        public static IEnumerable<TResult> OfType<TResult>(this IEnumerable source) =>
+            LinqEnumerable.OfType<TResult>(source);
+
+        public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer) =>
+            LinqEnumerable.OrderBy(source, keySelector, comparer);
+
+        public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.OrderBy(source, keySelector);
+
+        public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.OrderByDescending(source, keySelector);
+
+        public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer) =>
+            LinqEnumerable.OrderByDescending(source, keySelector, comparer);
+
+        public static IEnumerable<int> Range(int start, int count) =>
+            LinqEnumerable.Range(start, count);
+
+        public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count) =>
+            LinqEnumerable.Repeat(element, count);
+
+        public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Reverse(source);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
+            LinqEnumerable.Select(source, selector);
+
+        public static IEnumerable<TResult> Select<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, TResult> selector) =>
+            LinqEnumerable.Select(source, selector);
+
+        public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) =>
+            LinqEnumerable.SelectMany(source, collectionSelector, resultSelector);
+
+        public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector) =>
+            LinqEnumerable.SelectMany(source, selector);
+
+        public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TResult>> selector) =>
+            LinqEnumerable.SelectMany(source, selector);
+
+        public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) =>
+            LinqEnumerable.SelectMany(source, collectionSelector, resultSelector);
+
+        public static bool SequenceEqual<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.SequenceEqual(first, second, comparer);
+
+        public static bool SequenceEqual<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
+            LinqEnumerable.SequenceEqual(first, second);
+
+        public static TSource Single<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.Single(source);
+
+        public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.Single(source, predicate);
+
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.SingleOrDefault(source);
+
+        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.SingleOrDefault(source, predicate);
+
+        public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count) =>
+            LinqEnumerable.Skip(source, count);
+
+        public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.SkipWhile(source, predicate);
+
+        public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate) =>
+            LinqEnumerable.SkipWhile(source, predicate);
+
+        public static int? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static int Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static long Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static decimal? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static float Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static float? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static double Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static long? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static decimal Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static double? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
+            LinqEnumerable.Sum(source, selector);
+
+        public static float? Sum(this IEnumerable<float?> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static long? Sum(this IEnumerable<long?> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static int? Sum(this IEnumerable<int?> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static double? Sum(this IEnumerable<double?> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static decimal? Sum(this IEnumerable<decimal?> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static float Sum(this IEnumerable<float> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static long Sum(this IEnumerable<long> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static int Sum(this IEnumerable<int> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static double Sum(this IEnumerable<double> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static decimal Sum(this IEnumerable<decimal> source) =>
+            LinqEnumerable.Sum(source);
+
+        public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count) =>
+            LinqEnumerable.Take(source, count);
+
+        public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.TakeWhile(source, predicate);
+
+        public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate) =>
+            LinqEnumerable.TakeWhile(source, predicate);
+
+        public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer) =>
+            LinqEnumerable.ThenBy(source, keySelector, comparer);
+
+        public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.ThenBy(source, keySelector);
+
+        public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.ThenByDescending(source, keySelector);
+
+        public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer) =>
+            LinqEnumerable.ThenByDescending(source, keySelector, comparer);
+
+        public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.ToArray(source);
+
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.ToDictionary(source, keySelector);
+
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.ToDictionary(source, keySelector, comparer);
+
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+            LinqEnumerable.ToDictionary(source, keySelector, elementSelector);
+
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.ToDictionary(source, keySelector, elementSelector, comparer);
+
+        public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source) =>
+            LinqEnumerable.ToList(source);
+
+        public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+            LinqEnumerable.ToLookup(source, keySelector);
+
+        public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.ToLookup(source, keySelector, comparer);
+
+        public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+            LinqEnumerable.ToLookup(source, keySelector, elementSelector);
+
+        public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+            LinqEnumerable.ToLookup(source, keySelector, elementSelector, comparer);
+
+        public static IEnumerable<TSource> Union<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
+            LinqEnumerable.Union(first, second);
+
+        public static IEnumerable<TSource> Union<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer) =>
+            LinqEnumerable.Union(first, second, comparer);
+
+        public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate) =>
+            LinqEnumerable.Where(source, predicate);
+
+        public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+            LinqEnumerable.Where(source, predicate);
+
+        public static IEnumerable<TResult> Zip<TFirst, TSecond, TResult>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector) =>
+            LinqEnumerable.Zip(first, second, resultSelector);
+    }
+}

--- a/MoreLinq.Test/ExactlyTest.cs
+++ b/MoreLinq.Test/ExactlyTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class ExactlyTest
@@ -33,13 +32,13 @@ namespace MoreLinq.Test
         [Test]
         public void ExactlyWithEmptySequenceHasExactlyZeroElements()
         {
-            Assert.IsTrue(LinqEnumerable.Empty<int>().Exactly(0));
+            Assert.IsTrue(Enumerable.Empty<int>().Exactly(0));
         }
 
         [Test]
         public void ExactlyWithEmptySequenceHasExactlyOneElement()
         {
-            Assert.IsFalse(LinqEnumerable.Empty<int>().Exactly(1));
+            Assert.IsFalse(Enumerable.Empty<int>().Exactly(1));
         }
 
         [Test]

--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -17,9 +17,7 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class FallbackIfEmptyTest
@@ -27,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void FallbackIfEmptyWithEmptySequence()
         {
-            var source = LinqEnumerable.Empty<int>().Select(x => x);
+            var source = Enumerable.Empty<int>().Select(x => x);
             // ReSharper disable PossibleMultipleEnumeration
             source.FallbackIfEmpty(12).AssertSequenceEqual(12);
             source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
@@ -63,7 +61,7 @@ namespace MoreLinq.Test
 
         public void FallbackIfEmptyWithEmptySequenceCollectionOptimized()
         {
-            var source = LinqEnumerable.Empty<int>();
+            var source = Enumerable.Empty<int>();
             // ReSharper disable PossibleMultipleEnumeration
             source.FallbackIfEmpty(12).AssertSequenceEqual(12);
             source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);

--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/FillForwardTest.cs
+++ b/MoreLinq.Test/FillForwardTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using System.Text.RegularExpressions;
     using NUnit.Framework;
 

--- a/MoreLinq.Test/FoldTest.cs
+++ b/MoreLinq.Test/FoldTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/FromTest.cs
+++ b/MoreLinq.Test/FromTest.cs
@@ -19,7 +19,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     class FromTest

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -19,7 +19,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
     using static FullGroupJoinTest.OverloadCase;
 

--- a/MoreLinq.Test/GenerateTest.cs
+++ b/MoreLinq.Test/GenerateTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/GroupAdjacentTest.cs
+++ b/MoreLinq.Test/GroupAdjacentTest.cs
@@ -19,7 +19,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]
@@ -203,7 +202,7 @@ namespace MoreLinq.Test
             }
         }
 
-        static void AssertGrouping<TKey, TElement>(SequenceReader<IGrouping<TKey, TElement>> reader, 
+        static void AssertGrouping<TKey, TElement>(SequenceReader<System.Linq.IGrouping<TKey, TElement>> reader, 
             TKey key, params TElement[] elements)
         {
             var grouping = reader.Read();

--- a/MoreLinq.Test/IncrementalTest.cs
+++ b/MoreLinq.Test/IncrementalTest.cs
@@ -3,7 +3,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -46,6 +46,7 @@
       <Compile Include="Combinatorics.cs" />
       <Compile Include="Comparer.cs" />
       <Compile Include="CurrentThreadCultureScope.cs" />
+      <Compile Include="Enumerable.cs" />
       <Compile Include="EqualityComparer.cs" />
       <Compile Include="KeyValuePair.cs" />
       <Compile Include="Program.cs" />

--- a/MoreLinq.Test/MoveTest.cs
+++ b/MoreLinq.Test/MoveTest.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    // TODO remove System.Linq import when #352 is merged
-    // https://github.com/morelinq/MoreLINQ/pull/352
-
-    using System.Linq;
     using System.Collections.Generic;
     using NUnit.Framework;
 

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -21,7 +21,6 @@ namespace MoreLinq.Test
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using NUnit.Framework;
@@ -185,9 +184,9 @@ namespace MoreLinq.Test
                 IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             }
 
-            public class OrderedEnumerable<T> : Enumerable<T>, IOrderedEnumerable<T>
+            public class OrderedEnumerable<T> : Enumerable<T>, System.Linq.IOrderedEnumerable<T>
             {
-                public IOrderedEnumerable<T> CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey> comparer, bool descending)
+                public System.Linq.IOrderedEnumerable<T> CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey> comparer, bool descending)
                 {
                     if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
                     return this;

--- a/MoreLinq.Test/OrderByTest.cs
+++ b/MoreLinq.Test/OrderByTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -19,7 +19,6 @@ namespace MoreLinq.Test
 {
     using NUnit.Framework;
     using System;
-    using System.Linq;
     using System.Collections.Generic;
 
     [TestFixture]

--- a/MoreLinq.Test/PartialSortByTest.cs
+++ b/MoreLinq.Test/PartialSortByTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/PartitionTest.cs
+++ b/MoreLinq.Test/PartitionTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
     using Tuple = System.ValueTuple;
 

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/PipeTest.cs
+++ b/MoreLinq.Test/PipeTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
     using NUnit.Framework;
 

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -2,7 +2,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/RandomTest.cs
+++ b/MoreLinq.Test/RandomTest.cs
@@ -2,7 +2,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/RunLengthEncodeTest.cs
+++ b/MoreLinq.Test/RunLengthEncodeTest.cs
@@ -2,7 +2,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/ScanRightTest.cs
+++ b/MoreLinq.Test/ScanRightTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/SequenceTest.cs
+++ b/MoreLinq.Test/SequenceTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/SingleOrFallbackTest.cs
+++ b/MoreLinq.Test/SingleOrFallbackTest.cs
@@ -20,9 +20,7 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class SingleOrFallbackTest
@@ -30,12 +28,12 @@ namespace MoreLinq.Test
         [Test]
         public void SingleOrFallbackWithEmptySequence()
         {
-            Assert.AreEqual(5, LinqEnumerable.Empty<int>().Select(x => x).SingleOrFallback(() => 5));
+            Assert.AreEqual(5, Enumerable.Empty<int>().Select(x => x).SingleOrFallback(() => 5));
         }
         [Test]
         public void SingleOrFallbackWithEmptySequenceIListOptimized()
         {
-            Assert.AreEqual(5, LinqEnumerable.Empty<int>().SingleOrFallback(() => 5));
+            Assert.AreEqual(5, Enumerable.Empty<int>().SingleOrFallback(() => 5));
         }
 
         [Test]

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/SkipUntilTest.cs
+++ b/MoreLinq.Test/SkipUntilTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/SliceTest.cs
+++ b/MoreLinq.Test/SliceTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -2,7 +2,6 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/SplitTest.cs
+++ b/MoreLinq.Test/SplitTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/SubsetTest.cs
+++ b/MoreLinq.Test/SubsetTest.cs
@@ -1,7 +1,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -15,10 +15,6 @@
 // limitations under the License.
 #endregion
 
-using System.Linq; // Keep this import outside the MoreLinq namespace
-                   // to avoid conflicts. For more, see:
-                   // https://github.com/morelinq/MoreLINQ/issues/351
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/TakeUntilTest.cs
+++ b/MoreLinq.Test/TakeUntilTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/ToArrayByIndexTest.cs
+++ b/MoreLinq.Test/ToArrayByIndexTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System;
-    using System.Linq;
     using NUnit.Framework;
     using NUnit.Framework.Constraints;
 

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -21,7 +21,6 @@ namespace MoreLinq.Test
     using System.Collections;
     using System.Collections.Generic;
     using System.Data;
-    using System.Linq;
     using System.Linq.Expressions;
     using NUnit.Framework;
 

--- a/MoreLinq.Test/ToDelimitedStringTest.cs
+++ b/MoreLinq.Test/ToDelimitedStringTest.cs
@@ -22,7 +22,6 @@ namespace MoreLinq.Test
 {
     using System.Globalization;
     using NUnit.Framework;
-    using LinqEnumerable = System.Linq.Enumerable;
 
     [TestFixture]
     public class ToDelimitedStringTest
@@ -30,7 +29,7 @@ namespace MoreLinq.Test
         [Test]
         public void ToDelimitedStringWithEmptySequence()
         {
-            Assert.That(LinqEnumerable.Empty<int>().ToDelimitedString(), Is.Empty);
+            Assert.That(Enumerable.Empty<int>().ToDelimitedString(), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/TraverseTest.cs
+++ b/MoreLinq.Test/TraverseTest.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/UnfoldTest.cs
+++ b/MoreLinq.Test/UnfoldTest.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     [TestFixture]

--- a/MoreLinq.Test/WindowedTest.cs
+++ b/MoreLinq.Test/WindowedTest.cs
@@ -1,6 +1,5 @@
 namespace MoreLinq.Test
 {
-    using System.Linq;
     using NUnit.Framework;
 
     /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 
     grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' (dir MoreLinq.Test\*Test.cs)
 
-    if ($LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE -eq 0) {
         throw 'Unit tests should not import System.Linq'
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,16 @@ skip_commits:
     - lic/*
 build_script:
 - ps: >-
+    iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+
+    scoop install grep
+
+    grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' (dir MoreLinq.Test\*Test.cs)
+
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Unit tests should not import System.Linq'
+    }
+
     $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''
 
     $id = $id.Substring(0, 13)


### PR DESCRIPTION
This PR addresses #351.

The strategy taken in the initial commit, 8871edb14fd7f5f1148fbde8c81b819c277c8fe8, is to have an `Enumerable` type act as a proxy for `System.Linq.Enumerable` and forwards all calls. This allows all LINQ extension methods to be used without importing `System.Linq`, which is now only done in one place (`Enumerable.cs` in the test project). It also enables a controlled way to manage conflicts by not having any of the duplicate members defined on the `Enumerable` proxy. For example, since it doesn't define and wrap [`TakeLast`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.takelast?view=netcore-2.0) that was introduced in .NET Core 2.0, we know for that the unit tests for MoreLINQ's `TakeLast` won't accidentally test the LINQ implementation (which happened in #304).

This is not a fool-proof approach because it requires being careful that no one imports `System.Linq` in a file with a test fixture. This is something that would have to be caught during PR reviews. A grep should also be quick to conduct and shouldn't reveal any other file than `MoreLinq.Test/Enumerable.cs`:

    $ egrep '^ *using +System\.Linq;' MoreLinq.Test/*.cs

An alternative approach would be to move the `System.Linq` imports in each unit test file outside the `MoreLinq.Test` namespace declaration, as was done in 88967853e005a9f20100948a70525bb33b3bc289 for #304. It's a little less involved but requires equal care during reviews.