### PR TITLE
Replaced Is.EquivalentTo by Is.EqualTo on tests

### DIFF
--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -34,7 +34,7 @@ namespace MoreLinq.Test
             int? na = null;
             var input = new[] { na, na, 1, 2, na, na, na, 3, 4, na, na };
             var result = input.FillBackward();
-            Assert.That(result, Is.EquivalentTo(new[] { 1, 1, 1, 2, 3, 3, 3, 3, 4, na, na }));
+            Assert.That(result, Is.EqualTo(new[] { 1, 1, 1, 2, 3, 3, 3, 3, 4, na, na }));
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
                 xs.Select(x => new { X = x, Y = x })
                   .FillBackward(e => e.X == 0, (m, nm) => new { m.X, nm.Y });
 
-            Assert.That(result, Is.EquivalentTo(new[]
+            Assert.That(result, Is.EqualTo(new[]
             {
                 new { X = 0, Y = 1 },
                 new { X = 0, Y = 1 },

--- a/MoreLinq.Test/FillForwardTest.cs
+++ b/MoreLinq.Test/FillForwardTest.cs
@@ -35,7 +35,7 @@ namespace MoreLinq.Test
             int? na = null;
             var input = new[] { na, na, 1, 2, na, na, na, 3, 4, na, na };
             var result = input.FillForward();
-            Assert.That(result, Is.EquivalentTo(new[] { na, na, 1, 2, 2, 2, 2, 3, 4, 4, 4 }));
+            Assert.That(result, Is.EqualTo(new[] { na, na, 1, 2, 2, 2, 2, 3, 4, 4, 4 }));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace MoreLinq.Test
                        .FillForward(e => e.Country   == "-", (e, f) => new { e.Continent, f.Country, e.City, e.Value });
 
 
-            Assert.That(data, Is.EquivalentTo(new[]
+            Assert.That(data, Is.EqualTo(new[]
             {
                 new { Continent = "Europe", Country = "UK",      City = "London",     Value = 123 },
                 new { Continent = "Europe", Country = "UK",      City = "Manchester", Value = 234 },

--- a/MoreLinq.Test/FlattenTest.cs
+++ b/MoreLinq.Test/FlattenTest.cs
@@ -100,7 +100,7 @@ namespace MoreLinq.Test
             var result = source.Flatten().Cast<int>();
             var expectations = Enumerable.Range(1, 20);
 
-            Assert.That(result, Is.EquivalentTo(expectations));
+            Assert.That(result, Is.EqualTo(expectations));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace MoreLinq.Test
                 7,
             };
 
-            Assert.That(result, Is.EquivalentTo(expectations));
+            Assert.That(result, Is.EqualTo(expectations));
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace MoreLinq.Test
 
             var result = source.Flatten(_ => false);
 
-            Assert.That(result, Is.EquivalentTo(source));
+            Assert.That(result, Is.EqualTo(source));
         }
 
         [Test]
@@ -209,7 +209,7 @@ namespace MoreLinq.Test
                 6
             };
 
-            Assert.That(result, Is.EquivalentTo(expectations));
+            Assert.That(result, Is.EqualTo(expectations));
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace MoreLinq.Test
             using (var inner3 = TestingSequence.Of<object>(6, inner2, 7))
             using (var source = TestingSequence.Of<object>(inner1, inner3))
             {
-                Assert.That(source.Flatten(), Is.EquivalentTo(expectations));
+                Assert.That(source.Flatten(), Is.EqualTo(expectations));
             }
         }
 
@@ -284,7 +284,7 @@ namespace MoreLinq.Test
             var result = source.Flatten().Cast<int>();
             var expectations = Enumerable.Range(1, 10);
 
-            Assert.That(result.Take(10), Is.EquivalentTo(expectations));
+            Assert.That(result.Take(10), Is.EqualTo(expectations));
 
             Assert.Throws<TestException>(() =>
                 source.Flatten().ElementAt(11));

--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -179,8 +179,8 @@ namespace MoreLinq.Test
                    .ToArray() // start all before joining
                    .ForEach(t => t.Join());
 
-            Assert.That(sequence, Is.EquivalentTo(memoized));
-            lists.ForEach(list => Assert.That(list, Is.EquivalentTo(memoized)));
+            Assert.That(sequence, Is.EqualTo(memoized));
+            lists.ForEach(list => Assert.That(list, Is.EqualTo(memoized)));
         }
 
         [Test]

--- a/MoreLinq.Test/MoveTest.cs
+++ b/MoreLinq.Test/MoveTest.cs
@@ -63,7 +63,7 @@ namespace MoreLinq.Test
             using (var test = source.AsTestingSequence())
             {
                 var result = test.Move(fromIndex, count, toIndex);
-                Assert.That(result, Is.EquivalentTo(expectations));
+                Assert.That(result, Is.EqualTo(expectations));
             }
         }
 
@@ -90,7 +90,7 @@ namespace MoreLinq.Test
             using (var test = source.AsTestingSequence())
             {
                 var result = test.Move(fromIndex, count, toIndex);
-                Assert.That(result, Is.EquivalentTo(expectations));
+                Assert.That(result, Is.EqualTo(expectations));
             }
         }
 

--- a/MoreLinq.Test/PartitionTest.cs
+++ b/MoreLinq.Test/PartitionTest.cs
@@ -31,8 +31,8 @@ namespace MoreLinq.Test
                 Enumerable.Range(0, 10)
                           .Partition(x => x % 2 == 0);
 
-            Assert.That(evens, Is.EquivalentTo(new[] { 0, 2, 4, 6, 8 }));
-            Assert.That(odds,  Is.EquivalentTo(new[] { 1, 3, 5, 7, 9 }));
+            Assert.That(evens, Is.EqualTo(new[] { 0, 2, 4, 6, 8 }));
+            Assert.That(odds,  Is.EqualTo(new[] { 1, 3, 5, 7, 9 }));
         }
 
         [Test]
@@ -53,8 +53,8 @@ namespace MoreLinq.Test
                 Enumerable.Range(0, 10)
                           .Partition(x => x % 2 == 0, Tuple.Create);
 
-            Assert.That(evens, Is.EquivalentTo(new[] { 0, 2, 4, 6, 8 }));
-            Assert.That(odds,  Is.EquivalentTo(new[] { 1, 3, 5, 7, 9 }));
+            Assert.That(evens, Is.EqualTo(new[] { 0, 2, 4, 6, 8 }));
+            Assert.That(odds,  Is.EqualTo(new[] { 1, 3, 5, 7, 9 }));
         }
 
         [Test]
@@ -65,8 +65,8 @@ namespace MoreLinq.Test
                           .GroupBy(x => x % 2 == 0)
                           .Partition((t, f) => Tuple.Create(t, f));
 
-            Assert.That(evens, Is.EquivalentTo(new[] { 0, 2, 4, 6, 8 }));
-            Assert.That(odds,  Is.EquivalentTo(new[] { 1, 3, 5, 7, 9 }));
+            Assert.That(evens, Is.EqualTo(new[] { 0, 2, 4, 6, 8 }));
+            Assert.That(odds,  Is.EqualTo(new[] { 1, 3, 5, 7, 9 }));
         }
 
         [Test]
