### PR TITLE
Upgrade to .NET Core SDK 2.1.200

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ solution: MoreLinq.sln
 mono: 5.0.1
 dist: trusty
 sudo: required
-dotnet: 2.1.2
+dotnet: 2.1.200
 env:
   - CONFIGURATION=Debug
   - CONFIGURATION=Release

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "MoreLinq.Test"
     ],
     "sdk": {
-        "version": "2.1.2"
+        "version": "2.1.200"
     }
 }


### PR DESCRIPTION
Seems that [`dotnet` muxer uses the latest patch within the same _hundreds_](https://github.com/johnbeisner/core-setup/blob/5d6e8afba2379bb698e50f2ebe0282b1f7c267ac/src/corehost/cli/fxr/fx_muxer.cpp#L694-L702
):

```cpp
            if (global_cli_version.empty() ||
                // If a global cli version is specified:
                //   pick the greatest version that differs only in the 'minor-patch'
                //   and is semantically greater than or equal to the global cli version specified.
                (ver.get_major() == specified.get_major() && ver.get_minor() == specified.get_minor() &&
                (ver.get_patch() / 100) == (specified.get_patch() / 100) && ver >= specified))
            {
                max_ver = std::max(ver, max_ver);
            }
```
