### PR TITLE
Expand Choose implementation

### DIFF
--- a/MoreLinq/Choose.cs
+++ b/MoreLinq/Choose.cs
@@ -51,16 +51,20 @@ namespace MoreLinq
         /// </example>
 
         public static IEnumerable<TResult> Choose<T, TResult>(this IEnumerable<T> source,
-            Func<T, (bool IsSome, TResult Value)> chooser)
+            Func<T, (bool, TResult)> chooser)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (chooser == null) throw new ArgumentNullException(nameof(chooser));
 
-            return
-                from item in source
-                select chooser(item) into e
-                where e.IsSome
-                select e.Value;
+            return _(); IEnumerable<TResult> _()
+            {
+                foreach (var item in source)
+                {
+                    var (some, value) = chooser(item);
+                    if (some)
+                        yield return value;
+                }
+            }
         }
     }
 }

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -744,7 +744,7 @@ namespace MoreLinq.Extensions
         /// </example>
 
         public static IEnumerable<TResult> Choose<T, TResult>(this IEnumerable<T> source,
-            Func<T, (bool IsSome, TResult Value)> chooser)
+            Func<T, (bool, TResult)> chooser)
             => MoreEnumerable.Choose(source, chooser);
 
     }


### PR DESCRIPTION
`Choose`, which [shipped in 3.0](https://github.com/morelinq/MoreLINQ/releases/tag/v3.0.0), was implemented as a query comprehension that was a chained composition of `Select` &rarr; `Where` &rarr; `Select`. This PR expands and hand-rolls the implementation because it's very straightforward and probably won't require any maintenance. A hand-rolled implementation avoids lambda allocations, delegate and virtual invocation costs as well as having to name the tuple elements of the `chooser` result.
