### PR TITLE
Fix eclint-ing in CI build 🚧

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ skip_commits:
     - '.editorconfig'
     - lic/*
 install:
+- ps: Install-Product node 6
 - npm install -g eclint
 - git rm .editorconfig
 - eclint check -n "**/*.{cs,tt,cmd,sh,md,txt,yml}"


### PR DESCRIPTION
CI build on AppVeyor is [broke](https://ci.appveyor.com/project/raboof/morelinq/build/941) with cd737c861d6d1fdfdaa1a211949a7adbd7d24ab3 due to the error:

```
[00:00:26] C:\Users\appveyor\AppData\Roaming\npm\node_modules\eclint\node_modules\gulp-reporter\node_modules\fs-extra\lib\fs\index.js:87
[00:00:26] exports.write = function (fd, buffer, ...args) {
[00:00:26]                                       ^^^
[00:00:26] 
[00:00:26] SyntaxError: Unexpected token ...
[00:00:26]     at exports.runInThisContext (vm.js:53:16)
[00:00:26]     at Module._compile (module.js:373:25)
[00:00:26]     at Object.Module._extensions..js (module.js:416:10)
[00:00:26]     at Module.load (module.js:343:32)
[00:00:26]     at Function.Module._load (module.js:300:12)
[00:00:26]     at Module.require (module.js:353:17)
[00:00:26]     at require (internal/module.js:12:17)
[00:00:26]     at Object.<anonymous> (C:\Users\appveyor\AppData\Roaming\npm\node_modules\eclint\node_modules\gulp-reporter\node_modules\fs-extra\lib\index.js:6:3)
[00:00:26]     at Module._compile (module.js:409:26)
[00:00:26]     at Object.Module._extensions..js (module.js:416:10)
```

This PR is to try and fix that.

---
- [`log.txt`](https://github.com/morelinq/MoreLINQ/files/1987280/log.txt)
