### PR TITLE
Add support for partial Min/MaxBy

### DIFF
--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -59,5 +59,57 @@ namespace MoreLinq.Test
         {
             Assert.AreEqual(new[] { "aa" }, SampleData.Strings.MaxBy(x => x[1], SampleData.ReverseCharComparer));
         }
+
+        [TestCase(0, ExpectedResult = new string[0]             )]
+        [TestCase(1, ExpectedResult = new[] { "hello"          })]
+        [TestCase(2, ExpectedResult = new[] { "hello", "world" })]
+        [TestCase(3, ExpectedResult = new[] { "hello", "world" })]
+        public string[] MaxByTakeReturnsMaxima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MaxBy(s => s.Length).Take(count).ToArray();
+        }
+
+        [TestCase(0, ExpectedResult = new string[0]             )]
+        [TestCase(1, ExpectedResult = new[] { "world"          })]
+        [TestCase(2, ExpectedResult = new[] { "hello", "world" })]
+        [TestCase(3, ExpectedResult = new[] { "hello", "world" })]
+        public string[] MaxByTakeLastReturnsMaxima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MaxBy(s => s.Length).TakeLast(count).ToArray();
+        }
+
+        [TestCase(0, 0, ExpectedResult = new string[0]                         )]
+        [TestCase(3, 1, ExpectedResult = new[] { "aa"                         })]
+        [TestCase(1, 0, ExpectedResult = new[] { "ax"                         })]
+        [TestCase(2, 0, ExpectedResult = new[] { "ax", "aa"                   })]
+        [TestCase(3, 0, ExpectedResult = new[] { "ax", "aa", "ab"             })]
+        [TestCase(4, 0, ExpectedResult = new[] { "ax", "aa", "ab", "ay"       })]
+        [TestCase(5, 0, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        [TestCase(6, 0, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        public string[] MaxByTakeWithComparerReturnsMaxima(int count, int index)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MaxBy(s => s[index], SampleData.ReverseCharComparer)
+                              .Take(count)
+                              .ToArray();
+        }
+
+        [TestCase(0, 0, ExpectedResult = new string[0]                         )]
+        [TestCase(3, 1, ExpectedResult = new[] { "aa"                         })]
+        [TestCase(1, 0, ExpectedResult = new[] { "az"                         })]
+        [TestCase(2, 0, ExpectedResult = new[] { "ay", "az"                   })]
+        [TestCase(3, 0, ExpectedResult = new[] { "ab", "ay", "az"             })]
+        [TestCase(4, 0, ExpectedResult = new[] { "aa", "ab", "ay", "az"       })]
+        [TestCase(5, 0, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        [TestCase(6, 0, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        public string[] MaxByTakeLastWithComparerReturnsMaxima(int count, int index)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MaxBy(s => s[index], SampleData.ReverseCharComparer)
+                              .TakeLast(count)
+                              .ToArray();
+        }
     }
 }

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -17,6 +17,8 @@
 
 namespace MoreLinq.Test
 {
+    using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -58,6 +60,56 @@ namespace MoreLinq.Test
         public void MinByWithComparer()
         {
             Assert.AreEqual(new[] { "az" }, SampleData.Strings.MinBy(x => x[1], SampleData.ReverseCharComparer));
+        }
+
+        [TestCase(0, ExpectedResult = new string[0]                         )]
+        [TestCase(1, ExpectedResult = new[] { "ax"                         })]
+        [TestCase(2, ExpectedResult = new[] { "ax", "aa"                   })]
+        [TestCase(3, ExpectedResult = new[] { "ax", "aa", "ab"             })]
+        [TestCase(4, ExpectedResult = new[] { "ax", "aa", "ab", "ay"       })]
+        [TestCase(5, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        [TestCase(6, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        public string[] MinByTakeReturnsMinima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MinBy(s => s.Length).Take(count).ToArray();
+        }
+
+        [TestCase(0, ExpectedResult = new string[0]                         )]
+        [TestCase(1, ExpectedResult = new[] { "az"                         })]
+        [TestCase(2, ExpectedResult = new[] { "ay", "az"                   })]
+        [TestCase(3, ExpectedResult = new[] { "ab", "ay", "az"             })]
+        [TestCase(4, ExpectedResult = new[] { "aa", "ab", "ay", "az"       })]
+        [TestCase(5, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        [TestCase(6, ExpectedResult = new[] { "ax", "aa", "ab", "ay", "az" })]
+        public string[] MinByTakeLastReturnsMinima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MinBy(s => s.Length).TakeLast(count).ToArray();
+        }
+
+        [TestCase(0, ExpectedResult = new string[0]             )]
+        [TestCase(1, ExpectedResult = new[] { "hello",         })]
+        [TestCase(2, ExpectedResult = new[] { "hello", "world" })]
+        [TestCase(3, ExpectedResult = new[] { "hello", "world" })]
+        public string[] MinByTakeWithComparerReturnsMinima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MinBy(s => s.Length, Comparer<int>.Create((x, y) => -Math.Sign(x.CompareTo(y))))
+                              .Take(count)
+                              .ToArray();
+        }
+
+        [TestCase(0, ExpectedResult = new string[0]             )]
+        [TestCase(1, ExpectedResult = new[] { "world",         })]
+        [TestCase(2, ExpectedResult = new[] { "hello", "world" })]
+        [TestCase(3, ExpectedResult = new[] { "hello", "world" })]
+        public string[] MinByTakeLastWithComparerReturnsMinima(int count)
+        {
+            using (var strings = SampleData.Strings.AsTestingSequence())
+                return strings.MinBy(s => s.Length, Comparer<int>.Create((x, y) => -Math.Sign(x.CompareTo(y))))
+                              .TakeLast(count)
+                              .ToArray();
         }
     }
 }

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -18,10 +18,154 @@
 namespace MoreLinq
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Exposes the enumerator, which supports iteration over a sequence of
+    /// some extremum property (maximum or minimum) of a specified type.
+    /// </summary>
+
+    public interface IExtremaEnumerable<out T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// Returns a specified number of contiguous elements from the start of
+        /// the sequence.
+        /// </summary>
+        /// <param name="count">The number of elements to return.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> that contains the specified number
+        /// of elements from the start of the input sequence.
+        /// </returns>
+
+        IEnumerable<T> Take(int count);
+
+        /// <summary>
+        /// Returns a specified number of contiguous elements at the end of the
+        /// sequence.
+        /// </summary>
+        /// <param name="count">The number of elements to return.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> that contains the specified number
+        /// of elements at the end of the input sequence.
+        /// </returns>
+
+        IEnumerable<T> TakeLast(int count);
+    }
 
     static partial class MoreEnumerable
     {
+        /// <summary>
+        /// Returns the first element of a sequence.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequence is empty.</exception>
+        /// <returns>
+        /// The first element of the input sequence.
+        /// </returns>
+
+        public static T First<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.Take(1).AsEnumerable().First();
+        }
+
+        /// <summary>
+        /// Returns the first element of a sequence, or a default value if the
+        /// sequence contains no elements.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <returns>
+        /// Default value of type <typeparamref name="T"/> if source is empty;
+        /// otherwise, the first element in source.
+        /// </returns>
+
+        public static T FirstOrDefault<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.Take(1).AsEnumerable().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Returns the last element of a sequence.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequence is empty.</exception>
+        /// <returns>
+        /// The last element of the input sequence.
+        /// </returns>
+
+        public static T Last<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.TakeLast(1).AsEnumerable().Last();
+        }
+
+        /// <summary>
+        /// Returns the last element of a sequence, or a default value if the
+        /// sequence contains no elements.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <returns>
+        /// Default value of type <typeparamref name="T"/> if source is empty;
+        /// otherwise, the last element in source.
+        /// </returns>
+
+        public static T LastOrDefault<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.Take(1).AsEnumerable().LastOrDefault();
+        }
+
+        /// <summary>
+        /// Returns the only element of a sequence, and throws an exception if
+        /// there is not exactly one element in the sequence.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequence contains more than one element.</exception>
+        /// <returns>
+        /// The single element of the input sequence.
+        /// </returns>
+
+        public static T Single<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.Take(2).AsEnumerable().Single();
+        }
+
+        /// <summary>
+        /// Returns the only element of a sequence, or a default value if the
+        /// sequence is empty; this method throws an exception if there is more
+        /// than one element in the sequence.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The input sequence.</param>
+        /// <returns>
+        /// The single element of the input sequence, or default value of type
+        /// <typeparamref name="T"/> if the sequence contains no elements.
+        /// </returns>
+
+        public static T SingleOrDefault<T>(this IExtremaEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            return source.Take(2).AsEnumerable().SingleOrDefault();
+        }
+
         /// <summary>
         /// Returns the maximal elements of the given sequence, based on
         /// the given projection.
@@ -39,7 +183,7 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> is empty</exception>
 
-        public static IEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
             return source.MaxBy(selector, null);
@@ -63,14 +207,90 @@ namespace MoreLinq
         /// or <paramref name="comparer"/> is null</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> is empty</exception>
 
-        public static IEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey> comparer)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (selector == null) throw new ArgumentNullException(nameof(selector));
 
             comparer = comparer ?? Comparer<TKey>.Default;
-            return ExtremaBy(source, selector, (x, y) => comparer.Compare(x, y));
+            return new ExtremaEnumerable<TSource, TKey>(source, selector, (x, y) => comparer.Compare(x, y));
+        }
+
+        sealed class ExtremaEnumerable<T, TKey> : IExtremaEnumerable<T>
+        {
+            readonly IEnumerable<T> _source;
+            readonly Func<T, TKey> _selector;
+            readonly Func<TKey, TKey, int> _comparer;
+
+            public ExtremaEnumerable(IEnumerable<T> source, Func<T, TKey> selector, Func<TKey, TKey, int> comparer)
+            {
+                _source = source;
+                _selector = selector;
+                _comparer = comparer;
+            }
+
+            public IEnumerator<T> GetEnumerator() =>
+                ExtremaBy(_source, Extrema.First, null, _selector, _comparer).GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() =>
+                GetEnumerator();
+
+            public IEnumerable<T> Take(int count)
+                => count == 0 ? Enumerable.Empty<T>()
+                 : count == 1 ? ExtremaBy(_source, Extremum.First, 1    , _selector, _comparer)
+                              : ExtremaBy(_source, Extrema.First , count, _selector, _comparer);
+
+            public IEnumerable<T> TakeLast(int count)
+                => count == 0 ? Enumerable.Empty<T>()
+                 : count == 1 ? ExtremaBy(_source, Extremum.Last, 1    , _selector, _comparer)
+                              : ExtremaBy(_source, Extrema.Last , count, _selector, _comparer);
+
+            static class Extrema
+            {
+                public static readonly Extrema<List<T> , T> First = new FirstExtrema();
+                public static readonly Extrema<Queue<T>, T> Last  = new LastExtrema();
+
+                sealed class FirstExtrema : Extrema<List<T>, T>
+                {
+                    protected override IEnumerable<T> GetSomeEnumerable(List<T> store) => store;
+                    protected override int Count(List<T> store) => store?.Count ?? 0;
+                    protected override void Push(ref List<T> store, T item) => (store ?? (store = new List<T>())).Add(item);
+                    protected override bool TryPop(ref List<T> store) => false;
+                }
+
+                sealed class LastExtrema : Extrema<Queue<T>, T>
+                {
+                    protected override IEnumerable<T> GetSomeEnumerable(Queue<T> store) => store;
+                    protected override int Count(Queue<T> store) => store?.Count ?? 0;
+                    protected override void Push(ref Queue<T> store, T item) => (store ?? (store = new Queue<T>())).Enqueue(item);
+                    protected override bool TryPop(ref Queue<T> store) { store.Dequeue(); return true; }
+                }
+            }
+
+            sealed class Extremum : Extrema<(bool HasValue, T Value), T>
+            {
+                public static readonly Extrema<(bool, T), T> First = new Extremum(false);
+                public static readonly Extrema<(bool, T), T> Last  = new Extremum(true);
+
+                readonly bool _poppable;
+                Extremum(bool poppable) => _poppable = poppable;
+
+                protected override IEnumerable<T> GetSomeEnumerable((bool HasValue, T Value) store) =>
+                    Enumerable.Repeat(store.Value, 1);
+
+                protected override int Count((bool HasValue, T Value) store) => store.HasValue ? 1 : 0;
+                protected override void Push(ref (bool, T) store, T item) => store = (true, item);
+
+                protected override bool TryPop(ref (bool, T) store)
+                {
+                    if (!_poppable)
+                        return false;
+
+                    Restart(ref store);
+                    return true;
+                }
+            }
         }
 
         // > In mathematical analysis, the maxima and minima (the respective
