### PR TITLE
WindowLeft implementation

### DIFF
--- a/MoreLinq.Test/WindowRightTest.cs
+++ b/MoreLinq.Test/WindowRightTest.cs
@@ -1,0 +1,80 @@
+namespace MoreLinq.Test
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class WindowRightTest
+    {
+        [Test]
+        public void WindowRightIsLazy()
+        {
+            new BreakingSequence<int>().WindowRight(1);
+        }
+
+        [Test]
+        public void WindowRightWithNegativeWindowSize()
+        {
+            AssertThrowsArgument.OutOfRangeException("size", () =>
+                Enumerable.Repeat(1, 10).WindowRight(-5));
+        }
+
+        [Test]
+        public void WindowRightWithEmptySequence()
+        {
+            using (var xs = Enumerable.Empty<int>().AsTestingSequence())
+            {
+                var result = xs.WindowRight(5);
+                Assert.That(result, Is.Empty);
+            }
+        }
+
+        [Test]
+        public void WindowRightWithSingleElement()
+        {
+            const int count = 100;
+            var sequence = Enumerable.Range(1, count).ToArray();
+
+            IList<int>[] result;
+            using (var ts = sequence.AsTestingSequence())
+                result = ts.WindowRight(1).ToArray();
+
+            // number of windows should be equal to the source sequence length
+            Assert.That(result.Length, Is.EqualTo(count));
+
+            // each window should contain single item consistent of element at that offset
+            foreach (var window in result.Index())
+                Assert.That(sequence.ElementAt(window.Key), Is.EqualTo(window.Value.Single()));
+        }
+
+        [Test]
+        public void WindowRightWithWindowSizeLargerThanSequence()
+        {
+            using (var sequence = Enumerable.Range(1, 5).AsTestingSequence())
+            using (var reader = sequence.WindowRight(10).Read())
+            {
+                reader.Read().AssertSequenceEqual(            1);
+                reader.Read().AssertSequenceEqual(         1, 2);
+                reader.Read().AssertSequenceEqual(      1, 2, 3);
+                reader.Read().AssertSequenceEqual(   1, 2, 3, 4);
+                reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
+                reader.ReadEnd();
+            }
+        }
+
+        [Test]
+        public void WindowRightWithWindowSizeSmallerThanSequence()
+        {
+            using (var sequence = Enumerable.Range(1, 5).AsTestingSequence())
+            using (var reader = sequence.WindowRight(3).Read())
+            {
+                reader.Read().AssertSequenceEqual(      1);
+                reader.Read().AssertSequenceEqual(   1, 2);
+                reader.Read().AssertSequenceEqual(1, 2, 3);
+                reader.Read().AssertSequenceEqual(2, 3, 4);
+                reader.Read().AssertSequenceEqual(3, 4, 5);
+                reader.ReadEnd();
+            }
+        }
+    }
+}

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -103,6 +103,7 @@
         - TraverseDepthFirst
         - Unfold
         - Windowed
+        - WindowRight
         - ZipLongest
         - ZipShortest
     </Description>
@@ -124,7 +125,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>morelinq</PackageId>
     <PackageTags>linq;extensions</PackageTags>
-    <PackageReleaseNotes>Adds new operators: Await (EXPERIMENTAL), AwaitCompletion (EXPERIMENTAL), Backsert, CompareCount, Choose, CountDown, Memoize (EXPERIMENTAL), Transpose, ZipLongest (overloads). See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.</PackageReleaseNotes>
+    <PackageReleaseNotes>Adds new operators: Await (EXPERIMENTAL), AwaitCompletion (EXPERIMENTAL), Backsert, CompareCount, Choose, CountDown, Memoize (EXPERIMENTAL), Transpose, ZipLongest (overloads), WindowRight. See also https://github.com/morelinq/MoreLINQ/wiki/API-Changes.</PackageReleaseNotes>
     <PackageProjectUrl>https://morelinq.github.io/</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -1,0 +1,93 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Creates a right-aligned sliding window over the source sequence
+        /// of a given size.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">
+        /// The sequence over which to create the sliding window.</param>
+        /// <param name="size">Size of the sliding window.</param>
+        /// <returns>A sequence representing each sliding window.</returns>
+        /// <remarks>
+        /// <para>
+        /// A window can contain fewer elements than <paramref name="size"/>,
+        /// especially as it slides over the start of the sequence.</para>
+        /// <para>
+        /// This operator uses deferred execution and streams its results.</para>
+        /// </remarks>
+        /// <example>
+        /// <code><![CDATA[
+        /// Console.WriteLine(
+        ///     Enumerable
+        ///         .Range(1, 5)
+        ///         .WindowRight(3)
+        ///         .Select(w => "AVG(" + w.ToDelimitedString(",") + ") = " + w.Average())
+        ///         .ToDelimitedString(Environment.NewLine));
+        ///
+        /// // Output:
+        /// // AVG(1) = 1
+        /// // AVG(1,2) = 1.5
+        /// // AVG(1,2,3) = 2
+        /// // AVG(2,3,4) = 3
+        /// // AVG(3,4,5) = 4
+        /// ]]></code>
+        /// </example>
+
+        public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
+
+            return source.WindowRightWhile((_, i) => i < size);
+        }
+
+        /// <summary>
+        /// Creates a right-aligned sliding window over the source sequence
+        /// with a predicate function determining the window range.
+        /// </summary>
+
+        static IEnumerable<IList<TSource>> WindowRightWhile<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, int, bool> predicate)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return _(); IEnumerable<IList<TSource>> _()
+            {
+                var window = new List<TSource>();
+                foreach (var item in source)
+                {
+                    window.Add(item);
+                    yield return window;
+                    window = new List<TSource>(predicate(item, window.Count) ? window : window.Skip(1));
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -603,6 +603,10 @@ This method has 2 overloads.
 Processes a sequence into a series of subsequences representing a windowed
 subset of the original
 
+### WindowRight
+
+Creates a right-aligned sliding window over the source sequence of a given size.
+
 ### ZipLongest
 
 Returns a projection of tuples, where each tuple contains the N-th element


### PR DESCRIPTION
This PR implements `WindowRight` as proposed in #153.