### PR TITLE
Fix ToDataTable to skip write-only properties

### DIFF
--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -34,6 +34,7 @@ namespace MoreLinq.Test
 
             public string AString { get; }
             public decimal? ANullableDecimal { get; }
+            public object Unreadable { set => throw new NotImplementedException(); }
 
             public object this[int index]
             {

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -136,7 +136,8 @@ namespace MoreLinq
             {
                 return from m in typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance)
                        where m.MemberType == MemberTypes.Field
-                             || m.MemberType == MemberTypes.Property && ((PropertyInfo) m).GetIndexParameters().Length == 0
+                          || m is PropertyInfo p && p.CanRead
+                                                 && p.GetIndexParameters().Length == 0
                        select m;
             }
 


### PR DESCRIPTION
This PR fixes the bug raised in issue #564.