### PR TITLE
Much simplified (lazy) NestedLoop implementation

### DIFF
--- a/MoreLinq.Test/BreakingAction.cs
+++ b/MoreLinq.Test/BreakingAction.cs
@@ -1,0 +1,42 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2018 Leandro F. Vieira (leandromoh). All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System;
+
+    /// <summary>
+    /// Actions which throw NotImplementedException if they're ever called.
+    /// </summary>
+    static class BreakingAction
+    {
+        internal static Action WithoutArguments =>
+            () => throw new NotImplementedException();
+
+        internal static Action<T> Of<T>() =>
+            t => throw new NotImplementedException();
+
+        internal static Action<T1, T2> Of<T1, T2>() =>
+            (t1, t2) => throw new NotImplementedException();
+
+        internal static Action<T1, T2, T3> Of<T1, T2, T3>() =>
+            (t1, t2, t3) => throw new NotImplementedException();
+
+        internal static Action<T1, T2, T3, T4> Of<T1, T2, T3, T4>() =>
+            (t1, t2, t3, t4) => throw new NotImplementedException();
+    }
+}

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -43,6 +43,7 @@
       <None Remove="TestResult.xml" />
       <Compile Include="AssertThrowsArgument.cs" />
       <Compile Include="BreakingCollection.cs" />
+      <Compile Include="BreakingAction.cs" />
       <Compile Include="BreakingFunc.cs" />
       <Compile Include="BreakingList.cs" />
       <Compile Include="BreakingReadOnlyCollection.cs" />

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -61,7 +61,6 @@ namespace MoreLinq.Test
         public void NestedLoopWithEmptySequence()
         {
             var result = BreakingAction.WithoutArguments.NestedLoops(new int[0]);
-
             Assert.That(result, Is.Empty);
         }
 
