### PR TITLE
Rename Concat to Append, marking Concat obsolete

### DIFF
--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -21,47 +21,47 @@ namespace MoreLinq.Test
     using NUnit.Framework;
 
     [TestFixture]
-    public class ConcatTest
+    public class AppendTest
     {
-        #region Concat with single head and tail sequence
+        #region Append with single head and tail sequence
         [Test]
-        public void ConcatWithNonEmptyHeadSequence()
+        public void AppendWithNonEmptyHeadSequence()
         {
             var head = new[] { "first", "second" };
             var tail = "third";
-            var whole = head.Concat(tail);
+            var whole = head.Append(tail);
             whole.AssertSequenceEqual("first", "second", "third");
         }
 
         [Test]
-        public void ConcatWithEmptyHeadSequence()
+        public void AppendWithEmptyHeadSequence()
         {
             string[] head = { };
             var tail = "first";
-            var whole = head.Concat(tail);
+            var whole = head.Append(tail);
             whole.AssertSequenceEqual("first");
         }
 
         [Test]
-        public void ConcatWithNullTail()
+        public void AppendWithNullTail()
         {
             var head = new[] { "first", "second" };
             string tail = null;
-            var whole = head.Concat(tail);
+            var whole = head.Append(tail);
             whole.AssertSequenceEqual("first", "second", null);
         }
 
         [Test]
-        public void ConcatIsLazyInHeadSequence()
+        public void AppendIsLazyInHeadSequence()
         {
-            new BreakingSequence<string>().Concat("tail");
+            new BreakingSequence<string>().Append("tail");
         }
         #endregion
 
         [TestCaseSource(nameof(ContactManySource))]
-        public void ConcatMany(int[] head, int[] tail)
+        public void AppendMany(int[] head, int[] tail)
         {
-            tail.Aggregate(head.AsEnumerable(), (xs, x) => xs.Concat(x))
+            tail.Aggregate(head.AsEnumerable(), (xs, x) => xs.Append(x))
                 .AssertSequenceEqual(head.Concat(tail));
         }
 
@@ -79,11 +79,11 @@ namespace MoreLinq.Test
                                                     "Tail = [" + string.Join(", ", e.Tail) + "]");
 
         [Test]
-        public void ConcatWithSharedSource()
+        public void AppendWithSharedSource()
         {
-            var first  = new [] { 1 }.Concat(2);
-            var second = first.Concat(3).Concat(4);
-            var third  = first.Concat(4).Concat(8);
+            var first  = new [] { 1 }.Append(2);
+            var second = first.Append(3).Append(4);
+            var third  = first.Append(4).Append(8);
 
             second.AssertSequenceEqual(1, 2, 3, 4);
             third.AssertSequenceEqual(1, 2, 4, 8);

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -28,7 +28,7 @@ namespace MoreLinq.Test
         {
             var sorted = Enumerable.Range(1, 10)
                                    .Reverse()
-                                   .Concat(0)
+                                   .Append(0)
                                    .PartialSort(5);
 
             sorted.AssertSequenceEqual(Enumerable.Range(0, 5));
@@ -39,13 +39,13 @@ namespace MoreLinq.Test
         {
             var sorted = Enumerable.Range(1, 10)
                                     .Reverse()
-                                    .Concat(0)
+                                    .Append(0)
                                     .PartialSort(5, OrderByDirection.Ascending);
 
             sorted.AssertSequenceEqual(Enumerable.Range(0, 5));
             sorted = Enumerable.Range(1, 10)
                                 .Reverse()
-                                .Concat(0)
+                                .Append(0)
                                 .PartialSort(5, OrderByDirection.Descending);
             sorted.AssertSequenceEqual(Enumerable.Range(6, 5).Reverse());
         }

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -31,12 +31,25 @@ namespace MoreLinq
         /// <returns>A sequence consisting of the head elements and the given tail element.</returns>
         /// <remarks>This operator uses deferred execution and streams its results.</remarks>
 
-        public static IEnumerable<T> Concat<T>(this IEnumerable<T> head, T tail)
+        public static IEnumerable<T> Append<T>(this IEnumerable<T> head, T tail)
         {
             if (head == null) throw new ArgumentNullException(nameof(head));
-            return head is PcNode<T> node
-                 ? node.Concat(tail)
-                 : PcNode<T>.WithSource(head).Concat(tail);
+            return head is PendNode<T> node
+                ? node.Concat(tail)
+                : PendNode<T>.WithSource(head).Concat(tail);
         }
+
+        /// <summary>
+        /// Returns a sequence consisting of the head elements and the given tail element.
+        /// </summary>
+        /// <typeparam name="T">Type of sequence</typeparam>
+        /// <param name="head">All elements of the head. Must not be null.</param>
+        /// <param name="tail">Tail element of the new sequence.</param>
+        /// <returns>A sequence consisting of the head elements and the given tail element.</returns>
+        /// <remarks>This operator uses deferred execution and streams its results.</remarks>
+
+        [Obsolete("Use " + nameof(Append) + " instead.")]
+        public static IEnumerable<T> Concat<T>(this IEnumerable<T> head, T tail) =>
+            head.Append(tail);
     }
 }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -595,7 +595,7 @@ namespace MoreLinq.Experimental
                     // a consequence generate new and unique task objects.
 
                     var completedTask = await