@@ -78,9 +78,9 @@ namespace MoreLinq.Test
                 xs.GroupBy(x => x != null ? x < 5 : (bool?) null)
                   .Partition((t, f, n) => Tuple.Create(t, f, n));
 
-            Assert.That(lt5,  Is.EquivalentTo(new[] { 1, 2, 3 }));
-            Assert.That(gte5, Is.EquivalentTo(new[] { 5, 6, 7, 9, 10 }));
-            Assert.That(nils, Is.EquivalentTo(new int?[] { null, null }));
+            Assert.That(lt5,  Is.EqualTo(new[] { 1, 2, 3 }));
+            Assert.That(gte5, Is.EqualTo(new[] { 5, 6, 7, 9, 10 }));
+            Assert.That(nils, Is.EqualTo(new int?[] { null, null }));
         }
 
         [Test]
@@ -91,17 +91,17 @@ namespace MoreLinq.Test
                           .GroupBy(x => x % 3)
                           .Partition(0, Tuple.Create);
 
-            Assert.That(m3, Is.EquivalentTo(new[] { 0, 3, 6, 9 }));
+            Assert.That(m3, Is.EqualTo(new[] { 0, 3, 6, 9 }));
 
             using (var r = etc.Read())
             {
                 var r1 = r.Read();
                 Assert.That(r1.Key, Is.EqualTo(1));
-                Assert.That(r1, Is.EquivalentTo(new[] { 1, 4, 7 }));
+                Assert.That(r1, Is.EqualTo(new[] { 1, 4, 7 }));
 
                 var r2 = r.Read();
                 Assert.That(r2.Key, Is.EqualTo(2));
-                Assert.That(r2, Is.EquivalentTo(new[] { 2, 5, 8 }));
+                Assert.That(r2, Is.EqualTo(new[] { 2, 5, 8 }));
 
                 r.ReadEnd();
             }
