### PR TITLE
Change Cartesian to avoid re-iterating second sequence

### DIFF
--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -23,11 +23,12 @@ namespace MoreLinq.Test
         [Test]
         public void TestCartesianOfEmptySequences()
         {
-            var sequenceA = Enumerable.Empty<int>();
-            var sequenceB = Enumerable.Empty<int>();
-            var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
-
-            Assert.That(result, Is.Empty);
+            using (var sequenceA = Enumerable.Empty<int>().AsTestingSequence())
+            using (var sequenceB = Enumerable.Empty<int>().AsTestingSequence())
+            {
+                var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
+                Assert.That(result, Is.Empty);
+            }
         }
 
         /// <summary>
@@ -37,12 +38,21 @@ namespace MoreLinq.Test
         public void TestCartesianOfEmptyAndNonEmpty()
         {
             var sequenceA = Enumerable.Empty<int>();
-            var sequenceB = Enumerable.Repeat(1,10);
-            var resultA = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
-            var resultB = sequenceB.Cartesian(sequenceA, (a, b) => a + b);
+            var sequenceB = Enumerable.Repeat(1, 10);
 
-            Assert.That(resultA, Is.EqualTo(sequenceA));
-            Assert.That(resultB, Is.EqualTo(sequenceA));
+            using (var tsA = sequenceA.AsTestingSequence())
+            using (var tsB = sequenceB.AsTestingSequence())
+            {
+                var result = tsA.Cartesian(tsB, (a, b) => a + b);
+                Assert.That(result, Is.EqualTo(sequenceA));
+            }
+
+            using (var tsA = sequenceA.AsTestingSequence())
+            using (var tsB = sequenceB.AsTestingSequence())
+            {
+                var result = tsB.Cartesian(tsA, (a, b) => a + b);
+                Assert.That(result, Is.EqualTo(sequenceA));
+            }
         }
 
         /// <summary>
@@ -54,11 +64,12 @@ namespace MoreLinq.Test
             const int countA = 100;
             const int countB = 75;
             const int expectedCount = countA*countB;
-            var sequenceA = Enumerable.Range(1, countA);
-            var sequenceB = Enumerable.Range(1, countB);
-            var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
-
-            Assert.AreEqual( expectedCount, result.Count() );
+            using (var sequenceA = Enumerable.Range(1, countA).AsTestingSequence())
+            using (var sequenceB = Enumerable.Range(1, countB).AsTestingSequence())
+            {
+                var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
+                Assert.AreEqual( expectedCount, result.Count() );
+            }
         }
 
         /// <summary>
@@ -69,24 +80,30 @@ namespace MoreLinq.Test
         {
             var sequenceA = Enumerable.Range(0, 5);
             var sequenceB = Enumerable.Range(0, 5);
+
             var expectedSet = new[]
-                                  {
-                                      Enumerable.Repeat(false, 5).ToArray(),
-                                      Enumerable.Repeat(false, 5).ToArray(),
-                                      Enumerable.Repeat(false, 5).ToArray(),
-                                      Enumerable.Repeat(false, 5).ToArray(),
-                                      Enumerable.Repeat(false, 5).ToArray()
-                                  };
+            {
+                Enumerable.Repeat(false, 5).ToArray(),
+                Enumerable.Repeat(false, 5).ToArray(),
+                Enumerable.Repeat(false, 5).ToArray(),
+                Enumerable.Repeat(false, 5).ToArray(),
+                Enumerable.Repeat(false, 5).ToArray()
+            };
 
-            var result = sequenceA.Cartesian(sequenceB, (a, b) => new { A = a, B = b });
+            using (var tsA = sequenceA.AsTestingSequence())
+            using (var tsB = sequenceB.AsTestingSequence())
+            {
+                var result = tsA.Cartesian(tsB, (a, b) => new { A = a, B = b })
+                                .ToArray();
 
-            // verify that the expected number of results is correct
-            Assert.AreEqual(sequenceA.Count() * sequenceB.Count(), result.Count());
+                // verify that the expected number of results is correct
+                Assert.AreEqual(sequenceA.Count() * sequenceB.Count(), result.Count());
 
-            // ensure that all "cells" were visited by the cartesian product
-            foreach (var coord in result)
-                expectedSet[coord.A][coord.B] = true;
-            Assert.IsTrue(expectedSet.SelectMany(x => x).All(z => z));
+                // ensure that all "cells" were visited by the cartesian product
+                foreach (var coord in result)
+                    expectedSet[coord.A][coord.B] = true;
+                Assert.IsTrue(expectedSet.SelectMany(x => x).All(z => z));
+            }
         }
 
         /// <summary>
