### PR TITLE
WIP ToDataReader method

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -59,6 +59,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <Compile Remove="TraceTest.cs" />
+    <Compile Remove="ToDataReaderTest.cs" />
     <Compile Remove="ToDataTableTest.cs" />
   </ItemGroup>
 

--- a/MoreLinq.Test/ToDataReaderTest.cs
+++ b/MoreLinq.Test/ToDataReaderTest.cs
@@ -1,0 +1,103 @@
+namespace MoreLinq.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ToDataReaderTest
+    {
+        class TestObject
+        {
+            public int KeyField;
+            public Guid? ANullableGuidField;
+
+            public string AString { get; }
+            public decimal? ANullableDecimal { get; }
+
+            public object this[int index]
+            {
+                get => new object();
+                set { }
+            }
+
+
+            public TestObject(int key)
+            {
+                KeyField = key;
+                ANullableGuidField = Guid.NewGuid();
+
+                ANullableDecimal = key / 3;
+                AString = "ABCDEFGHIKKLMNOPQRSTUVWXYSZ";
+            }
+        }
+
+        readonly IReadOnlyCollection<TestObject> _testObjects;
+
+        public ToDataReaderTest()
+        {
+            _testObjects = Enumerable.Range(0, 3)
+                                     .Select(i => new TestObject(i))
+                                     .ToArray();
+        }
+
+        [Test]
+        public void ToDataReaderSchemaInDeclarationOrder()
+        {
+            var dr = _testObjects.ToDataReader();
+
+            // Assert properties first, then fields, then in declaration order
+
+            Assert.AreEqual("AString", dr.GetName(0));
+            Assert.AreEqual(typeof(string), dr.GetFieldType(0));
+
+            Assert.AreEqual("ANullableDecimal", dr.GetName(1));
+            Assert.AreEqual(typeof(decimal?), dr.GetFieldType(1));
+
+            Assert.AreEqual("KeyField", dr.GetName(2));
+            Assert.AreEqual(typeof(int), dr.GetFieldType(2));
+
+            Assert.AreEqual("ANullableGuidField", dr.GetName(3));
+            Assert.AreEqual(typeof(Guid?), dr.GetFieldType(3));
+
+            Assert.AreEqual(4, dr.FieldCount);
+        }
+
+        [Test]
+        public void ToDataReaderHasValues()
+        {
+            var dr = _testObjects.ToDataReader();
+
+            var count = 0;
+            while (dr.Read())
+            {
+                var expectedItem = _testObjects.ElementAt(count);
+
+                Assert.AreEqual(expectedItem.AString, dr.GetValue(0));
+                Assert.AreEqual(expectedItem.ANullableDecimal, dr.GetValue(1));
+                Assert.AreEqual(expectedItem.KeyField, dr.GetValue(2));
+                Assert.AreEqual(expectedItem.ANullableGuidField, dr.GetValue(3));
+                count++;
+            }
+
+            Assert.AreEqual(3, count);
+        }
+
+        struct Point
+        {
+            public static Point Empty = new Point();
+            public bool IsEmpty => X == 0 && Y == 0;
+            public int X { get; }
+            public int Y { get; }
+            public Point(int x, int y) : this() { X = x; Y = y; }
+        }
+
+        [Test]
+        public void ToDataReaderIgnoresStaticMembers()
+        {
+            var points = new[] { new Point(12, 34) }.ToDataReader();
+
+            Assert.AreEqual(3, points.FieldCount);
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -64,6 +64,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <Compile Remove="ToDataReader.cs" />
     <Compile Remove="ToDataTable.cs" />
   </ItemGroup>
 

--- a/MoreLinq/ToDataReader.cs
+++ b/MoreLinq/ToDataReader.cs
@@ -1,0 +1,235 @@
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
+    using System.Reflection;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static IDataReader ToDataReader<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return new ReflectedDataReader<TSource>(source);
+        }
+
+        private class ReflectedDataReader<TSource> : IDataReader
+        {
+            private readonly IEnumerator<TSource> _enumerator;
+            private readonly PropertyInfo[] _properties;
+            private readonly FieldInfo[] _fields;
+            private readonly string[] _names;
+            private readonly Dictionary<string, int> _ordinals;
+            private readonly Type[] _types;
+
+            public ReflectedDataReader(IEnumerable<TSource> source)
+            {
+                _enumerator = source.GetEnumerator();
+
+                _properties = typeof(TSource).GetProperties().
+                    Where(x => !x.GetIndexParameters().Any()).
+                    ToArray();
+                _fields = typeof(TSource).GetFields().
+                    Where(x => !x.IsStatic).
+                    ToArray();
+
+                _names = _properties.Select(x => x.Name).
+                    Concat(_fields.Select(x => x.Name)).
+                    ToArray();
+                _ordinals = _names
+                    .Select((name, index) => new { name, index })
+                    .ToDictionary(x => x.name, x => x.index);
+
+                _types = _properties.Select(x => x.PropertyType).
+                    Concat(_fields.Select(x => x.FieldType)).
+                    ToArray();
+            }
+
+            public int FieldCount => _properties.Length + _fields.Length;
+
+            public string GetName(int i) => _names[i];
+
+            public int GetOrdinal(string name) => _ordinals[name];
+
+            public object GetValue(int i)
+            {
+                if (i < 0 || i >= FieldCount)
+                    throw new ArgumentOutOfRangeException(nameof(i));
+
+                var current = _enumerator.Current;
+                if (i < _properties.Length)
+                {
+                    return _properties[i].GetValue(current, null);
+                }
+                return _fields[i - _properties.Length].GetValue(current);
+            }
+
+            public Type GetFieldType(int i) => _types[i];
+
+            public bool Read() => _enumerator.MoveNext();
+
+            #region Unimplemented
+
+            public object this[int i] => throw new NotImplementedException();
+
+            public object this[string name] => throw new NotImplementedException();
+
+            public int Depth => throw new NotImplementedException();
+
+            public bool IsClosed => throw new NotImplementedException();
+
+            public int RecordsAffected => throw new NotImplementedException();
+
+            public void Close()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool GetBoolean(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte GetByte(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public char GetChar(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDataReader GetData(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetDataTypeName(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public DateTime GetDateTime(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public decimal GetDecimal(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public double GetDouble(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public float GetFloat(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Guid GetGuid(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public short GetInt16(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetInt32(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long GetInt64(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public DataTable GetSchemaTable()
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetString(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetValues(object[] values)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsDBNull(int i)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool NextResult()
+            {
+                throw new NotImplementedException();
+            }
+
+            #endregion
+
+            #region IDisposable Support
+            private bool disposedValue = false; // To detect redundant calls
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposedValue)
+                {
+                    if (disposing)
+                    {
+                        // TODO: dispose managed state (managed objects).
+                        _enumerator.Dispose();
+                    }
+
+                    // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                    // TODO: set large fields to null.
+
+                    disposedValue = true;
+                }
+            }
+
+            // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+            // ~ReflectedDataReader() {
+            //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            //   Dispose(false);
+            // }
+
+            // This code added to correctly implement the disposable pattern.
+            public void Dispose()
+            {
+                // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+                Dispose(true);
+                // TODO: uncomment the following line if the finalizer is overridden above.
+                // GC.SuppressFinalize(this);
+            }
+            #endregion
+        }
+    }
+}


### PR DESCRIPTION
This method converts an `IEnumerable<TSource>` to an `IDataReader`. I use something like this to give data to `SqlBulkCopy`, and I thought it would fit nicely in MoreLINQ.

This blog post was the inspiration for this method: http://www.michaelbowersox.com/2011/12/22/using-a-custom-idatareader-to-stream-data-into-a-database/

I left a lot of the `IDataReader` methods unimplemented because they are necessary for usage with `SqlBulkCopy`.