### PR TITLE
Make sequences equality comparison consistent in tests

### DIFF
--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -27,7 +27,7 @@ namespace MoreLinq.Test
             var sequenceB = Enumerable.Empty<int>();
             var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
 
-            Assert.IsTrue(result.SequenceEqual(sequenceA));
+            Assert.That(result, Is.EqualTo(sequenceA));
         }
 
         /// <summary>
@@ -41,8 +41,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
             var resultB = sequenceB.Cartesian(sequenceA, (a, b) => a + b);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceA));
+            Assert.That(resultA, Is.EqualTo(sequenceA));
+            Assert.That(resultB, Is.EqualTo(sequenceA));
         }
 
         /// <summary>

--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -59,9 +59,9 @@ namespace MoreLinq.Test
             var resultA = sequence.Exclude(0, 0);
             var resultB = sequence.Exclude(0, 10); // shouldn't matter how many we ask for past end
             var resultC = sequence.Exclude(5, 5);  // shouldn't matter where we start
-            Assert.IsTrue(resultA.SequenceEqual(sequence));
-            Assert.IsTrue(resultB.SequenceEqual(sequence));
-            Assert.IsTrue(resultC.SequenceEqual(sequence));
+            Assert.That(resultA, Is.EqualTo(sequence));
+            Assert.That(resultB, Is.EqualTo(sequence));
+            Assert.That(resultC, Is.EqualTo(sequence));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(0, count / 2);
 
-            Assert.IsTrue(result.SequenceEqual(sequence.Skip(count / 2)));
+            Assert.That(result, Is.EqualTo(sequence.Skip(count / 2)));
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(count / 2, count);
 
-            Assert.IsTrue(result.SequenceEqual(sequence.Take(count / 2)));
+            Assert.That(result, Is.EqualTo(sequence.Take(count / 2)));
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(startIndex, excludeCount);
 
-            Assert.IsTrue(result.SequenceEqual(sequence.Take(startIndex).Concat(sequence.Skip(startIndex + excludeCount))));
+            Assert.That(result, Is.EqualTo(sequence.Take(startIndex).Concat(sequence.Skip(startIndex + excludeCount))));
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(0, count);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.That(result, Is.EqualTo(Enumerable.Empty<int>()));
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(1, count * 10);
 
-            Assert.IsTrue(result.SequenceEqual(sequence.Take(1)));
+            Assert.That(result, Is.EqualTo(sequence.Take(1)));
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Exclude(count + 5, count);
 
-            Assert.IsTrue(result.SequenceEqual(sequence));
+            Assert.That(result, Is.EqualTo(sequence));
         }
     }
 }

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -43,7 +43,7 @@ namespace MoreLinq.Test
             var sequenceB = Enumerable.Range(1, count);
             var result = sequenceA.Interleave(sequenceB);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Range(1, count).Select(x => new[] { x, x }).SelectMany(z => z)));
