### PR TITLE
Batch with lazy enumerables (issue #400)

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -41,13 +41,21 @@ namespace MoreLinq.Test
         public void BatchEvenlyDivisibleSequence()
         {
             var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(3);
+            IEnumerable<IEnumerable<int>> batch2;
+
             using (var reader = result.Read())
             {
                 reader.Read().AssertSequenceEqual(1, 2, 3);
-                reader.Read().AssertSequenceEqual(4, 5, 6);
+
+                batch2 = reader.Read();
+
+                batch2.AssertSequenceEqual(4, 5, 6);
                 reader.Read().AssertSequenceEqual(7, 8, 9);
+
                 reader.ReadEnd();
             }
+
+            batch2.AssertSequenceEqual(4, 5, 6);
         }
 
         [Test]

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -19,6 +19,7 @@ namespace MoreLinq.Test
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using System;
 
     [TestFixture]
     public class BatchTest
@@ -94,6 +95,21 @@ namespace MoreLinq.Test
         public void BatchIsLazy()
         {
             new BreakingSequence<object>().Batch(1);
+        }
+
+        [Test]
+        public void BatchHasLazyEnumerables()
+        {
+            var seq1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var seq2 = MoreEnumerable.From<int>(() => throw new InvalidOperationException());
+            var result = seq1.Concat(seq2).Batch(4);
+
+            using (var reader = result.Read())
+            {
+                reader.Read().AssertSequenceEqual(1, 2, 3, 4);
+                reader.Read().AssertSequenceEqual(5, 6, 7, 8);
+                reader.Read().Take(1).AssertSequenceEqual(9);
+            }
         }
     }
 }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -80,13 +80,13 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void BatchSequenceYieldsListsOfBatches()
+        public void BatchSequenceYieldsIEnumerablesOfBatches()
         {
             var result = new[] { 1, 2, 3 }.Batch(2);
             using (var reader = result.Read())
             {
-                Assert.That(reader.Read(), Is.InstanceOf(typeof(IList<int>)));
-                Assert.That(reader.Read(), Is.InstanceOf(typeof(IList<int>)));
+                Assert.That(reader.Read(), Is.InstanceOf(typeof(IEnumerable<int>)));
+                Assert.That(reader.Read(), Is.InstanceOf(typeof(IEnumerable<int>)));
                 reader.ReadEnd();
             }
         }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         public void BatchEvenlyDivisibleSequence()
         {
             var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(3);
-            IEnumerable<IEnumerable<int>> batch2;
+            IEnumerable<int> batch2;
 
             using (var reader = result.Read())
             {

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -103,5 +103,34 @@ namespace MoreLinq.Test
                 reader.Read().Take(1).AssertSequenceEqual(9);
             }
         }
+
+        [Test]
+        public void BatchesCanBePartialIterated()
+        {
+            var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 }.Batch(3);
+            IEnumerable<int> batch1, batch2, batch3, batch4;
+
+            using (var reader = result.Read())
+            {
+                batch1 = reader.Read();
+                batch1.AssertSequenceEqual(1, 2, 3);
+
+                batch2 = reader.Read();
+                batch2.Take(1).AssertSequenceEqual(4);
+
+                batch3 = reader.Read();
+                batch3.Take(2).AssertSequenceEqual(7, 8);
+
+                batch4 = reader.Read();
+                batch4.Take(3).AssertSequenceEqual(10, 11);
+
+                reader.ReadEnd();
+            }
+
+            batch1.AssertSequenceEqual( 1, 2, 3);
+            batch2.AssertSequenceEqual( 4, 5, 6);
+            batch3.AssertSequenceEqual( 7, 8, 9);
+            batch4.AssertSequenceEqual(10, 11);
+        }
     }
 }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -42,21 +42,13 @@ namespace MoreLinq.Test
         public void BatchEvenlyDivisibleSequence()
         {
             var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(3);
-            IEnumerable<int> batch2;
-
             using (var reader = result.Read())
             {
                 reader.Read().AssertSequenceEqual(1, 2, 3);
-
-                batch2 = reader.Read();
-
-                batch2.AssertSequenceEqual(4, 5, 6);
+                reader.Read().AssertSequenceEqual(4, 5, 6);
                 reader.Read().AssertSequenceEqual(7, 8, 9);
-
                 reader.ReadEnd();
             }
-
-            batch2.AssertSequenceEqual(4, 5, 6);
         }
 
         [Test]

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -1,6 +1,6 @@
 #region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
