### PR TITLE
Add IsEmpty that judges that sequence is empty or not

### DIFF
--- a/MoreLinq.Test/IsEmptyTest.cs
+++ b/MoreLinq.Test/IsEmptyTest.cs
@@ -1,0 +1,82 @@
+#region License and Terms
+
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 RyotaMurohoshi All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace MoreLinq.Test
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class IsEmptyTest
+    {
+        [Test]
+        public void IsEmptyTrueWithEmptySequence()
+        {
+            Assert.IsTrue(new int[0].IsEmpty());
+        }
+
+        [Test]
+        public void IsEmptyFalseWithSingleElement()
+        {
+            Assert.IsFalse(new[] {1}.IsEmpty());
+        }
+
+        [Test]
+        public void IsEmptyFalseWithSomeElements()
+        {
+            var sequence = new[] {0};
+            var infiniteSequence = sequence.Repeat();
+            Assert.IsFalse(infiniteSequence.IsEmpty());
+        }
+
+        [Test]
+        public void IsEmptyThrowsException()
+        {
+            Assert.Throws<TestException>(() =>
+            {
+                var source = MoreEnumerable.From<int>(() => throw new TestException());
+                source.IsEmpty();
+                Assert.Fail();
+            });
+        }
+
+        [Test]
+        public void IsEmptyThrowsNullArgumentException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                IEnumerable<int> source = null;
+                source.IsEmpty();
+                Assert.Fail();
+            });
+        }
+
+        [Test]
+        public void IsEmptyFalseNoThrowsException()
+        {
+            var source = MoreEnumerable.From(
+                () => 0,
+                () => throw new TestException()
+            );
+            Assert.IsFalse(source.IsEmpty());
+        }
+    }
+}

--- a/MoreLinq/IsEmpty.cs
+++ b/MoreLinq/IsEmpty.cs
@@ -1,0 +1,43 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 RyotaMurohoshi. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Determines whether source is empty or not.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of the source sequences</typeparam>
+        /// <param name="source">The sequence to check whether is empty or not</param>
+        /// <returns><c>true</c> if the sequence is empty or <c>false</c> otherwise.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <remarks>
+        /// This operator executes immediately.
+        /// </remarks>
+        public static bool IsEmpty<TSource>(this IEnumerable<TSource> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            return !source.Any ();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ skipping sequences as they are consumed.
 
 This method has 2 overloads.
 
+### IsEmpty
+
+Determines whether source sequence is empty or not.
+
 ### Lag
 
 Produces a projection of a sequence by evaluating pairs of elements separated


### PR DESCRIPTION
# Summary

Add `IsEmpty` method.

* Judges that `IEnumerable<T>` is empty.
* Someone uses "Count() == 0" incorrectly. `IsEmpty` method helps them.
* This is so declarative and easy to find from Intellisense.


# Background

Someone uses "Count() == 0" incorrectly to judge that `IEnumerable<T>` is empty or not. This is bad usage. Next code is an example.

Next code read all line twice. To judge `target.txt` is empty, we do not need read all lines. If `target.txt` is huge, it is so bad.

```csharp
IEnumerable<string> lines = File.ReadLines("target.txt");
// Bad solution
if(lines.Count() == 0) {
    Console.WriteLine("target.txt is empty.");
    return ;
}

// iterate all line and use it.
```

Good practice is to use `Any` method and `!` to judge `is empty`. This can judge that file is empty or not without reading all lines.

```csharp
IEnumerable<string> lines = File.ReadLines("target.txt");
// Current good solution
if(!lines.Any()) {
    Console.WriteLine("target.txt is empty.");
    return ;
}

// iterate all line and use it.
```

By the way, I do NOT think this is BEST way.

# Solution

I suggest `IsEmpty` method to MoreLinq. `IsEmpty` judeges that Array, `IEnumerable<T>` and `List<T>` etc are empty or not.


```csharp
IEnumerable<string> lines = File.ReadLines("target.txt");
if(lines.IsEmpty()) {
    Console.WriteLine("target.txt is empty.");
    return ;
}

// iterate all line and use it.
```

This is more clear and explicit than `Any` and `!` usage.  And beginner can notice the `IsEmpty` method with IntelliSense.

# In other languages.

Next languages have `IsEmpty` or `isEmpty` methods.

F#
https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/list.isempty%5B't%5D-function-%5Bfsharp%5D
https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/array.isempty%5b't%5d-function-%5bfsharp%5d
https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/seq.isempty%5b't%5d-function-%5bfsharp%5d

Java
https://docs.oracle.com/javase/10/docs/api/java/util/Collection.html#isEmpty()


Kotlin
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/is-empty.html
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-collection/is-empty.html

Scala
https://www.scala-lang.org/api/current/scala/collection/GenTraversableOnce.html#isEmpty:Boolean


# Discussion

## How about use `!enumrable.Any()`?

I think `enumerable.IsEmpty()` is better than `!enumerable.Any()` with next reasons.

* `IsEmpty()` is more clear and more explicit to check that `enumerable` is empty than `!enumerable.Any()`. 
* For C# beginner, `!enumerable.Any()` to check empty is not familiar, not clear and not easy to find.


I think everyone who participates in this issue is familiar to C# and LINQ. So we know how to use `!enumerable.Any()` and reason to use `!enumerable.Any()`.

But I think that C# beginner is not same. Please imagine C# beginner. It is a little difficult to find usage of `!enumerable.Any()` to check empty for them. I think `IsEmpty` is so easy to find and useful to them.