+            Assert.That(result, Is.EqualTo(Enumerable.Range(1, count).Select(x => new[] { x, x }).SelectMany(z => z)));
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace MoreLinq.Test
             var sequenceB = Enumerable.Empty<int>();
             var result = sequenceA.Interleave(sequenceB);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.That(result, Is.EqualTo(Enumerable.Empty<int>()));
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace MoreLinq.Test
 
             var expectedResult = new[] { 0, 1, 0, 1, 0, 1, 0, 1, 0, 0 };
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace MoreLinq.Test
             var sequenceE = Enumerable.Empty<int>();
             var result = sequenceA.Interleave(sequenceB, sequenceC, sequenceD, sequenceE);
 
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Empty<int>()));
+            Assert.That(result, Is.EqualTo(Enumerable.Empty<int>()));
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace MoreLinq.Test
 
             var expectedResult = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -51,7 +51,7 @@ namespace MoreLinq.Test
             var result = sequence.Lag(lagBy, lagDefault, (val, lagVal) => lagVal);
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.Take(lagBy).SequenceEqual(Enumerable.Repeat(lagDefault, lagBy)));
+            Assert.That(result.Take(lagBy), Is.EqualTo(Enumerable.Repeat(lagDefault, lagBy)));
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             var result = sequence.Lag(lagBy, (val, lagVal) => lagVal);
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.Take(lagBy).SequenceEqual(Enumerable.Repeat(default(int), lagBy)));
+            Assert.That(result.Take(lagBy), Is.EqualTo(Enumerable.Repeat(default(int), lagBy)));
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace MoreLinq.Test
             var result = sequence.Lag(count + 1, (a, b) => a);
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.SequenceEqual(sequence));
+            Assert.That(result, Is.EqualTo(sequence));
         }
 
         /// <summary>

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -51,7 +51,7 @@ namespace MoreLinq.Test
             var result = sequence.Lead(leadBy, leadDefault, (val, leadVal) => leadVal);
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.Skip(count - leadBy).SequenceEqual(Enumerable.Repeat(leadDefault, leadBy)));
+            Assert.That(result.Skip(count - leadBy), Is.EqualTo(Enumerable.Repeat(leadDefault, leadBy)));
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             var result = sequence.Lead(leadBy, (val, leadVal) => leadVal);
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.Skip(count - leadBy).SequenceEqual(Enumerable.Repeat(default(int), leadBy)));
+            Assert.That(result.Skip(count - leadBy), Is.EqualTo(Enumerable.Repeat(default(int), leadBy)));
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace MoreLinq.Test
             var result = sequence.Lead(count + 1, leadDefault, (val, leadVal) => new { A = val, B = leadVal });
 
             Assert.AreEqual(count, result.Count());
-            Assert.IsTrue(result.SequenceEqual(sequence.Select(x => new { A = x, B = leadDefault })));
+            Assert.That(result, Is.EqualTo(sequence.Select(x => new { A = x, B = leadDefault })));
         }
 
         /// <summary>

--- a/MoreLinq.Test/OrderByTest.cs
+++ b/MoreLinq.Test/OrderByTest.cs
@@ -20,12 +20,12 @@ namespace MoreLinq.Test
             var resultAsc1 = sequenceAscending.OrderBy(x => x, OrderByDirection.Descending);
             var resultAsc2 = sequenceAscending.OrderByDescending(x => x);
             // ensure both order by operations produce identical results
-            Assert.IsTrue(resultAsc1.SequenceEqual(resultAsc2));
+            Assert.That(resultAsc1, Is.EqualTo(resultAsc2));
 
             var resultDes1 = sequenceDescending.OrderBy(x => x, OrderByDirection.Ascending);
             var resultDes2 = sequenceDescending.OrderBy(x => x);
             // ensure both order by operations produce identical results
-            Assert.IsTrue(resultDes1.SequenceEqual(resultDes2));
+            Assert.That(resultDes1, Is.EqualTo(resultDes2));
         }
 
         /// <summary>
@@ -43,16 +43,16 @@ namespace MoreLinq.Test
             var resultAsc1 = sequenceAscending.OrderBy(x => x, comparer, OrderByDirection.Descending);
             var resultAsc2 = sequenceAscending.OrderByDescending(x => x, comparer);
             // ensure both order by operations produce identical results
-            Assert.IsTrue(resultAsc1.SequenceEqual(resultAsc2));
+            Assert.That(resultAsc1, Is.EqualTo(resultAsc2));
             // ensure comparer was applied in the order by evaluation
-            Assert.IsTrue(resultAsc1.SequenceEqual(sequenceDescending));
+            Assert.That(resultAsc1, Is.EqualTo(sequenceDescending));
 
             var resultDes1 = sequenceDescending.OrderBy(x => x, comparer, OrderByDirection.Ascending);
             var resultDes2 = sequenceDescending.OrderBy(x => x, comparer);
             // ensure both order by operations produce identical results
-            Assert.IsTrue(resultDes1.SequenceEqual(resultDes2));
+            Assert.That(resultDes1, Is.EqualTo(resultDes2));
             // ensure comparer was applied in the order by evaluation
-            Assert.IsTrue(resultDes1.SequenceEqual(sequenceAscending));
+            Assert.That(resultDes1, Is.EqualTo(sequenceAscending));
         }
 
         /// <summary>
@@ -76,14 +76,14 @@ namespace MoreLinq.Test
             var resultA2 = sequence.OrderBy(x => x.A)
                                    .ThenBy(y => y.B);
             // ensure both produce the same order
