### PR TITLE
Use value tuples to reduce allocations in TagFirstLast

### DIFF
--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -65,8 +65,8 @@ namespace MoreLinq
                 var edge = new(bool HasValue, TSource Value)[] { default };
                 return edge.Concat(source.Select(e => (HasValue: true, Value: e)))
                            .Concat(edge)
-                           .Pairwise((a, b) => new { Prev = a, Curr = b })
-                           .Pairwise((a, b) => new { a.Prev, a.Curr, Next = b.Curr })
+                           .Pairwise((a, b) => (Prev: a, Curr: b))
+                           .Pairwise((a, b) => (a.Prev, a.Curr, Next: b.Curr))
                            .Select(e => resultSelector(e.Curr.Value, !e.Prev.HasValue, !e.Next.HasValue));
             }
         }


### PR DESCRIPTION
`TagFirstLast` was allocating (anonymous) objects for internal representations, _at least two per source element_! This PR reduces those allocations by using value tuples instead.