### PR TITLE
Upgrade to C# 7.1

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -15,7 +15,7 @@
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject>MoreLinq.Test.Program</StartupObject>
-    <LangVersion>7</LangVersion>
+    <LangVersion>7.1</LangVersion>
     <WarningsNotAsErrors>618</WarningsNotAsErrors>
   </PropertyGroup>
 

--- a/MoreLinq.Test/SequenceReader.cs
+++ b/MoreLinq.Test/SequenceReader.cs
@@ -77,7 +77,7 @@ namespace MoreLinq.Test
         {
             EnsureNotDisposed();
 
-            value = default(T);
+            value = default;
 
             var e = _enumerator;
             if (!e.MoveNext())
@@ -91,7 +91,7 @@ namespace MoreLinq.Test
         /// Tires to read the next value otherwise return the default.
         /// </summary>
 
-        public T TryRead() => TryRead(default(T));
+        public T TryRead() => TryRead(default);
 
         /// <summary>
         /// Tires to read the next value otherwise return a given default.

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -170,8 +170,8 @@ namespace MoreLinq
                                              && ((e4 == null || e4.MoveNext())))
                     {
                         yield return resultSelector(e1.Current, e2.Current,
-                                                    e3 != null ? e3.Current : default(T3),
-                                                    e4 != null ? e4.Current : default(T4));
+                                                    e3 != null ? e3.Current : default,
+                                                    e4 != null ? e4.Current : default);
                     }
                     else
                     {

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -45,7 +45,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 1, fallback, default(T), default(T), default(T), null);
+            return FallbackIfEmptyImpl(source, 1, fallback, default, default, default, null);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 2, fallback1, fallback2, default(T), default(T), null);
+            return FallbackIfEmptyImpl(source, 2, fallback1, fallback2, default, default, null);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2, T fallback3)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 3, fallback1, fallback2, fallback3, default(T), null);
+            return FallbackIfEmptyImpl(source, 3, fallback1, fallback2, fallback3, default, null);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
-            return FallbackIfEmptyImpl(source, null, default(T), default(T), default(T), default(T), fallback);
+            return FallbackIfEmptyImpl(source, null, default, default, default, default, fallback);
         }
 
         static IEnumerable<T> FallbackIfEmptyImpl<T>(IEnumerable<T> source,

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -114,7 +114,7 @@ namespace MoreLinq
                                 switch (imbalanceStrategy)
                                 {
                                     case ImbalancedInterleaveStrategy.Pad:
-                                        var newIter = iteratorList[index] = Generate(default(T), x => default(T)).GetEnumerator();
+                                        var newIter = iteratorList[index] = Generate(default(T), x => default).GetEnumerator();
                                         newIter.MoveNext();
                                         break;
 

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -38,7 +38,7 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
         {
-            return Lag(source, offset, default(TSource), resultSelector);
+            return Lag(source, offset, default, resultSelector);
         }
 
         /// <summary>

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -39,7 +39,7 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
         {
-            return Lead(source, offset, default(TSource), resultSelector);
+            return Lead(source, offset, default, resultSelector);
         }
 
         /// <summary>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -9,7 +9,7 @@
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
     <TargetFrameworks>net451;netstandard1.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>7</LangVersion>
+    <LangVersion>7.1</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -111,7 +111,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-            return PadImpl(source, width, default(TSource), paddingSelector);
+            return PadImpl(source, width, default, paddingSelector);
         }
 
         static IEnumerable<T> PadImpl<T>(IEnumerable<T> source,

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -110,7 +110,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-            return PadLeftImpl(source, width, default(TSource), paddingSelector);
+            return PadLeftImpl(source, width, default, paddingSelector);
         }
 
         static IEnumerable<T> PadLeftImpl<T>(IEnumerable<T> source,

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -178,7 +178,7 @@ namespace MoreLinq
             Func<IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return PartitionImpl(source, 1, key, default(TKey), default(TKey), comparer,
+            return PartitionImpl(source, 1, key, default, default, comparer,
                                  (a, b, c, rest) => resultSelector(a, rest));
         }
 
@@ -236,7 +236,7 @@ namespace MoreLinq
             Func<IEnumerable<TElement>, IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-            return PartitionImpl(source, 2, key1, key2, default(TKey), comparer,
+            return PartitionImpl(source, 2, key1, key2, default, comparer,
                                  (a, b, c, rest) => resultSelector(a, b, rest));
         }
 

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -62,7 +62,7 @@ namespace MoreLinq
 
             return _(); IEnumerable<TResult> _()
             {
-                var edge = new[] { new KeyValuePair<bool, TSource>(false, default(TSource)) };
+                var edge = new[] { new KeyValuePair<bool, TSource>(false, default) };
                 return edge.Concat(source.Select(e => new KeyValuePair<bool, TSource>(true, e)))
                            .Concat(edge)
                            .Pairwise((a, b) => new { Prev = a, Curr = b })

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -72,13 +72,13 @@ namespace MoreLinq
                         }
                         else
                         {
-                            do { yield return resultSelector(e1.Current, default(TSecond)); }
+                            do { yield return resultSelector(e1.Current, default); }
                             while (e1.MoveNext());
                             yield break;
                         }
                     }
                     while (e2.MoveNext())
-                        yield return resultSelector(default(TFirst), e2.Current);
+                        yield return resultSelector(default, e2.Current);
                 }
             }
         }

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -157,8 +157,8 @@ namespace MoreLinq
                                       && (e4 == null || e4.MoveNext()))
                     {
                         yield return resultSelector(e1.Current, e2.Current,
-                            e3 != null ? e3.Current : default(T3),
-                            e4 != null ? e4.Current : default(T4));
+                            e3 != null ? e3.Current : default,
+                            e4 != null ? e4.Current : default);
                     }
                 }
             }


### PR DESCRIPTION
This is to primarily help get rid of more syntactic redundancies, like:

- [Default literal expressions][default-literal-expressions] (`default`)
- [Inferred tuple element names][inferred-tuple-element-names]


[default-literal-expressions]: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-1#default-literal-expressions
[inferred-tuple-element-names]: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-1#inferred-tuple-element-names