@@ -69,7 +68,6 @@ namespace MoreLinq.Test
         public void NestedLoopContainingZero()
         {
             var result = BreakingAction.WithoutArguments.NestedLoops(new[] { 3, 2, 1, 0, 4 });
-
             Assert.That(result, Is.Empty);
         }
     }

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -21,7 +21,7 @@ namespace MoreLinq.Test
         [Test]
         public void NestedLoopWithFirstElementNegative()
         {
-            AssertThrowsArgument.Exception("loopCounts", () =>
+            Assert.Throws<InvalidOperationException>(() =>
                 BreakingAction.WithoutArguments.NestedLoops(Enumerable.Range(-10, 10))
                                                .ElementAt(0));
         }
@@ -29,7 +29,7 @@ namespace MoreLinq.Test
         [Test]
         public void NestedLoopWithLastElementNegative()
         {
-            AssertThrowsArgument.Exception("loopCounts", () =>
+            Assert.Throws<InvalidOperationException>(() =>
                 BreakingAction.WithoutArguments.NestedLoops(MoreEnumerable.Sequence(10, -1))
                                                .ElementAt(0));
         }

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -10,10 +10,6 @@ namespace MoreLinq.Test
     [TestFixture]
     public class NestedLoopTest
     {
-        static void DoNothing() { }
-
-        static readonly Action EmptyLoopBody = DoNothing;
-
         [Test]
         public void NestedLoopsIsLazy()
         {
@@ -27,7 +23,8 @@ namespace MoreLinq.Test
         public void TestNegativeLoopCountsException()
         {
             AssertThrowsArgument.Exception("loopCounts", () =>
-                EmptyLoopBody.NestedLoops(Enumerable.Range(-10, 10)).ElementAt(0));
+                BreakingAction.WithoutArguments.NestedLoops(Enumerable.Range(-10, 10))
+                                               .ElementAt(0));
         }
 
         /// <summary>

--- a/MoreLinq.Test/NestedLoopTest.cs
+++ b/MoreLinq.Test/NestedLoopTest.cs
@@ -2,7 +2,6 @@ namespace MoreLinq.Test
 {
     using System;
     using NUnit.Framework;
-    using static MoreEnumerable;
 
     /// <summary>
     /// Tests that verify the behavior of the NestedLoops extension method.
@@ -20,10 +19,18 @@ namespace MoreLinq.Test
         /// Verify that passing negative loop counts results in an exception
         /// </summary>
         [Test]
-        public void TestNegativeLoopCountsException()
+        public void NestedLoopWithFirstElementNegative()
         {
             AssertThrowsArgument.Exception("loopCounts", () =>
                 BreakingAction.WithoutArguments.NestedLoops(Enumerable.Range(-10, 10))
+                                               .ElementAt(0));
+        }
+
+        [Test]
+        public void NestedLoopWithLastElementNegative()
+        {
+            AssertThrowsArgument.Exception("loopCounts", () =>
+                BreakingAction.WithoutArguments.NestedLoops(MoreEnumerable.Sequence(10, -1))
                                                .ElementAt(0));
         }
 
@@ -51,21 +58,19 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void TestNestedLoopConsumesSequenceLazily()
+        public void NestedLoopWithEmptySequence()
         {
-            var i = 0;
-            Action loopBody = () => ++i;
+            var result = BreakingAction.WithoutArguments.NestedLoops(new int[0]);
 
-            const int count = 4;
-            var expectedCount = (int) Combinatorics.Factorial(count);
+            Assert.That(result, Is.Empty);
+        }
 
-            var loopCounts = Enumerable.Range(1, count)
-                                       .Concat(From<int>(() => throw new TestException()));
+        [Test]
+        public void NestedLoopContainingZero()
+        {
+            var result = BreakingAction.WithoutArguments.NestedLoops(new[] { 3, 2, 1, 0, 4 });
 
-            var nestedLoops = loopBody.NestedLoops(loopCounts);
-
-            Assert.AreEqual( expectedCount, nestedLoops.Take(expectedCount).Count() );
-            Assert.Throws<TestException>(() => nestedLoops.ElementAt(expectedCount));
+            Assert.That(result, Is.Empty);
         }
     }
 }

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -46,7 +46,7 @@ namespace MoreLinq
                 using (var e = loopCounts.GetEnumerator())
                 {
                     var count = 1;
-                    var called = 0;
+                    var yielded = 0;
 
                     while (e.MoveNext())
                     {
@@ -55,10 +55,10 @@ namespace MoreLinq
 
                         count *= e.Current;
 
-                        while (called < count)
+                        while (yielded < count)
                         {
                             yield return action;
-                            called++;
+                            yielded++;
                         }
                     }
                 }

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -49,9 +49,7 @@ namespace MoreLinq
                                       .Aggregate((acc, x) => acc * x);
 
                 for (var i = 0; i < count; i++)
-                {
                     yield return action;
-                }
             }
         }
     }

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -44,7 +44,7 @@ namespace MoreLinq
             return _(); IEnumerable<Action> _()
             {
                 var count = loopCounts.Assert(n => n >= 0,
-                                              n => new ArgumentException("All loop counts must be greater than or equal to zero.", nameof(loopCounts)))
+                                              n => new InvalidOperationException("All loop counts must be greater than or equal to zero.", nameof(loopCounts)))
                                       .DefaultIfEmpty()
                                       .Aggregate((acc, x) => acc * x);
 

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -43,24 +43,14 @@ namespace MoreLinq
 
             return _(); IEnumerable<Action> _()
             {
-                using (var e = loopCounts.GetEnumerator())
+                var count = loopCounts.Assert(n => n >= 0,
+                                              n => new ArgumentException("All loop counts must be greater than or equal to zero.", nameof(loopCounts)))
+                                      .DefaultIfEmpty()
+                                      .Aggregate((acc, x) => acc * x);
+
+                for (var i = 0; i < count; i++)
                 {
-                    var count = 1;
-                    var yielded = 0;
-
-                    while (e.MoveNext())
-                    {
-                        if (e.Current < 0)
-                            throw new ArgumentException("All loop counts must be greater than or equal to zero.", nameof(loopCounts));
-
-                        count *= e.Current;
-
-                        while (yielded < count)
-                        {
-                            yield return action;
-                            yielded++;
-                        }
-                    }
+                    yield return action;
                 }
             }
         }

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -44,7 +44,7 @@ namespace MoreLinq
             return _(); IEnumerable<Action> _()
             {
                 var count = loopCounts.Assert(n => n >= 0,
-                                              n => new InvalidOperationException("All loop counts must be greater than or equal to zero."))
+                                              n => new InvalidOperationException("Invalid loop count (must be greater than or equal to zero)."))
                                       .DefaultIfEmpty()
                                       .Aggregate((acc, x) => acc * x);
 

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -44,7 +44,7 @@ namespace MoreLinq
             return _(); IEnumerable<Action> _()
             {
                 var count = loopCounts.Assert(n => n >= 0,
-                                              n => new InvalidOperationException("All loop counts must be greater than or equal to zero.", nameof(loopCounts)))
+                                              n => new InvalidOperationException("All loop counts must be greater than or equal to zero."))
                                       .DefaultIfEmpty()
                                       .Aggregate((acc, x) => acc * x);
 

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -1,6 +1,6 @@
 #region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
-// Copyright (c) 2018 Leandro F. Vieira (leandromoh). All rights reserved.
+// Copyright (c) 2010 Leopold Bushkin. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
changes:

- refactored `NestedLoop` to become lazy
- added `NestedLoopsIsLazy` test
- refactored tests considering lazy evaluation
- ~~added `TestNestedLoopConsumesSequenceLazily` test~~
- added `NestedLoopWithEmptySequence` test
- added `NestedLoopContainingZero` test
- added `NestedLoopWithLastElementNegative` test
