### PR TITLE
Added additional nuget packages to enable live testing

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -22,7 +22,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
-    <StartupObject />
+    <StartupObject>MoreLinq.Test.Program</StartupObject>
     <LangVersion>7</LangVersion>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
   </PropertyGroup>
@@ -35,6 +35,8 @@
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnitLite" Version="3.6.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The _Live Unit Testing_ feature is available from Visual Studio 2017 update 15.3.

**NuGet packages added**

- _NUnit3TestAdapter_ because visual studio needs that for live testing to find the tests.
- _Microsoft.NET.Test.Sdk_ because live testing asked if it was installed - which implies it is required.

**Set the startup object explicitly in MoreLinq.Test**

- It was necessary to set the startup  object to be _MoreLinq.Test.Program_ because of additional possible start points created by one or other of the NuGet packages above.