@@ -96,15 +113,16 @@ namespace MoreLinq.Test
         [Test]
         public void TestEmptyCartesianEvaluation()
         {
-            var sequence = Enumerable.Range(0, 5);
+            using (var sequence = Enumerable.Range(0, 5).AsTestingSequence())
+            {
+                var resultA = sequence.Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
+                var resultB = Enumerable.Empty<int>().Cartesian(sequence, (a, b) => new { A = a, B = b });
+                var resultC = Enumerable.Empty<int>().Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
 
-            var resultA = sequence.Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
-            var resultB = Enumerable.Empty<int>().Cartesian(sequence, (a, b) => new { A = a, B = b });
-            var resultC = Enumerable.Empty<int>().Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
-
-            Assert.AreEqual(0, resultA.Count());
-            Assert.AreEqual(0, resultB.Count());
-            Assert.AreEqual(0, resultC.Count());
+                Assert.AreEqual(0, resultA.Count());
+                Assert.AreEqual(0, resultB.Count());
+                Assert.AreEqual(0, resultC.Count());
+            }
         }
     }
 }

--- a/MoreLinq/Cartesian.cs
+++ b/MoreLinq/Cartesian.cs
@@ -41,7 +41,13 @@ namespace MoreLinq
         /// <returns>A sequence of elements returned by
         /// <paramref name="resultSelector"/>.</returns>
         /// <remarks>
-        /// This method uses deferred execution and stream its results.
+        /// <para>
+        /// Elements of <paramref name="second"/> are cached when being paired
+        /// with the first element of the <paramref name="first"/>. The cache is
+        /// then re-used for pairing with all subsequent element of
+        /// <paramref name="first"/>.</para>
+        /// <para>
+        /// This method uses deferred execution and stream its results.</para>
         /// </remarks>
 
         public static IEnumerable<TResult> Cartesian<TFirst, TSecond, TResult>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)

--- a/MoreLinq/Cartesian.cs
+++ b/MoreLinq/Cartesian.cs
@@ -19,7 +19,7 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
+    using Experimental;
 
     public static partial class MoreEnumerable
     {
@@ -41,9 +41,13 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return from item1 in first
-                   from item2 in second // TODO buffer to avoid multiple enumerations
-                   select resultSelector(item1, item2);
+            var secondMemo = second.Memoize();
+            using (secondMemo as IDisposable)
+            {
+                foreach (var item1 in first)
+                foreach (var item2 in secondMemo)
+                    yield return resultSelector(item1, item2);
+            }
         }
     }
 }

--- a/MoreLinq/Cartesian.cs
+++ b/MoreLinq/Cartesian.cs
@@ -41,12 +41,15 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            var secondMemo = second.Memoize();
-            using (secondMemo as IDisposable)
+            return _(); IEnumerable<TResult> _()
             {
-                foreach (var item1 in first)
-                foreach (var item2 in secondMemo)
-                    yield return resultSelector(item1, item2);
+                var secondMemo = second.Memoize();
+                using (secondMemo as IDisposable)
+                {
+                    foreach (var item1 in first)
+                    foreach (var item2 in secondMemo)
+                        yield return resultSelector(item1, item2);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes for #488.

Initial push contains bd628dea2f844efb0089bb8a4504b6e341616204 that uses `TestingSequence` to demonstrate that the test break.
