### PR TITLE
Make empty sequence checks consistent in tests

### DIFF
--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -27,7 +27,7 @@ namespace MoreLinq.Test
             var sequenceB = Enumerable.Empty<int>();
             var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
 
-            Assert.IsTrue(result.SequenceEqual(sequenceA));
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>

--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -115,7 +115,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(0, count);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -88,7 +88,7 @@ namespace MoreLinq.Test
             var sequenceE = Enumerable.Empty<int>();
             var result = sequenceA.Interleave(sequenceB, sequenceC, sequenceD, sequenceE);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>

--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
         [Test]
         public void MaxByEmptySequence()
         {
-            Assert.IsEmpty(new string[0].MaxBy(x => x.Length));
+            Assert.That(new string[0].MaxBy(x => x.Length), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
         [Test]
         public void MinByEmptySequence()
         {
-            Assert.IsEmpty(new string[0].MinBy(x => x.Length));
+            Assert.That(new string[0].MinBy(x => x.Length), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -26,7 +26,7 @@ namespace MoreLinq.Test
         [Test]
         public void ScanEmpty()
         {
-            Assert.False(new int[0].Scan(SampleData.Plus).GetEnumerator().MoveNext());
+            Assert.That(new int[0].Scan(SampleData.Plus), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         {
             var sequence = Enumerable.Repeat(-1, 0);
             var result = sequence.Segment(x => true);
-            Assert.IsFalse(result.Any());
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>

--- a/MoreLinq.Test/SequenceTest.cs
+++ b/MoreLinq.Test/SequenceTest.cs
@@ -70,9 +70,8 @@ namespace MoreLinq.Test
         public void SequenceWithAscendingRangeDescendigStep(int start, int stop, int step)
         {
             var result = MoreEnumerable.Sequence(start, stop, step);
-            var expectations = Enumerable.Empty<int>();
 
-            Assert.That(result, Is.EqualTo(expectations));
+            Assert.That(result, Is.Empty);
         }
 
         [TestCase( -4, -10, 2)]
@@ -83,9 +82,8 @@ namespace MoreLinq.Test
         public void SequenceWithDescendingRangeAscendingStep(int start, int stop, int step)
         {
             var result = MoreEnumerable.Sequence(start, stop, step);
-            var expectations = Enumerable.Empty<int>();
 
-            Assert.That(result, Is.EqualTo(expectations));
+            Assert.That(result, Is.Empty);
         }
 
         [TestCase( -4, -10, -2)]

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -48,7 +48,7 @@ namespace MoreLinq.Test
         [TestCase(6)]
         public void SkipLastWithSequenceShorterThanCount(int skip)
         {
-            Assert.IsFalse(Enumerable.Range(1, 5).SkipLast(skip).Any());
+            Assert.That(Enumerable.Range(1, 5).SkipLast(skip), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/SkipUntilTest.cs
+++ b/MoreLinq.Test/SkipUntilTest.cs
@@ -33,7 +33,7 @@ namespace MoreLinq.Test
         public void SkipUntilPredicateNeverTrue()
         {
             var sequence = Enumerable.Range(0, 5).SkipUntil(x => x == 100);
-            sequence.AssertSequenceEqual();
+            Assert.That(sequence, Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/TakeEveryTest.cs
+++ b/MoreLinq.Test/TakeEveryTest.cs
@@ -39,7 +39,7 @@ namespace MoreLinq.Test
         [Test]
         public void TakeEveryEmptySequence()
         {
-            Assert.That(new object[0].TakeEvery(1).GetEnumerator().MoveNext(), Is.False);
+            Assert.That(new object[0].TakeEvery(1), Is.Empty);
         }
 
         [Test]

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
         {
             AssertTakeLast(new[] { 12, 34, 56 },
                            -2,
-                           result => Assert.IsFalse(result.GetEnumerator().MoveNext()));
+                           result => Assert.That(result, Is.Empty));
         }
 
         [Test]

--- a/MoreLinq.Test/UnfoldTest.cs
+++ b/MoreLinq.Test/UnfoldTest.cs
@@ -79,10 +79,7 @@ namespace MoreLinq.Test
                                                   x => x.Result < 0,
                                                   e => e.State,
                                                   e => e.Result);
-
-            var expectations = new int[] { };
-
-            Assert.That(result, Is.EqualTo(expectations));
+            Assert.That(result, Is.Empty);
         }
     }
 }

--- a/MoreLinq.Test/WindowedTest.cs
+++ b/MoreLinq.Test/WindowedTest.cs
@@ -39,7 +39,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Empty<int>();
             var result = sequence.Windowed(5);
 
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
 
             // there should only be one window whose contents is the same
             // as the source sequence
-            Assert.IsEmpty(result);
+            Assert.That(result, Is.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
use a single approach to check empty sequences.

all current approaches

```c#
Assert.That(result, Is.EqualTo(Enumerable.Empty<int>()));
Assert.IsFalse(result.Any());
result.AssertSequenceEqual();
Assert.False(result.GetEnumerator().MoveNext());
Assert.That(result.GetEnumerator().MoveNext(), Is.False);
Assert.IsEmpty(result);
```

were replaced by:

```c#
Assert.That(result, Is.Empty);
```