### PR TITLE
ZipShortest: moved particular behavior from remarks to summary

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6483,8 +6483,9 @@ namespace MoreLinq.Extensions
     public static partial class ZipShortestExtension
     {
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -6506,9 +6507,10 @@ namespace MoreLinq.Extensions
         /// </example>
         /// <remarks>
         /// <para>
-        /// If the two input sequences are of different lengths, the result
-        /// sequence is terminated as soon as the shortest input sequence is
-        /// exhausted.</para>
+        /// If the input sequences are of different lengths, the result sequence
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
+        /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>
         /// </remarks>
@@ -6521,7 +6523,8 @@ namespace MoreLinq.Extensions
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element  from each of the argument sequences.
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -6548,7 +6551,8 @@ namespace MoreLinq.Extensions
         /// <remarks>
         /// <para>
         /// If the input sequences are of different lengths, the result sequence
-        /// is terminated as soon as the shortest input sequence is exhausted.
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
         /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>
@@ -6563,7 +6567,8 @@ namespace MoreLinq.Extensions
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -6593,7 +6598,8 @@ namespace MoreLinq.Extensions
         /// <remarks>
         /// <para>
         /// If the input sequences are of different lengths, the result sequence
-        /// is terminated as soon as the shortest input sequence is exhausted.
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
         /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -47,9 +47,9 @@ namespace MoreLinq
         /// </example>
         /// <remarks>
         /// <para>
-        /// If the two input sequences are of different lengths, the result
-        /// sequence is terminated as soon as the shortest input sequence is
-        /// exhausted.</para>
+        /// If the input sequences are of different lengths, the result sequence
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>
         /// </remarks>
@@ -96,7 +96,8 @@ namespace MoreLinq
         /// <remarks>
         /// <para>
         /// If the input sequences are of different lengths, the result sequence
-        /// is terminated as soon as the shortest input sequence is exhausted.
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
         /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>
@@ -149,7 +150,8 @@ namespace MoreLinq
         /// <remarks>
         /// <para>
         /// If the input sequences are of different lengths, the result sequence
-        /// is terminated as soon as the shortest input sequence is exhausted.
+        /// is terminated as soon as the shortest input sequence is exhausted
+        /// and remainder elements from the longer sequences are never consumed.
         /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -23,8 +23,9 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -67,7 +68,8 @@ namespace MoreLinq
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element  from each of the argument sequences.
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -116,7 +118,8 @@ namespace MoreLinq
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
+        /// element from each of the argument sequences. The resulting sequence
+        /// is as short as the shortest input sequence.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -50,6 +50,7 @@ namespace MoreLinq
         /// If the input sequences are of different lengths, the result sequence
         /// is terminated as soon as the shortest input sequence is exhausted
         /// and remainder elements from the longer sequences are never consumed.
+        /// </para>
         /// <para>
         /// This operator uses deferred execution and streams its results.</para>
         /// </remarks>

--- a/README.md
+++ b/README.md
@@ -693,8 +693,9 @@ This method has 3 overloads.
 
 ### ZipShortest
 
-Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences.
+Returns a projection of tuples, where each tuple contains the N-th
+element from each of the argument sequences. The resulting sequence
+is as short as the shortest input sequence.
 
 This method has 3 overloads.
 


### PR DESCRIPTION
Currently, all zip methods have the same summary, what is a bad thing because user can get confused thinkg they all do the same thing. 

The particular behavior of each opertator is being quoted on remarks sessions, but if the particular behaviors are important enough for morelinq have 3 different kinds of zip, then it should be discern on the summary session.