### PR TITLE
Remove delimiter-less ToDelimitedString overloads

### DIFF
--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -122,7 +122,6 @@ namespace MoreLinq.Test
                 #if NET451 || NETCOREAPP2_0
                 nameof(MoreEnumerable.ToDataTable) + ".expressions",
                 #endif
-                nameof(MoreEnumerable.ToDelimitedString) + ".delimiter",
                 nameof(MoreEnumerable.Trace) + ".format"
             };
 

--- a/MoreLinq.Test/ToDelimitedStringTest.cs
+++ b/MoreLinq.Test/ToDelimitedStringTest.cs
@@ -15,52 +15,18 @@
 // limitations under the License.
 #endregion
 
-#pragma warning disable 612 // 'ToDelimitedString' is obsolete
-
-
 namespace MoreLinq.Test
 {
-    using System.Globalization;
     using NUnit.Framework;
 
     [TestFixture]
     public class ToDelimitedStringTest
     {
         [Test]
-        public void ToDelimitedStringWithEmptySequence()
-        {
-            Assert.That(Enumerable.Empty<int>().ToDelimitedString(), Is.Empty);
-        }
-
-        [Test]
         public void ToDelimitedStringWithNonEmptySequenceAndDelimiter()
         {
             var result = new[] { 1, 2, 3 }.ToDelimitedString("-");
             Assert.That(result, Is.EqualTo("1-2-3"));
-        }
-
-        [Test]
-        public void ToDelimitedStringWithNonEmptySequenceAndDefaultDelimiter()
-        {
-            using (new CurrentThreadCultureScope(new CultureInfo("fr-FR")))
-            {
-                var xs = new[] { 1, 2, 3 };
-                var result = xs.ToDelimitedString();
-                var separator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
-                Assert.That(result, Is.EqualTo(string.Join(separator, xs)));
-            }
-        }
-
-        [Test]
-        public void ToDelimitedStringWithNonEmptySequenceAndNullDelimiter()
-        {
-            using (new CurrentThreadCultureScope(new CultureInfo("fr-FR")))
-            {
-                var xs = new[] { 1, 2, 3 };
-                var result = xs.ToDelimitedString(null);
-                var separator = CultureInfo.CurrentCulture.TextInfo.ListSeparator;
-                Assert.That(result, Is.EqualTo(string.Join(separator, xs)));
-            }
         }
 
         [Test]

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -26,36 +26,13 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <typeparam name="TSource">Type of element in the source sequence</typeparam>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        /// <summary>
         /// Creates a delimited string from a sequence of values and
         /// a given delimiter.
         /// </summary>
         /// <typeparam name="TSource">Type of element in the source sequence</typeparam>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -68,15 +45,16 @@ namespace MoreLinq
         public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
         }
 
         static string ToDelimitedStringImpl<T>(IEnumerable<T> source, string delimiter, Func<StringBuilder, T, StringBuilder> append)
         {
             Debug.Assert(source != null);
+            Debug.Assert(delimiter != null);
             Debug.Assert(append != null);
 
-            delimiter = delimiter ?? CultureInfo.CurrentCulture.TextInfo.ListSeparator;
             var sb = new StringBuilder();
             var i = 0;
 

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -38,6 +38,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -46,6 +46,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -74,6 +77,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -102,6 +108,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -130,6 +139,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -158,6 +170,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -186,6 +201,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -214,6 +232,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -242,6 +263,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -270,6 +294,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -298,6 +325,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -326,6 +356,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -354,6 +387,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -382,6 +418,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
@@ -410,6 +449,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -35,24 +35,26 @@ namespace MoreLinq
     partial class MoreEnumerable
     {
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
+        /// Creates a delimited string from a sequence of values and
+        /// a given delimiter.
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
+        /// delimited by <paramref name="delimiter"/>. If the source sequence
+        /// is empty, the method returns an empty string.
         /// </returns>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<bool> source)
+        public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
         {
-            return ToDelimitedString(source, null);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
         }
 
         static partial class StringBuilderAppenders
@@ -66,8 +68,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -77,31 +78,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<byte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<byte> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Byte);
         }
 
         static partial class StringBuilderAppenders
@@ -115,8 +96,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -126,31 +106,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<byte> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<char> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Byte);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<char> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Char);
         }
 
         static partial class StringBuilderAppenders
@@ -164,8 +124,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -175,31 +134,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<char> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Char);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<decimal> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
         }
 
         static partial class StringBuilderAppenders
@@ -213,8 +152,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -224,31 +162,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<double> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
         }
 
         static partial class StringBuilderAppenders
@@ -262,8 +180,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -273,31 +190,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<float> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
         }
 
         static partial class StringBuilderAppenders
