### PR TITLE
Reworked GroupAdjacent and Batch to perform fully deferred execution

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -27,14 +27,14 @@ namespace MoreLinq.Test
         public void BatchZeroSize()
         {
             AssertThrowsArgument.OutOfRangeException("size",() =>
-                new object[0].Batch(0));
+                new object[0].Batch(0).ToList()); // force enumeration to trigger the exception
         }
 
         [Test]
         public void BatchNegativeSize()
         {
             AssertThrowsArgument.OutOfRangeException("size",() =>
-                new object[0].Batch(-1));
+                new object[0].Batch(-1).ToList()); // force enumeration to trigger the exception
         }
 
         [Test]
@@ -71,6 +71,7 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        [Ignore("Obsolete : Batch performs fully deferred processing hence not instantiating lists")]
         public void BatchSequenceYieldsListsOfBatches()
         {
             var result = new[] { 1, 2, 3 }.Batch(2);

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -27,14 +27,14 @@ namespace MoreLinq.Test
         public void BatchZeroSize()
         {
             AssertThrowsArgument.OutOfRangeException("size",() =>
-                new object[0].Batch(0).ToList()); // force enumeration to trigger the exception
+                new object[0].Batch(0));
         }
 
         [Test]
         public void BatchNegativeSize()
         {
             AssertThrowsArgument.OutOfRangeException("size",() =>
-                new object[0].Batch(-1).ToList()); // force enumeration to trigger the exception
+                new object[0].Batch(-1));
         }
 
         [Test]

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -57,6 +57,12 @@ namespace MoreLinq
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
+            return BatchImpl(source, size, resultSelector);
+        }
+
+        private static IEnumerable<TResult> BatchImpl<TSource, TResult>(IEnumerable<TSource> source, int size,
+            Func<IEnumerable<TSource>, TResult> resultSelector)
+        {
             using (var enumerator = source.GetEnumerator())
             {
                 while (enumerator.MoveNext())

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -1,6 +1,6 @@
 #region License and Terms
 // MoreLINQ - Extensions to LINQ to Objects
-// Copyright (c) 2009 Atif Aziz, 2018 Thibault Reigner All rights reserved.
+// Copyright (c) 2009 Atif Aziz, 2018 Thibault Reigner. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -371,20 +371,19 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.Batch(source, size);
 
         /// <summary>
-        /// Batches the source sequence into sized buckets and applies a projection to each bucket.
+        /// Batches the source sequence into sized enumerables and applies a projection to each enumerable.
         /// </summary>
         /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
         /// <typeparam name="TResult">Type of result returned by <paramref name="resultSelector"/>.</typeparam>
         /// <param name="source">The source sequence.</param>
-        /// <param name="size">Size of buckets.</param>
+        /// <param name="size">Size of enumerable.</param>
         /// <param name="resultSelector">The projection to apply to each bucket.</param>
-        /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
+        /// <returns>A sequence of projections on equally sized enumerables containing elements of the source collection.</returns>
         /// <remarks>
-        /// This operator uses deferred execution and streams its results (buckets and bucket content).
+        /// This operator uses deferred execution and streams its results (enmerables and their contents).
         /// </remarks>
 
-        public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
-            Func<IEnumerable<TSource>, TResult> resultSelector)
+        public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size, Func<IEnumerable<TSource>, TResult> resultSelector)
             => MoreEnumerable.Batch(source, size, resultSelector);
 
     }
@@ -2514,6 +2513,7 @@ namespace MoreLinq.Extensions
         /// buffered. Each grouping is therefore yielded as soon as it
         /// is complete and before the next grouping occurs.
         /// </remarks>
+
 
         public static IEnumerable<TResult> GroupAdjacent<TSource, TKey, TResult>(
             this IEnumerable<TSource> source,

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -291,12 +291,14 @@ namespace MoreLinq
                 while (!iterator.HasEnded)
                 {
                     var currentKey = keySelector(iterator.Current);
-                    yield return resultSelector(currentKey, GetAdjacentGroup(iterator, currentKey, keySelector, elementSelector, comparer));
+                    yield return resultSelector(currentKey,
+                        GetAdjacentGroup(iterator, currentKey, keySelector, elementSelector, comparer));
                 }
-            }           
+            }
         }
 
-        static IGrouping<TKey, TElement> CreateGroupAdjacentGrouping<TKey, TElement>(TKey key, IEnumerable<TElement> members)
+        static IGrouping<TKey, TElement> CreateGroupAdjacentGrouping<TKey, TElement>(TKey key,
+            IEnumerable<TElement> members)
         {
             Debug.Assert(members != null);
             return Grouping.Create(key, members);


### PR DESCRIPTION
#### What's this PR do?
Simplify the code of GroupAdjacent and Batch to remove internal partial enumeration relying on instantiation of arrays and lists, hence performing fully deferred enumeration of the sources.
In my tests it improves the performances by avoiding allocation of large objects which often end up in the generation 2 part of the heap.