@@ -79,7 +299,9 @@ namespace MoreLinq
         // >
         // > - https://en.wikipedia.org/wiki/Maxima_and_minima
 
-        static IEnumerable<TSource> ExtremaBy<TSource, TKey>(IEnumerable<TSource> source,
+        static IEnumerable<TSource> ExtremaBy<TSource, TKey, TStore>(
+            this IEnumerable<TSource> source,
+            Extrema<TStore, TSource> extrema, int? limit,
             Func<TSource, TKey> selector, Func<TKey, TKey, int> comparer)
         {
             foreach (var item in Extrema())
@@ -92,7 +314,8 @@ namespace MoreLinq
                     if (!e.MoveNext())
                         return new List<TSource>();
 
-                    var extrema = new List<TSource> { e.Current };
+                    var store = extrema.New();
+                    extrema.Add(ref store, limit, e.Current);
                     var extremaKey = selector(e.Current);
 
                     while (e.MoveNext())
@@ -102,18 +325,42 @@ namespace MoreLinq
                         var comparison = comparer(key, extremaKey);
                         if (comparison > 0)
                         {
-                            extrema = new List<TSource> { item };
+                            extrema.Restart(ref store);
+                            extrema.Add(ref store, limit, item);
                             extremaKey = key;
                         }
                         else if (comparison == 0)
                         {
-                            extrema.Add(item);
+                            extrema.Add(ref store, limit, item);
                         }
                     }
 
-                    return extrema;
+                    return extrema.GetEnumerable(store);
                 }
             }
