### PR TITLE
Fix AwaitCompletion to yield results during source iteration

### DIFF
--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -569,7 +569,7 @@ namespace MoreLinq.Experimental
                         {
                             await semaphore.WaitAsync(cancellationToken);
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
                         {
                             return;
                         }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -537,6 +537,12 @@ namespace MoreLinq.Experimental
             int maxConcurrency,
             CancellationTokenSource cancellationTokenSource)
         {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            if (taskSelector == null) throw new ArgumentNullException(nameof(taskSelector));
+            if (completionNoticeSelector == null) throw new ArgumentNullException(nameof(completionNoticeSelector));
+            if (observer == null) throw new ArgumentNullException(nameof(observer));
+            if (maxConcurrency < 1) throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+
             try
             {
                 var cancellationToken = cancellationTokenSource.Token;

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -422,7 +422,6 @@ namespace MoreLinq.Experimental
 
             IEnumerable<TResult> _(int? maxConcurrency, TaskScheduler scheduler, bool ordered)
             {
-                var cancellationTokenSource = new CancellationTokenSource();
                 var consumerCancellationTokenSource = new CancellationTokenSource();
                 Exception lastCriticalError = null;
 
@@ -434,8 +433,6 @@ namespace MoreLinq.Experimental
                 {
                     try
                     {
-                        if (notice == Notice.Error)
-                            cancellationTokenSource.Cancel();
                         notices.Add((notice, item, error));
                     }
                     catch (Exception e)
@@ -451,6 +448,7 @@ namespace MoreLinq.Experimental
                 }
 
                 var completed = false;
+                var cancellationTokenSource = new CancellationTokenSource();
 
                 var enumerator = source.Index().GetEnumerator();
                 IDisposable disposable = enumerator; // disables AccessToDisposedClosure warnings

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -429,11 +429,14 @@ namespace MoreLinq.Experimental
 
                 void PostNotice(Notice notice,
                                 (int, T, Task<TTaskResult>) item,
-                                ExceptionDispatchInfo error)
+                                Exception error)
                 {
                     try
                     {
-                        notices.Add((notice, item, error));
+                        var edi = error != null
+                                ? ExceptionDispatchInfo.Capture(error)
+                                : null;
+                        notices.Add((notice, item, edi));
                     }
                     catch (Exception e)
                     {
@@ -470,7 +473,7 @@ namespace MoreLinq.Experimental
                             }
                             catch (Exception e)
                             {
-                                PostNotice(Notice.Error, default, ExceptionDispatchInfo.Capture(e));
+                                PostNotice(Notice.Error, default, e);
                             }
                         },
                         CancellationToken.None,

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -509,7 +509,7 @@ namespace MoreLinq.Experimental
                         TaskCreationOptions.DenyChildAttach,
                         scheduler);
 
-                    // Remainde here is the main loop that waits for and
+                    // Remainder here is the main loop that waits for and
                     // processes notices.
 
                     var nextKey = 0;

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -571,12 +571,12 @@ namespace MoreLinq.Experimental
                         }
                         catch (OperationCanceledException)
                         {
-                            break;
+                            return;
                         }
                     }
 
                     if (cancellationToken.IsCancellationRequested)
-                        break;
+                        return;
 
                     Interlocked.Increment(ref pendingCount);
 

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -575,35 +575,32 @@ namespace MoreLinq.Experimental
                         {
                             semaphore.Release();
 
-                            //
-                            // try
-                            // {
-                            //     collection.Add(completionNoticeSelector(item, t));
-                            // }
-                            // catch (Exception exception)
-                            // {
-                            //     collection.Add(errorNoticeSelector(exception));
-                            // }
-                            //
-
                             if (cancellationToken.IsCancellationRequested)
                                 return;
 
+                            // TODO Consider what happens if following fails
                             observer.OnNext(completionNoticeSelector(item, t));
 
                             if (Interlocked.Decrement(ref pendingCount) == 0)
+                            {
+                                // TODO Consider what happens if following fails
                                 observer.OnCompleted();
+                            }
                         });
 
                     #pragma warning restore 4014
                 }
 
                 if (Interlocked.Decrement(ref pendingCount) == 0)
+                {
+                    // TODO Consider what happens if following fails
                     observer.OnCompleted();
+                }
             }
             catch (Exception ex)
             {
                 cancellationTokenSource.Cancel();
+                // TODO Consider what happens if following fails
                 observer.OnError(ex);
             }
             finally

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -456,6 +456,9 @@ namespace MoreLinq.Experimental
                         if (kind == Notice.Error)
                             error.Throw();
 