-// Copyright (c) 2009 Atif Aziz. All rights reserved.
+// Copyright (c) 2016 Leandro F. Vieira (leandromoh). All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -59,8 +59,8 @@ namespace MoreLinq
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _().TakeWhile(x => x.Any()).Select(resultSelector); 
-            
+            return _().TakeWhile(x => x.Any()).Select(resultSelector);
+
             IEnumerable<IEnumerable<TSource>> _()
             {
                 List<TSource> previousBatch = null;
@@ -113,7 +113,7 @@ namespace MoreLinq
                         {
                             if (!disposed)
                             {
-                                e.Dispose(); 
+                                e.Dispose();
                                 disposed = true;
                             }
                         }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -97,6 +97,8 @@ namespace MoreLinq
                         index++;
                     }
 
+                    previousBucket = null;
+
                     for (var i = 0; i < size; i++)
                     {
                         if (i < pcurrentBucket.Count)

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -63,8 +63,8 @@ namespace MoreLinq
 
             IEnumerable<IEnumerable<TSource>> _()
             {
-                List<TSource> previousBatch = null;
-                List<TSource> currentBatch = null;
+                List<TSource> previousBucket = null;
+                List<TSource> currentBucket = null;
                 var group = 1;
                 var disposed = false;
                 var e = source.GetEnumerator();
@@ -74,9 +74,9 @@ namespace MoreLinq
                 {
                     while (!disposed)
                     {
-                        currentBatch = new List<TSource>(size);
-                        yield return GetBatch(group, currentBatch);
-                        previousBatch = currentBatch;
+                        currentBucket = new List<TSource>(size);
+                        yield return GetBucket(group, currentBucket);
+                        previousBucket = currentBucket;
                         group++;
                     }
                 }
@@ -86,27 +86,27 @@ namespace MoreLinq
                         e.Dispose();
                 }
 
-                IEnumerable<TSource> GetBatch(int pgroup, List<TSource> pcurrentBatch)
+                IEnumerable<TSource> GetBucket(int pgroup, List<TSource> pcurrentBucket)
                 {
                     var min = (pgroup - 1) * size;
                     var hasValue = false;
 
                     while (index < min && e.MoveNext())
                     {
-                        previousBatch.Add(e.Current);
+                        previousBucket.Add(e.Current);
                         index++;
                     }
 
                     for (var i = 0; i < size; i++)
                     {
-                        if (i < pcurrentBatch.Count)
+                        if (i < pcurrentBucket.Count)
                         {
                             hasValue = true;
                         }
                         else if (hasValue = (!disposed && e.MoveNext()))
                         {
                             index++;
-                            pcurrentBatch.Add(e.Current);
+                            pcurrentBucket.Add(e.Current);
                         }
                         else
                         {
@@ -118,7 +118,7 @@ namespace MoreLinq
                         }
 
                         if (hasValue)
-                            yield return pcurrentBatch[i];
+                            yield return pcurrentBucket[i];
                         else
                             yield break;
                     }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -93,7 +93,6 @@ namespace MoreLinq
 
                     while (index < min && e.MoveNext())
                     {
-                        if (previousBatch == null) previousBatch = pcurrentBatch;
                         previousBatch.Add(e.Current);
                         index++;
                     }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -74,7 +74,7 @@ namespace MoreLinq
                 {
                     while (!disposed)
                     {
-                        currentBatch = new List<TSource>();
+                        currentBatch = new List<TSource>(size);
                         yield return GetBatch(group, currentBatch);
                         previousBatch = currentBatch;
                         group++;


### PR DESCRIPTION
implements the requested of [Optimize Batch to return lazy enumerables](https://github.com/morelinq/MoreLINQ/issues/400).  

As requested [here](https://github.com/morelinq/MoreLINQ/issues/400#issuecomment-370135245), all batches are buffered in different lists. So when you move on to the next batch, the one before becomes fodder for GC.