-            Assert.IsTrue(resultA1.SequenceEqual(resultA2));
+            Assert.That(resultA1, Is.EqualTo(resultA2));
 
             var resultB1 = sequence.OrderBy(x => x.A, OrderByDirection.Ascending)
                                      .ThenBy(y => y.B, OrderByDirection.Descending);
             var resultB2 = sequence.OrderBy(x => x.A)
                                    .ThenByDescending(y => y.B);
             // ensure both produce the same order
-            Assert.IsTrue(resultB1.SequenceEqual(resultB2));
+            Assert.That(resultB1, Is.EqualTo(resultB2));
         }
 
         /// <summary>
@@ -109,14 +109,14 @@ namespace MoreLinq.Test
             var resultA2 = sequence.OrderBy(x => x.A, comparer)
                                    .ThenBy(y => y.B, comparer);
             // ensure both produce the same order
-            Assert.IsTrue(resultA1.SequenceEqual(resultA2));
+            Assert.That(resultA1, Is.EqualTo(resultA2));
 
             var resultB1 = sequence.OrderBy(x => x.A, comparer, OrderByDirection.Ascending)
                                      .ThenBy(y => y.B, comparer, OrderByDirection.Descending);
             var resultB2 = sequence.OrderBy(x => x.A, comparer)
                                    .ThenByDescending(y => y.B, comparer);
             // ensure both produce the same order
-            Assert.IsTrue(resultB1.SequenceEqual(resultB2));
+            Assert.That(resultB1, Is.EqualTo(resultB2));
         }
     }
 }

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -19,7 +19,7 @@ namespace MoreLinq.Test
             var permutations = emptySet.Permutations();
 
             // should contain a single result: the empty set itself
-            Assert.IsTrue(permutations.Single().SequenceEqual(emptySet));
+            Assert.That(permutations.Single(), Is.EqualTo(emptySet));
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
             var permutations = set.Permutations();
 
             // should contain a single result: the set itself
-            Assert.IsTrue(permutations.Single().SequenceEqual(set));
+            Assert.That(permutations.Single(), Is.EqualTo(set));
         }
 
         /// <summary>
@@ -47,8 +47,8 @@ namespace MoreLinq.Test
 
             // should contain two results: the set itself and its reverse
             Assert.IsTrue(permutations.Count() == 2);
-            Assert.IsTrue(permutations.First().SequenceEqual(set));
-            Assert.IsTrue(permutations.Last().SequenceEqual(set.Reverse()));
+            Assert.That(permutations.First(), Is.EqualTo(set));
+            Assert.That(permutations.Last(), Is.EqualTo(set.Reverse()));
         }
 
         /// <summary>

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -203,7 +203,7 @@ namespace MoreLinq.Test
             resultB.Consume();
 
             // verify the original sequence is untouched
-            Assert.IsTrue(sequence.SequenceEqual(sequenceClone));
+            Assert.That(sequence, Is.EqualTo(sequenceClone));
         }
 
         static double RelativeStandardDeviation(IEnumerable<double> values)

--- a/MoreLinq.Test/RandomTest.cs
+++ b/MoreLinq.Test/RandomTest.cs
@@ -109,7 +109,7 @@ namespace MoreLinq.Test
             var randomSeq = MoreEnumerable.Random(randB);
             var valuesB = randomSeq.Take(RandomTrials);
 
-            Assert.IsTrue(valuesA.SequenceEqual(valuesB));
+            Assert.That(valuesA, Is.EqualTo(valuesB));
         }
     }
 }

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -43,7 +43,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(1, count);
 
             Assert.AreEqual(count, result.Length);
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(1, count).Reverse();
 
             Assert.AreEqual(count, result.Length);
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace MoreLinq.Test
             var result = sequence.AsTestingSequence().Rank().ToArray();
 
             Assert.AreEqual(count, result.Length);
-            Assert.IsTrue(result.SequenceEqual(Enumerable.Repeat(1, count)));
+            Assert.That(result, Is.EqualTo(Enumerable.Repeat(1, count)));
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace MoreLinq.Test
             var result = sequence.AsTestingSequence().Rank().ToArray();
 
             Assert.AreEqual(count, result.Distinct().Count());