-                        Task.WhenAny(tasks.Select(it => (Task) it.Task).Concat(cancellationTaskSource.Task))
+                        Task.WhenAny(tasks.Select(it => (Task) it.Task).Append(cancellationTaskSource.Task))
                             .ConfigureAwait(continueOnCapturedContext: false);
 
                     if (completedTask == cancellationTaskSource.Task)

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -10,6 +10,7 @@
 
         - Acquire
         - AggregateRight
+        - Append
         - Assert
         - AssertCount
         - AtLeast
@@ -24,7 +25,6 @@
         - CompareCount
         - CountBy
         - CountDown
-        - Concat
         - Consume
         - DistinctBy
         - EndsWith

--- a/MoreLinq/PendNode.cs
+++ b/MoreLinq/PendNode.cs
@@ -22,25 +22,25 @@ namespace MoreLinq
     using System.Collections.Generic;
 
     /// <summary>
-    /// Prepend-Concat node is a single linked-list of the discriminated union
-    /// of a prepend item, a concat item and the source.
+    /// Prepend-Append node is a single linked-list of the discriminated union
+    /// of an item to prepend, an item to append and the source.
     /// </summary>
 
-    abstract class PcNode<T> : IEnumerable<T>
+    abstract class PendNode<T> : IEnumerable<T>
     {
-        public static PcNode<T> WithSource(IEnumerable<T> source) => new Source(source);
+        public static PendNode<T> WithSource(IEnumerable<T> source) => new Source(source);
 
-        public PcNode<T> Prepend(T item) => new Item(item, isPrepend: true , next: this);
-        public PcNode<T> Concat(T item)  => new Item(item, isPrepend: false, next: this);
+        public PendNode<T> Prepend(T item) => new Item(item, isPrepend: true , next: this);
+        public PendNode<T> Concat(T item)  => new Item(item, isPrepend: false, next: this);
 
-        sealed class Item : PcNode<T>
+        sealed class Item : PendNode<T>
         {
             public T Value { get; }
             public bool IsPrepend { get; }
             public int ConcatCount { get; }
-            public PcNode<T> Next { get; }
+            public PendNode<T> Next { get; }
 
-            public Item(T item, bool isPrepend, PcNode<T> next)
+            public Item(T item, bool isPrepend, PendNode<T> next)
             {
                 if (next == null) throw new ArgumentNullException(nameof(next));
 
@@ -53,7 +53,7 @@ namespace MoreLinq
             }
         }
 
-        sealed class Source : PcNode<T>
+        sealed class Source : PendNode<T>
         {
             public IEnumerable<T> Value { get; }
             public Source(IEnumerable<T> source) => Value = source;

--- a/MoreLinq/Prepend.cs
+++ b/MoreLinq/Prepend.cs
@@ -44,9 +44,9 @@ namespace MoreLinq
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return source is PcNode<TSource> node
+            return source is PendNode<TSource> node
                  ? node.Prepend(value)
-                 : PcNode<TSource>.WithSource(source).Prepend(value);
+                 : PendNode<TSource>.WithSource(source).Prepend(value);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This operator is the right-associative version of the Aggregate LINQ operator.
 
 This method has 3 overloads.
 
+### Append
+
+Returns a sequence consisting of the head element and the given tail elements.
+
 ### Assert
 
 Asserts that all elements of a sequence meet a given condition otherwise
@@ -109,9 +113,12 @@ second.
 Compares two sequences and returns an integer that indicates whether the
 first sequence has fewer, the same or more elements than the second sequence.
 
-### Concat
+### ~~Concat~~
 
 Returns a sequence consisting of the head element and the given tail elements.
+
+This method is obsolete and will be removed in a future version. Use `Append`
+insted.
 
 ### Consume
 


### PR DESCRIPTION
This PR addresses #496.

`Concat` will still ship but is marked obsolete and calls `Append` behind the scenes. It will then be removed in a future version.
