### PR TITLE
EquiZip: moved differential behavior from remarks to summary

### DIFF
--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -27,7 +27,7 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
@@ -69,7 +69,7 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
@@ -115,7 +115,7 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -27,6 +27,8 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -49,11 +51,7 @@ namespace MoreLinq
         /// "2B", "3C", "4D" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the two input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<TFirst, TSecond, TResult>(
@@ -71,6 +69,8 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -96,10 +96,7 @@ namespace MoreLinq
         /// "2Bb", "3Cc", "4Dd" in turn.
         /// </example>
         /// <remarks>
-        /// <para>If the three input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<T1, T2, T3, TResult>(
@@ -118,6 +115,8 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>
@@ -146,11 +145,7 @@ namespace MoreLinq
         /// "2BbFalse", "3CcTrue", "4DdFalse" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the four input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<T1, T2, T3, T4, TResult>(

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -40,6 +40,9 @@ namespace MoreLinq
         /// A sequence that contains elements of the two input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// <exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -83,6 +86,9 @@ namespace MoreLinq
         /// A sequence that contains elements of the three input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// <exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -130,6 +136,9 @@ namespace MoreLinq
         /// A sequence that contains elements of the four input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// <exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -42,7 +42,7 @@ namespace MoreLinq
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The input sequences are of different lengths.
-        /// <exception>
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -88,7 +88,7 @@ namespace MoreLinq
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The input sequences are of different lengths.
-        /// <exception>
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -138,7 +138,7 @@ namespace MoreLinq
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// The input sequences are of different lengths.
-        /// <exception>
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -26,9 +26,8 @@ namespace MoreLinq
     {
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -68,9 +67,8 @@ namespace MoreLinq
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -114,9 +112,8 @@ namespace MoreLinq
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1014,9 +1014,8 @@ namespace MoreLinq.Extensions
     {
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -1029,6 +1028,9 @@ namespace MoreLinq.Extensions
         /// A sequence that contains elements of the two input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -1050,9 +1052,8 @@ namespace MoreLinq.Extensions
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -1067,6 +1068,9 @@ namespace MoreLinq.Extensions
         /// A sequence that contains elements of the three input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };
@@ -1089,9 +1093,8 @@ namespace MoreLinq.Extensions
 
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.
+        /// element from each of the argument sequences. An exception is thrown
+        /// if the input sequences are of different lengths.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>
@@ -1108,6 +1111,9 @@ namespace MoreLinq.Extensions
         /// A sequence that contains elements of the four input sequences,
         /// combined by <paramref name="resultSelector"/>.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// The input sequences are of different lengths.
+        /// </exception>
         /// <example>
         /// <code><![CDATA[
         /// var numbers = new[] { 1, 2, 3, 4 };

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1015,7 +1015,7 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
@@ -1051,7 +1051,7 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
@@ -1090,7 +1090,7 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
-        /// If the two input sequences are of different lengths then
+        /// If the input sequences are of different lengths then
         /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1015,6 +1015,8 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -1037,11 +1039,7 @@ namespace MoreLinq.Extensions
         /// "2B", "3C", "4D" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the two input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<TFirst, TSecond, TResult>(
@@ -1053,6 +1051,8 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -1078,10 +1078,7 @@ namespace MoreLinq.Extensions
         /// "2Bb", "3Cc", "4Dd" in turn.
         /// </example>
         /// <remarks>
-        /// <para>If the three input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<T1, T2, T3, TResult>(
@@ -1093,6 +1090,8 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the two input sequences are of different lengths then
+        /// <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>
@@ -1121,11 +1120,7 @@ namespace MoreLinq.Extensions
         /// "2BbFalse", "3CcTrue", "4DdFalse" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the four input sequences are of different lengths then
-        /// <see cref="InvalidOperationException"/> is thrown.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> EquiZip<T1, T2, T3, T4, TResult>(

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ This method has 2 overloads.
 ### EquiZip
 
 Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences.
+from each of the argument sequences. If the two input sequences are of
+different lengths then a exception is thrown.
 
 This method has 3 overloads.
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ This method has 2 overloads.
 
 ### EquiZip
 
-Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences. If the input sequences are of
-different lengths then a exception is thrown.
+Returns a projection of tuples, where each tuple contains the N-th
+element from each of the argument sequences. An exception is thrown
+if the input sequences are of different lengths.
 
 This method has 3 overloads.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ This method has 2 overloads.
 ### EquiZip
 
 Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences. If the two input sequences are of
+from each of the argument sequences. If the input sequences are of
 different lengths then a exception is thrown.
 
 This method has 3 overloads.


### PR DESCRIPTION
Currently, all zip methods have the same summary, what is a bad thing because user can get confused thinkg they all do the same thing. 

The particular behavior of each opertator is being quoted on remarks sessions, but if the particular behaviors are important enough for morelinq have 3 different kinds of zip, then it should be discern on the summary session.