@@ -311,8 +208,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -322,31 +218,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<int> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<int> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int32);
         }
 
         static partial class StringBuilderAppenders
@@ -360,8 +236,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -371,31 +246,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<int> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<long> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int32);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<long> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int64);
         }
 
         static partial class StringBuilderAppenders
@@ -409,8 +264,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -419,32 +273,12 @@ namespace MoreLinq
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
-
-        public static string ToDelimitedString(this IEnumerable<long> source, string delimiter)
+        [CLSCompliant(false)]
+        public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int64);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        [CLSCompliant(false)]
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<sbyte> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
         }
 
         static partial class StringBuilderAppenders
@@ -458,8 +292,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -468,32 +301,12 @@ namespace MoreLinq
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
-        [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
+
+        public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<short> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
         }
 
         static partial class StringBuilderAppenders
@@ -507,8 +320,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -518,31 +330,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
 
-        public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<string> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
         }
 
         static partial class StringBuilderAppenders
@@ -556,8 +348,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -566,32 +357,12 @@ namespace MoreLinq
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
-
-        public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
+        [CLSCompliant(false)]
+        public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        [CLSCompliant(false)]
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<uint> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
         }
 
         static partial class StringBuilderAppenders
@@ -605,8 +376,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -616,31 +386,11 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>
         [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
+        public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        [CLSCompliant(false)]
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<ulong> source)
-        {
-            return ToDelimitedString(source, null);
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
         }
 
         static partial class StringBuilderAppenders
@@ -654,57 +404,7 @@ namespace MoreLinq
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <paramref name="delimiter"/>. If the source sequence
-        /// is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        [CLSCompliant(false)]
-        public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
-        {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-        [CLSCompliant(false)]
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<ushort> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, ushort, StringBuilder> UInt16 = (sb, e) => sb.Append(e);
-        }
-
-        /// <summary>
-        /// Creates a delimited string from a sequence of values and
-        /// a given delimiter.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -717,7 +417,13 @@ namespace MoreLinq
         public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);
+        }
+
+        static partial class StringBuilderAppenders
+        {
+            public static readonly Func<StringBuilder, ushort, StringBuilder> UInt16 = (sb, e) => sb.Append(e);
         }
 
 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -83,6 +83,9 @@ namespace MoreLinq
         /// delimited by <paramref name="delimiter"/>. If the source sequence
         /// is empty, the method returns an empty string.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/> or <paramref name="delimiter"/> is <c>null</c>.
+        /// </exception>
         /// <remarks>
         /// This operator uses immediate execution and effectively buffers the sequence.
         /// </remarks>

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -72,39 +72,12 @@ namespace MoreLinq
             }
         #>
         /// <summary>
-        /// Creates a delimited string from a sequence of values. The
-        /// delimiter used depends on the current culture of the executing thread.
-        /// </summary>
-        /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
-        /// simple ToString() conversion.</param>
-        /// <returns>
-        /// A string that consists of the elements in <paramref name="source"/>
-        /// delimited by <see cref="TextInfo.ListSeparator"/>. If the source
-        /// sequence is empty, the method returns an empty string.
-        /// </returns>
-        /// <remarks>
-        /// This operator uses immediate execution and effectively buffers the sequence.
-        /// </remarks>
-<#= attribute #>
-        [Obsolete]
-        public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source)
-        {
-            return ToDelimitedString(source, null);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, <#= type.Name #>, StringBuilder> <#= type.Type.Name #> = (sb, e) => sb.Append(e);
-        }
-
-        /// <summary>
         /// Creates a delimited string from a sequence of values and
         /// a given delimiter.
         /// </summary>
         /// <param name="source">The sequence of items to delimit. Each is converted to a string using the
         /// simple ToString() conversion.</param>
-        /// <param name="delimiter">The delimiter to inject between elements. May be null, in which case
-        /// the executing thread's current culture's list separator is used.</param>
+        /// <param name="delimiter">The delimiter to inject between elements.</param>
         /// <returns>
         /// A string that consists of the elements in <paramref name="source"/>
         /// delimited by <paramref name="delimiter"/>. If the source sequence
@@ -117,7 +90,13 @@ namespace MoreLinq
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, string delimiter)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
+            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
             return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.<#= type.Type.Name #>);
+        }
+
+        static partial class StringBuilderAppenders
+        {
+            public static readonly Func<StringBuilder, <#= type.Name #>, StringBuilder> <#= type.Type.Name #> = (sb, e) => sb.Append(e);
         }
 
 <#      } #>


### PR DESCRIPTION
This PR addresses #229.

The overloads have been obsolete since [version 2.1](https://github.com/morelinq/MoreLINQ/releases/tag/v2.1.0).