+        }
+
+        abstract class Extrema<TStore, T>
+        {
+            public virtual TStore New() => default;
+            public virtual void Restart(ref TStore store) => store = default;
+
+            public void Add(ref TStore store, int? limit, T item)
+            {
+                if (limit == null || Count(store) < limit || TryPop(ref store))
+                    Push(ref store, item);
+            }
+
+            protected abstract int Count(TStore store);
+            protected abstract void Push(ref TStore store, T item);
+            protected abstract bool TryPop(ref TStore store);
+
+            public virtual IEnumerable<T> GetEnumerable(TStore store) =>
+                Count(store) > 0
+                ? GetSomeEnumerable(store)
+                : Enumerable.Empty<T>();
+
+            protected abstract IEnumerable<T> GetSomeEnumerable(TStore store);
         }
     }
 }

--- a/MoreLinq/MinBy.cs
+++ b/MoreLinq/MinBy.cs
@@ -39,7 +39,7 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> is empty</exception>
 
-        public static IEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
             return source.MinBy(selector, null);
@@ -63,14 +63,14 @@ namespace MoreLinq
         /// or <paramref name="comparer"/> is null</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> is empty</exception>
 
-        public static IEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey> comparer)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (selector == null) throw new ArgumentNullException(nameof(selector));
 
             comparer = comparer ?? Comparer<TKey>.Default;
