### PR TITLE
Fix AssertCount to be lazy for collections too

### DIFF
--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -18,6 +18,7 @@
 namespace MoreLinq.Test
 {
     using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -100,6 +101,43 @@ namespace MoreLinq.Test
         public void AssertCountIsLazy()
         {
             new BreakingSequence<object>().AssertCount(0);
+        }
+
+        [Test]
+        public void AssertCountWithCollectionIsLazy()
+        {
+            new BreakingCollection<object>(5).AssertCount(0);
+        }
+
+        [Test]
+        public void AssertCountWithMatchingCollectionCount()
+        {
+            var xs = new[] { 123, 456, 789 };
+            Assert.AreSame(xs, xs.AssertCount(3));
+        }
+
+        [TestCase(3, 2, "Sequence contains too many elements when exactly 2 were expected.")]
+        [TestCase(3, 4, "Sequence contains too few elements when exactly 4 were expected.")]
+        public void AssertCountWithMismatchingCollectionCount(int sourceCount, int count, string message)
+        {
+            var xs = new int[sourceCount];
+            var enumerator = xs.AssertCount(count).GetEnumerator();
+            var e = Assert.Throws<SequenceException>(() => enumerator.MoveNext());
+            Assert.AreEqual(e.Message, message);
+        }
+
+        sealed class BreakingCollection<T> : BreakingSequence<T>, ICollection<T>
+        {
+            public BreakingCollection(int count) => Count = count;
+
+            public int Count { get; }
+
+            public void Add(T item)      => throw new NotImplementedException();
+            public void Clear()          => throw new NotImplementedException();
+            public bool Contains(T item) => throw new NotImplementedException();
+            public void CopyTo(T[] array, int arrayIndex) => throw new NotImplementedException();
+            public bool Remove(T item)   => throw new NotImplementedException();
+            public bool IsReadOnly       => throw new NotImplementedException();
         }
     }
 }

--- a/MoreLinq.Test/BreakingSequence.cs
+++ b/MoreLinq.Test/BreakingSequence.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
     /// Enumerable sequence which throws InvalidOperationException as soon as its
     /// enumerator is requested. Used to check lazy evaluation.
     /// </summary>
-    sealed class BreakingSequence<T> : IEnumerable<T>
+    class BreakingSequence<T> : IEnumerable<T>
     {
         public IEnumerator<T> GetEnumerator() => throw new InvalidOperationException();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -83,12 +83,11 @@ namespace MoreLinq
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
-            var collection = source as ICollection<TSource>; // Optimization for collections
-            if (collection != null)
+            if (source is ICollection<TSource> collection)
             {
-                if (collection.Count != count)
-                    throw errorSelector(collection.Count.CompareTo(count), count);
-                return source;
+                return collection.Count == count
+                     ? collection
+                     : From<TSource>(() => throw errorSelector(collection.Count.CompareTo(count), count));
             }
 
             return _(); IEnumerable<TSource> _()


### PR DESCRIPTION
This PR addresses #364.

If the collection count is the value to be asserted then it is returned directly. Otherwise, a sequence is returned that will throw as soon as it is enumerated.