### PR TITLE
Skip `dotnet --info` except during CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - dotnet-sharedframework-microsoft.netcore.app-1.0.5
 
 before_install:
+  - dotnet --info
   - msbuild /version
   - |
     if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ install:
 - eclint check -n "**/*.{cs,tt,cmd,sh,md,txt,yml}"
 - eclint check -w "**/*.{cs,tt,cmd,sh,md,txt,yml,json,sln,csproj,shfbproj}"
 - git reset --hard
+before_build:
+- dotnet --info
 build_script:
 - ps: >-
     grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' (dir MoreLinq.Test\*Test.cs)

--- a/build.cmd
+++ b/build.cmd
@@ -10,8 +10,7 @@ for %%i in (dotnet.exe) do set dotnet=%%~dpnx$PATH:i
 if "%dotnet%"=="" goto :nodotnet
 if "%1"=="docs" shift & goto :docs
 :build
-dotnet --info ^
-  && dotnet restore ^
+dotnet restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
   && for %%i in (debug release) do call msbuild.cmd "MoreLinq.sln" /v:m /p:Configuration=%%i %* || exit /b 1

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
-dotnet --info
 dotnet restore
 codegen() {
     dest="$1"


### PR DESCRIPTION
`dotnet --info` can be noisy when doing local builds. This PR removes `dotnet --info` from build scripts and adds it to CI build configurations.