-            Assert.IsTrue(result.SequenceEqual(sequence.Reverse().Select(x => x + 1)));
+            Assert.That(result, Is.EqualTo(sequence.Reverse().Select(x => x + 1)));
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace MoreLinq.Test
             var result = sequence.AsTestingSequence().RankBy(x => x.Age).ToArray();
 
             Assert.AreEqual(sequence.Length, result.Length);
-            Assert.IsTrue(result.SequenceEqual(sequence.Select(x => x.ExpectedRank)));
+            Assert.That(result, Is.EqualTo(sequence.Select(x => x.ExpectedRank)));
         }
 
         /// <summary>
@@ -141,8 +141,8 @@ namespace MoreLinq.Test
             var resultA = sequence.AsTestingSequence().Rank(Comparer.Create<DateTime>((a, b) => -a.CompareTo(b)));
             var resultB = sequence.AsTestingSequence().RankBy(x => x.Day, Comparer.Create<int>((a, b) => -a.CompareTo(b)));
 
-            Assert.IsTrue(resultA.SequenceEqual(ordinals));
-            Assert.IsTrue(resultB.SequenceEqual(ordinals.Reverse()));
+            Assert.That(resultA, Is.EqualTo(ordinals));
+            Assert.That(resultB, Is.EqualTo(ordinals.Reverse()));
         }
     }
 }

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -33,7 +33,7 @@ namespace MoreLinq.Test
                 expectedResult = expectedResult.Concat(sequence);
 
             Assert.AreEqual(count * repeatCount, result.Count());
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>

--- a/MoreLinq.Test/RunLengthEncodeTest.cs
+++ b/MoreLinq.Test/RunLengthEncodeTest.cs
@@ -29,7 +29,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Empty<int>();
             var result = sequence.RunLengthEncode();
 
-            Assert.IsTrue(result.SequenceEqual(sequence.Select(x => new KeyValuePair<int, int>(x, x))));
+            Assert.That(result, Is.EqualTo(sequence.Select(x => new KeyValuePair<int, int>(x, x))));
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace MoreLinq.Test
             var expectedResult = new[] {new KeyValuePair<string, int>("a", 3),
                                          new KeyValuePair<string, int>("b", 4)};
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(1, 6).Select(x => new KeyValuePair<int, int>(x, x));
             var result = sequence.RunLengthEncode();
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace MoreLinq.Test
             var result = sequence.RunLengthEncode();
             var expectedResult = sequence.Select(x => new KeyValuePair<int, int>(x, 1));
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace MoreLinq.Test
             var result = sequence.RunLengthEncode();
             var expectedResult = new[] { new KeyValuePair<char, int>(value, repeatCount) };
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
     }
 }

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -30,7 +30,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Segment(x => false);
 
-            Assert.IsTrue(result.Single().SequenceEqual(sequence));
+            Assert.That(result.Single(), Is.EqualTo(sequence));
         }
 
         /// <summary>

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -28,7 +28,7 @@ namespace MoreLinq.Test
         {
             var numbers = Enumerable.Range(1, 5);
 
-            Assert.IsTrue(numbers.SkipLast(skip).SequenceEqual(numbers));
+            Assert.That(numbers.SkipLast(skip), Is.EqualTo(numbers));
         }
 
         [Test]

--- a/MoreLinq.Test/SliceTest.cs
+++ b/MoreLinq.Test/SliceTest.cs
@@ -33,8 +33,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Slice(0, count);
             var resultB = sequenceB.Slice(0, count);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceB));
+            Assert.That(resultA, Is.EqualTo(sequenceA));
+            Assert.That(resultB, Is.EqualTo(sequenceB));
         }
 
         /// <summary>
@@ -51,8 +51,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Slice(0, 1);
             var resultB = sequenceB.Slice(0, 1);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA.Take(1)));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceB.Take(1)));
+            Assert.That(resultA, Is.EqualTo(sequenceA.Take(1)));
+            Assert.That(resultB, Is.EqualTo(sequenceB.Take(1)));
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Slice(count - 1, 1);
             var resultB = sequenceB.Slice(count - 1, 1);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA.Skip(9).Take(1)));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceB.Skip(9).Take(1)));
