### PR TITLE
Cross-platform T4 template generation

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -185,6 +185,7 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
+    <DotNetCliToolReference Include="T5.TextTransform.Tool" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/MoreLinq/tt.cmd
+++ b/MoreLinq/tt.cmd
@@ -1,0 +1,8 @@
+@echo off
+pushd "%~dp0"
+for /f %%f in ('dir /s /b *.tt') do (
+    echo>&2 dotnet tt %%f
+    dotnet tt %%f || goto :end
+)
+:end
+popd

--- a/MoreLinq/tt.sh
+++ b/MoreLinq/tt.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+[[ -e tt.sh ]] || { echo >&2 "Please cd into the script location before running it."; exit 1; }
+set -e
+find . -name "*.tt" | xargs -t -n 1 dotnet tt


### PR DESCRIPTION
This PR addresses #381.

I don't think these should be invoked with every build so as not to slow down `build.cmd` and `build.sh` further. There should be a check during CI that the generated code is fresh, like was done in 8ffe07c060c7d8a51243a6a149c4ef8a43d366a3 for #235.