-            return ExtremaBy(source, selector, (x, y) => -Math.Sign(comparer.Compare(x, y)));
+            return new ExtremaEnumerable<TSource, TKey>(source, selector, (x, y) => -Math.Sign(comparer.Compare(x, y)));
         }
     }
 }


### PR DESCRIPTION
This PR addresses #380.

It adds support for partial query of `MinBy` and `MaxBy` without introducing any new methods. “It just works” with natural methods of LINQ like `Take` and `First`. It does this by introducing a new `IExtremaEnumerable<>`, which is now returned by `MinBy` and `MaxBy`:

```c#
public interface IExtremaEnumerable<out T> : IEnumerable<T>
{
    IEnumerable<T> Take(int count);
    IEnumerable<T> TakeLast(int count);
}
```

By composing `MaxBy` or `MinBy` with `Take` or `TakeLast`, the internal iteration is optimised to only keep the requested count of elements in memory at any given time. What's more, if `count` is 1 for either then yet another optimised version ensures that only a single element is maintained (i.e. no cost of a collection type is incurred). There are also extensions defined for `IExtremaEnumerable<>`:

- `First`
- `FirstOrDefault`
- `Last`
- `LastOrDefault`
- `Single`
- `SingleOrDefault`

These extensions internally call `Take` or `TakeLast` with a count of 1 (with the exception of `Single` and `SingleOrDefault` that use a count of 2), which effectively gives back the single-element version of `MaxBy` and `MinBy` up to the breaking change in #328 and without much additional cost of building a list only to throw away everything except one element.

## Examples

```c#
var strings = new[] { "ax", "hello", "world", "aa", "ab", "ay", "az" };
Console.WriteLine(strings.MinBy(s => s.Length).Take(3).ToDelimitedString(", "));
// output: ax, aa, ab
```

```c#
var strings = new[] { "ax", "hello", "world", "aa", "ab", "ay", "az" };
Console.WriteLine(strings.MaxBy(s => s.Length).First());
// output: hello
```

```c#
var strings = new[] { "ax", "hello", "world", "aa", "ab", "ay", "az" };
Console.WriteLine(strings.MaxBy(s => s.Length).Last());
// output: world
```