@@ -115,14 +115,14 @@ namespace MoreLinq.Test
                           .GroupBy(x => x % 3)
                           .Partition(0, 1, Tuple.Create);
 
-            Assert.That(ms, Is.EquivalentTo(new[] { 0, 3, 6, 9 }));
-            Assert.That(r1, Is.EquivalentTo(new[] { 1, 4, 7 }));
+            Assert.That(ms, Is.EqualTo(new[] { 0, 3, 6, 9 }));
+            Assert.That(r1, Is.EqualTo(new[] { 1, 4, 7 }));
 
             using (var r = etc.Read())
             {
                 var r2 = r.Read();
                 Assert.That(r2.Key, Is.EqualTo(2));
-                Assert.That(r2, Is.EquivalentTo(new[] { 2, 5, 8 }));
+                Assert.That(r2, Is.EqualTo(new[] { 2, 5, 8 }));
                 r.ReadEnd();
             }
         }
@@ -135,9 +135,9 @@ namespace MoreLinq.Test
                     .GroupBy(x => x % 3)
                     .Partition(0, 1, 2, Tuple.Create);
 
-            Assert.That(ms, Is.EquivalentTo(new[] { 0, 3, 6, 9 }));
-            Assert.That(r1, Is.EquivalentTo(new[] { 1, 4, 7 }));
-            Assert.That(r2, Is.EquivalentTo(new[] { 2, 5, 8 }));
+            Assert.That(ms, Is.EqualTo(new[] { 0, 3, 6, 9 }));
+            Assert.That(r1, Is.EqualTo(new[] { 1, 4, 7 }));
+            Assert.That(r2, Is.EqualTo(new[] { 2, 5, 8 }));
             Assert.That(etc, Is.Empty);
         }
 
@@ -151,12 +151,12 @@ namespace MoreLinq.Test
                 words.GroupBy(s => s, StringComparer.OrdinalIgnoreCase)
                     .Partition("foo", StringComparer.OrdinalIgnoreCase, Tuple.Create);
 
-            Assert.That(foo, Is.EquivalentTo(new[] { "foo", "FOO" }));
+            Assert.That(foo, Is.EqualTo(new[] { "foo", "FOO" }));
 
             using (var r = etc.Read())
             {
                 var bar = r.Read();
-                Assert.That(bar, Is.EquivalentTo(new[] { "bar", "Bar" }));
+                Assert.That(bar, Is.EqualTo(new[] { "bar", "Bar" }));
                 r.ReadEnd();
             }
         }
@@ -171,18 +171,18 @@ namespace MoreLinq.Test
                 words.GroupBy(s => s, StringComparer.OrdinalIgnoreCase)
                      .Partition("foo", "bar", StringComparer.OrdinalIgnoreCase, Tuple.Create);
 
-            Assert.That(foos, Is.EquivalentTo(new[] { "foo", "FOO" }));
-            Assert.That(bar, Is.EquivalentTo(new[] { "bar", "Bar" }));
+            Assert.That(foos, Is.EqualTo(new[] { "foo", "FOO" }));
+            Assert.That(bar, Is.EqualTo(new[] { "bar", "Bar" }));
 
             using (var r = etc.Read())
             {
                 var baz = r.Read();
                 Assert.That(baz.Key, Is.EqualTo("baz"));
-                Assert.That(baz, Is.EquivalentTo(new[] { "baz", "bAz" }));
+                Assert.That(baz, Is.EqualTo(new[] { "baz", "bAz" }));
 
                 var qux = r.Read();
                 Assert.That(qux.Key, Is.EqualTo("QUx"));
-                Assert.That(qux, Is.EquivalentTo(new[] { "QUx", "QuX" }));
+                Assert.That(qux, Is.EqualTo(new[] { "QUx", "QuX" }));
 
                 r.ReadEnd();
             }
@@ -198,15 +198,15 @@ namespace MoreLinq.Test
                 words.GroupBy(s => s, StringComparer.OrdinalIgnoreCase)
                     .Partition("foo", "bar", "baz", StringComparer.OrdinalIgnoreCase, Tuple.Create);
 
