### PR TITLE
Drop .NET Framework 3.5 target/support

### DIFF
--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -26,21 +26,19 @@ namespace MoreLinq
             Func<T, TResult> folder1 = null,
             Func<T, T, TResult> folder2 = null,
             Func<T, T, T, TResult> folder3 = null,
-            Func<T, T, T, T, TResult> folder4 = null
-            #if FUNC16
-            , Func<T, T, T, T, T, TResult> folder5 = null
-            , Func<T, T, T, T, T, T, TResult> folder6 = null
-            , Func<T, T, T, T, T, T, T, TResult> folder7 = null
-            , Func<T, T, T, T, T, T, T, T, TResult> folder8 = null
-            , Func<T, T, T, T, T, T, T, T, T, TResult> folder9 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, TResult> folder10 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder11 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder12 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder13 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder14 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder15 = null
-            , Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder16 = null
-            #endif
+            Func<T, T, T, T, TResult> folder4 = null,
+            Func<T, T, T, T, T, TResult> folder5 = null,
+            Func<T, T, T, T, T, T, TResult> folder6 = null,
+            Func<T, T, T, T, T, T, T, TResult> folder7 = null,
+            Func<T, T, T, T, T, T, T, T, TResult> folder8 = null,
+            Func<T, T, T, T, T, T, T, T, T, TResult> folder9 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, TResult> folder10 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder11 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder12 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder13 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder14 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder15 = null,
+            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder16 = null
             )
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -48,7 +46,6 @@ namespace MoreLinq
                 || count ==  2 && folder2  == null
                 || count ==  3 && folder3  == null
                 || count ==  4 && folder4  == null
-                #if FUNC16
                 || count ==  5 && folder5  == null
                 || count ==  6 && folder6  == null
                 || count ==  7 && folder7  == null
@@ -61,7 +58,6 @@ namespace MoreLinq
                 || count == 14 && folder14 == null
                 || count == 15 && folder15 == null
                 || count == 16 && folder16 == null
-                #endif
                 )
             {                                                // ReSharper disable NotResolvedInText
                 throw new ArgumentNullException("folder");   // ReSharper restore NotResolvedInText
@@ -77,7 +73,6 @@ namespace MoreLinq
                 case  2: return folder2 (elements[0], elements[1]);
                 case  3: return folder3 (elements[0], elements[1], elements[2]);
                 case  4: return folder4 (elements[0], elements[1], elements[2], elements[3]);
-                #if FUNC16
                 case  5: return folder5 (elements[0], elements[1], elements[2], elements[3], elements[4]);
                 case  6: return folder6 (elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
                 case  7: return folder7 (elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
@@ -90,7 +85,6 @@ namespace MoreLinq
                 case 14: return folder14(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
                 case 15: return folder15(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
                 case 16: return folder16(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
-                #endif
                 default: throw new NotSupportedException();
             }
         }

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -110,8 +110,6 @@ namespace MoreLinq
             return FoldImpl(source, 4, folder4: folder);
         }
 
-        #if FUNC16
-
         /// <summary>
         /// Returns the result of applying a function to a sequence of
         /// 5 elements.
@@ -376,6 +374,5 @@ namespace MoreLinq
             return FoldImpl(source, 16, folder16: folder);
         }
 
-        #endif // FUNC16
     }
 }

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -42,10 +42,6 @@ namespace MoreLinq
             };
 
         foreach (var e in overloads) { #>
-<#          if (e.Count == 5) { #>
-        #if FUNC16
-
-<# } #>
         /// <summary>
         /// Returns the result of applying a function to a sequence of
         /// <#= e.CountElements #>.
@@ -69,6 +65,5 @@ namespace MoreLinq
         }
 
 <#      } #>
-        #endif // FUNC16
     }
 }

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -24,8 +24,6 @@ namespace MoreLinq
     // Inspiration & credit: http://stackoverflow.com/a/13503860/6682
     static partial class MoreEnumerable
     {
-        #if !NO_VALUE_TUPLES
-
         /// <summary>
         /// Performs a Full Group Join between the <paramref name="first"/> and <paramref name="second"/> sequences.
         /// </summary>
@@ -80,8 +78,6 @@ namespace MoreLinq
         {
             return FullGroupJoin(first, second, firstKeySelector, secondKeySelector, ValueTuple.Create, comparer);
         }
-
-        #endif
 
         /// <summary>
         /// Performs a full group-join between two sequences.

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -8,7 +8,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>net40;net35;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0;netstandard2.0</TargetFrameworks>
     <LangVersion>7</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
@@ -44,23 +44,19 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net40' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <DefineConstants>$(DefineConstants);MORELINQ;NO_VALUE_TUPLES</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);MORELINQ;FUNC16</DefineConstants>
+    <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <DefineConstants>$(DefineConstants);MORELINQ;FUNC16;NO_SERIALIZATION_ATTRIBUTES;NO_EXCEPTION_SERIALIZATION;NO_TRACING;NO_COM</DefineConstants>
+    <DefineConstants>$(DefineConstants);MORELINQ;NO_SERIALIZATION_ATTRIBUTES;NO_EXCEPTION_SERIALIZATION;NO_TRACING;NO_COM</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -24,8 +24,6 @@ namespace MoreLinq
 
     static partial class MoreEnumerable
     {
-        #if !NO_VALUE_TUPLES
-
         /// <summary>
         /// Partitions or splits a sequence in two using a predicate.
         /// </summary>
@@ -49,8 +47,6 @@ namespace MoreLinq
         public static (IEnumerable<T> True, IEnumerable<T> False)
             Partition<T>(this IEnumerable<T> source, Func<T, bool> predicate) =>
             source.Partition(predicate, ValueTuple.Create);
-
-        #endif
 
         /// <summary>
         /// Partitions or splits a sequence in two using a predicate and then

--- a/MoreLinq/ToDictionary.cs
+++ b/MoreLinq/ToDictionary.cs
@@ -59,8 +59,6 @@ namespace MoreLinq
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);
         }
 
-        #if !NO_VALUE_TUPLES
-
         /// <summary>
         /// Creates a <see cref="Dictionary{TKey,TValue}" /> from a sequence of
         /// tuples of 2 where the first item is the key and the second the
@@ -97,7 +95,5 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);
         }
-
-        #endif
     }
 }

--- a/MoreLinq/ToLookup.cs
+++ b/MoreLinq/ToLookup.cs
@@ -59,8 +59,6 @@ namespace MoreLinq
             return source.ToLookup(e => e.Key, e => e.Value, comparer);
         }
 
-        #if !NO_VALUE_TUPLES
-
         /// <summary>
         /// Creates a <see cref="Lookup{TKey,TValue}" /> from a sequence of
         /// tuples of 2 where the first item is the key and the second the
@@ -97,7 +95,5 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.ToLookup(e => e.Key, e => e.Value, comparer);
         }
-
-        #endif
     }
 }


### PR DESCRIPTION
This PR addresses #329.

Gone are also the `FUNC16` and `NO_VALUE_TUPLES` conditional symbols.
