### PR TITLE
optimize FallbackIfEmpty for IReadOnlyCollection

### DIFF
--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -36,10 +37,13 @@ namespace MoreLinq.Test
             // ReSharper restore PossibleMultipleEnumeration
         }
 
-        [Test]
-        public void FallbackIfEmptyPreservesSourceCollectionIfPossible()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void FallbackIfEmptyPreservesSourceCollectionIfPossible(bool readOnly)
         {
-            var source = new[] { 1 };
+            var source = readOnly
+                            ? new UnenumerableReadOnlyList<int>(new[] { 1 })
+                            : (IEnumerable<int>)new UnenumerableList<int> { 1 };
             // ReSharper disable PossibleMultipleEnumeration
             Assert.AreSame(source.FallbackIfEmpty(12), source);
             Assert.AreSame(source.FallbackIfEmpty(12, 23), source);
@@ -50,26 +54,16 @@ namespace MoreLinq.Test
             // ReSharper restore PossibleMultipleEnumeration
         }
 
-        [Test]
-        public void FallbackIfEmptyPreservesFallbackCollectionIfPossible()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void FallbackIfEmptyPreservesFallbackCollectionIfPossible(bool readOnly)
         {
-            var source = new int[0];
+            var source = readOnly
+                            ? new UnenumerableReadOnlyList<int>(new int[0])
+                            : (IEnumerable<int>)new UnenumerableList<int>();
             var fallback = new[] { 1 };
             Assert.AreSame(source.FallbackIfEmpty(fallback), fallback);
             Assert.AreSame(source.FallbackIfEmpty(fallback.AsEnumerable()), fallback);
-        }
-
-        public void FallbackIfEmptyWithEmptySequenceCollectionOptimized()
-        {
-            var source = Enumerable.Empty<int>();
-            // ReSharper disable PossibleMultipleEnumeration
-            source.FallbackIfEmpty(12).AssertSequenceEqual(12);
-            source.FallbackIfEmpty(12, 23).AssertSequenceEqual(12, 23);
-            source.FallbackIfEmpty(12, 23, 34).AssertSequenceEqual(12, 23, 34);
-            source.FallbackIfEmpty(12, 23, 34, 45).AssertSequenceEqual(12, 23, 34, 45);
-            source.FallbackIfEmpty(12, 23, 34, 45, 56).AssertSequenceEqual(12, 23, 34, 45, 56);
-            source.FallbackIfEmpty(12, 23, 34, 45, 56, 67).AssertSequenceEqual(12, 23, 34, 45, 56, 67);
-            // ReSharper restore PossibleMultipleEnumeration
         }
     }
 }

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -163,14 +163,12 @@ namespace MoreLinq
         {
             if (source is ICollection<T> collection)
             {
-                if (collection.Count == 0)
-                {
-                    return Fallback();
-                }
-                else
-                {
-                    return collection;
-                }
+                return collection.Count == 0 ? Fallback() : collection;
+            }
+
+            if (source is IReadOnlyCollection<T> readOnlyCollection)
+            {
+                return readOnlyCollection.Count == 0 ? Fallback() : readOnlyCollection;
             }
 
             return _();


### PR DESCRIPTION
The tests here, as in #383, use `I(ReadOnly)List` in their collections despite being optimized at the collection level more generally. If that is a problem, I can update them both (though this was already a problem when using simple arrays for test parameters).