+                        if (kind == Notice.End)
+                            break;
+
                         Debug.Assert(kind == Notice.Result);
 
                         var (key, inp, value) = result;

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -636,10 +636,9 @@ namespace MoreLinq.Experimental
                         onEnd();
                 }
 
-                var concurrencyGate
-                    = maxConcurrency is int count
-                    ? new ConcurrencyGate(count)
-                    : ConcurrencyGate.Unbounded;
+                var concurrencyGate = maxConcurrency is int count
+                                    ? new ConcurrencyGate(count)
+                                    : ConcurrencyGate.Unbounded;
 
                 while (enumerator.MoveNext())
                 {

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -527,26 +527,6 @@ namespace MoreLinq.Experimental
             }
         }
 
-        sealed class Observer<T> : IObserver<T>
-        {
-            readonly Action<T> _onNext;
-            readonly Action<Exception> _onError;
-            readonly Action _onCompleted;
-
-            public Observer(Action<T> onNext, Action<Exception> onError, Action onCompleted)
-            {
-                _onNext      = onNext      ?? throw new ArgumentNullException(nameof(onNext));
-                _onError     = onError     ?? throw new ArgumentNullException(nameof(onError));
-                _onCompleted = onCompleted ?? throw new ArgumentNullException(nameof(onCompleted));
-            }
-
-            public void OnNext(T value)          => _onNext(value);
-            public void OnError(Exception error) => _onError(error);
-            public void OnCompleted()            => _onCompleted();
-        }
-
-        static Lazy<T> Lazy<T>(Func<T> valueFactory) => new Lazy<T>(valueFactory, LazyThreadSafetyMode.None);
-
         enum Notice { Result, Error }
 
         static async Task StartAsync<T, TResult, TNotice>(
@@ -663,6 +643,26 @@ namespace MoreLinq.Experimental
             public IEnumerator<T> GetEnumerator() => _impl(Options).GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        sealed class Observer<T> : IObserver<T>
+        {
+            readonly Action<T> _onNext;
+            readonly Action<Exception> _onError;
+            readonly Action _onCompleted;
+
+            public Observer(Action<T> onNext, Action<Exception> onError, Action onCompleted)
+            {
+                _onNext      = onNext      ?? throw new ArgumentNullException(nameof(onNext));
+                _onError     = onError     ?? throw new ArgumentNullException(nameof(onError));
+                _onCompleted = onCompleted ?? throw new ArgumentNullException(nameof(onCompleted));
+            }
+
+            public void OnNext(T value)          => _onNext(value);
+            public void OnError(Exception error) => _onError(error);
+            public void OnCompleted()            => _onCompleted();
+        }
+
+        static Lazy<T> Lazy<T>(Func<T> valueFactory) => new Lazy<T>(valueFactory, LazyThreadSafetyMode.None);
 
         static class TupleComparer<T1, T2, T3>
         {

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -615,14 +615,14 @@ namespace MoreLinq.Experimental
         static async Task StartAsync<T, TResult>(
             this IEnumerator<T> enumerator,
             Func<T, Task<TResult>> starter,
-            Action<T, Task<TResult>> onCompletion,
+            Action<T, Task<TResult>> onTaskCompletion,
             Action onEnd,
             int? maxConcurrency,
             CancellationToken cancellationToken)
         {
             if (enumerator == null) throw new ArgumentNullException(nameof(enumerator));
             if (starter == null) throw new ArgumentNullException(nameof(starter));
-            if (onCompletion == null) throw new ArgumentNullException(nameof(onCompletion));
+            if (onTaskCompletion == null) throw new ArgumentNullException(nameof(onTaskCompletion));
             if (onEnd == null) throw new ArgumentNullException(nameof(onEnd));
             if (maxConcurrency < 1) throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
 
@@ -672,7 +672,7 @@ namespace MoreLinq.Experimental
                             if (cancellationToken.IsCancellationRequested)
                                 return;
 
-                            onCompletion(item, t);
+                            onTaskCompletion(item, t);
                             OnPendingCompleted();
                         });
 


### PR DESCRIPTION
This PR addresses #502.

Changes:

- A continuation is used to post task completions to the main loop so they can be reported and yielded while the source is still being iterated
- A semaphore is used to gate concurrency (when limited)

The source iteration loop has been refactored considerably. It is more complex since it uses asynchronous notification and requires synchronisation of shared state. Previously, the naïve approach was to loop through the entire source, launching tasks and then wait in another loop to post notifications as they complete. That unfortunately led to the behaviour documented in #502.
