### PR TITLE
Set initial capacity on buffer queues

### DIFF
--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -84,7 +84,7 @@ namespace MoreLinq
 
             IEnumerable<TResult> IterateSequence()
             {
-                var queue = new Queue<T>();
+                var queue = new Queue<T>(count + 1);
 
                 foreach (var item in source)
                 {

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -64,7 +64,7 @@ namespace MoreLinq
 
             return _(); IEnumerable<TResult> _()
             {
-                var leadQueue = new Queue<TSource>();
+                var leadQueue = new Queue<TSource>(offset);
                 using (var iter = source.GetEnumerator())
                 {
                     bool hasMore;


### PR DESCRIPTION
Lag.cs included offset when creating its buffer queue, but not Lead or CountDown.