-            Assert.That(foos, Is.EquivalentTo(new[] { "foo", "FOO" }));
-            Assert.That(bar, Is.EquivalentTo(new[] { "bar", "Bar" }));
-            Assert.That(baz, Is.EquivalentTo(new[] { "baz", "bAz" }));
+            Assert.That(foos, Is.EqualTo(new[] { "foo", "FOO" }));
+            Assert.That(bar, Is.EqualTo(new[] { "bar", "Bar" }));
+            Assert.That(baz, Is.EqualTo(new[] { "baz", "bAz" }));
 
             using (var r = etc.Read())
             {
                 var qux = r.Read();
                 Assert.That(qux.Key, Is.EqualTo("QUx"));
-                Assert.That(qux, Is.EquivalentTo(new[] { "QUx", "QuX" }));
+                Assert.That(qux, Is.EqualTo(new[] { "QUx", "QuX" }));
                 r.ReadEnd();
             }
         }

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -84,7 +84,7 @@ namespace MoreLinq.Test
             for (var i = 0; i < repeatCount; i++)
                 expectedResult = expectedResult.Concat(sequence);
 
-            Assert.That(expectedResult, Is.EquivalentTo(result));
+            Assert.That(expectedResult, Is.EqualTo(result));
         }
 
         /// <summary>

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
 
             var expectations = sequence.Take(take - skip);
 
-            Assert.That(expectations, Is.EquivalentTo(sequence.SkipLast(skip)));
+            Assert.That(expectations, Is.EqualTo(sequence.SkipLast(skip)));
         }
 
         [TestCase(5)]

--- a/MoreLinq.Test/ToLookupTest.cs
+++ b/MoreLinq.Test/ToLookupTest.cs
@@ -39,9 +39,9 @@ namespace MoreLinq.Test
             var dict = pairs.ToLookup();
 
             Assert.That(dict.Count, Is.EqualTo(3));
-            Assert.That(dict["foo"], Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(dict["bar"], Is.EquivalentTo(new[] { 3 }));
-            Assert.That(dict["baz"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+            Assert.That(dict["foo"], Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(dict["bar"], Is.EqualTo(new[] { 3 }));
+            Assert.That(dict["baz"], Is.EqualTo(new[] { 4, 5, 6 }));
         }
 
         [Test]
@@ -60,9 +60,9 @@ namespace MoreLinq.Test
             var dict = pairs.ToLookup();
 
             Assert.That(dict.Count, Is.EqualTo(3));
-            Assert.That(dict["foo"], Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(dict["bar"], Is.EquivalentTo(new[] { 3 }));
-            Assert.That(dict["baz"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+            Assert.That(dict["foo"], Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(dict["bar"], Is.EqualTo(new[] { 3 }));
+            Assert.That(dict["baz"], Is.EqualTo(new[] { 4, 5, 6 }));
         }
 
         [Test]
@@ -81,9 +81,9 @@ namespace MoreLinq.Test
             var dict = pairs.ToLookup(StringComparer.OrdinalIgnoreCase);
 
             Assert.That(dict.Count, Is.EqualTo(3));
-            Assert.That(dict["FOO"], Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(dict["BAR"], Is.EquivalentTo(new[] { 3 }));
-            Assert.That(dict["BAZ"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+            Assert.That(dict["FOO"], Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(dict["BAR"], Is.EqualTo(new[] { 3 }));
+            Assert.That(dict["BAZ"], Is.EqualTo(new[] { 4, 5, 6 }));
         }
 
         [Test]
@@ -102,9 +102,9 @@ namespace MoreLinq.Test
             var dict = pairs.ToLookup(StringComparer.OrdinalIgnoreCase);
 
             Assert.That(dict.Count, Is.EqualTo(3));
-            Assert.That(dict["FOO"], Is.EquivalentTo(new[] { 1, 2 }));
-            Assert.That(dict["BAR"], Is.EquivalentTo(new[] { 3 }));
-            Assert.That(dict["BAZ"], Is.EquivalentTo(new[] { 4, 5, 6 }));
+            Assert.That(dict["FOO"], Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(dict["BAR"], Is.EqualTo(new[] { 3 }));
+            Assert.That(dict["BAZ"], Is.EqualTo(new[] { 4, 5, 6 }));
         }
     }
 }


### PR DESCRIPTION
since [thery are not equivalent](https://github.com/morelinq/MoreLINQ/pull/492#discussion_r226183306).