+            Assert.That(resultA, Is.EqualTo(sequenceA.Skip(9).Take(1)));
+            Assert.That(resultB, Is.EqualTo(sequenceB.Skip(9).Take(1)));
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Slice(4, 5);
             var resultB = sequenceB.Slice(4, 5);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA.Skip(4).Take(5)));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceB.Skip(4).Take(5)));
+            Assert.That(resultA, Is.EqualTo(sequenceA.Skip(4).Take(5)));
+            Assert.That(resultB, Is.EqualTo(sequenceB.Skip(4).Take(5)));
         }
 
         /// <summary>
@@ -107,8 +107,8 @@ namespace MoreLinq.Test
             var resultA = sequenceA.Slice(count / 2, count);
             var resultB = sequenceB.Slice(count / 2, count);
 
-            Assert.IsTrue(resultA.SequenceEqual(sequenceA.Skip(count / 2).Take(count)));
-            Assert.IsTrue(resultB.SequenceEqual(sequenceB.Skip(count / 2).Take(count)));
+            Assert.That(resultA, Is.EqualTo(sequenceA.Skip(count / 2).Take(count)));
+            Assert.That(resultB, Is.EqualTo(sequenceB.Skip(count / 2).Take(count)));
         }
 
         /// <summary>

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -47,7 +47,7 @@ namespace MoreLinq.Test
             var sequenceB = Enumerable.Range(4, 3);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, (IComparer<int>)null, sequenceB);
 
-            Assert.IsTrue(result.SequenceEqual(sequenceA.Concat(sequenceB)));
+            Assert.That(result, Is.EqualTo(sequenceA.Concat(sequenceB)));
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace MoreLinq.Test
             var sequenceA = Enumerable.Range(1, count);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending);
 
-            Assert.IsTrue(result.SequenceEqual(sequenceA));
+            Assert.That(result, Is.EqualTo(sequenceA));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
             var sequenceC = Enumerable.Empty<int>();
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(sequenceA));
+            Assert.That(result, Is.EqualTo(sequenceA));
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(1, 12);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(0, count * 3);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace MoreLinq.Test
             var expectedResult = sequenceA.Concat(sequenceB).Concat(sequenceC).OrderBy(x => x);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace MoreLinq.Test
             var expectedResult = Enumerable.Range(0, count * 3).Reverse();
             var result = sequenceA.SortedMerge(OrderByDirection.Descending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace MoreLinq.Test
                                           .OrderBy(a => a, StringComparer.CurrentCultureIgnoreCase);
             var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB, sequenceC);
 
-            Assert.IsTrue(result.SequenceEqual(expectedResult));
+            Assert.That(result, Is.EqualTo(expectedResult));
         }
 
         /// <summary>

--- a/MoreLinq.Test/SubsetTest.cs
+++ b/MoreLinq.Test/SubsetTest.cs
@@ -57,7 +57,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Repeat(0, 0);
             var result = sequence.Subsets();
 
-            Assert.IsTrue(result.Single().SequenceEqual(sequence));
+            Assert.That(result.Single(), Is.EqualTo(sequence));
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace MoreLinq.Test
 
             var index = 0;
             foreach (var subset in result)
-                Assert.IsTrue(subset.SequenceEqual(expectedSubsets[index++]));
+                Assert.That(subset, Is.EqualTo(expectedSubsets[index++]));
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace MoreLinq.Test
 
             var index = 0;
             foreach (var subset in result)
-                Assert.IsTrue(subset.SequenceEqual(expectedSubsets[index++]));
+                Assert.That(subset, Is.EqualTo(expectedSubsets[index++]));
         }
     }
 }

--- a/MoreLinq.Test/WindowedTest.cs
+++ b/MoreLinq.Test/WindowedTest.cs
@@ -94,7 +94,7 @@ namespace MoreLinq.Test
             // ensure each window contains the correct set of items
             var index = -1;
             foreach (var window in result)
-                Assert.IsTrue(window.SequenceEqual(sequence.Skip(++index).Take(windowSize)));
+                Assert.That(window, Is.EqualTo(sequence.Skip(++index).Take(windowSize)));
         }
     }
 }


### PR DESCRIPTION
in many tests we compare sequences using.

```c#
Assert.IsTrue(result.SequenceEqual(expectations));
```

this PR replaces the above approach by the following, so we can get a more meaningful error

```c#
Assert.That(result, Is.EqualTo(expectations));
```