### PR TITLE
ZipLongest: moved differential behavior from remarks to summary

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6281,6 +6281,10 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -6303,13 +6307,7 @@ namespace MoreLinq.Extensions
         /// "2B", "3C", "0D" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the two input sequences are of different lengths then the result
-        /// sequence will always be as long as the longer of the two input
-        /// sequences. The default value of the shorter sequence element type
-        /// is used for padding.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<TFirst, TSecond, TResult>(
@@ -6321,6 +6319,10 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th element
         /// from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -6346,14 +6348,7 @@ namespace MoreLinq.Extensions
         /// "2Bb", "3Cc", "0Dd", "0e" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
-        /// for padding. This operator uses deferred execution and streams its
-        /// results.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<T1, T2, T3, TResult>(
@@ -6366,6 +6361,10 @@ namespace MoreLinq.Extensions
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th element
         /// from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>
@@ -6394,13 +6393,7 @@ namespace MoreLinq.Extensions
         /// "2BbFalse", "3CcTrue", "0DdFalse", "0eTrue", "0\0False" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
-        /// for padding.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<T1, T2, T3, T4, TResult>(

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6280,10 +6280,9 @@ namespace MoreLinq.Extensions
     {
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
@@ -6317,11 +6316,10 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.ZipLongest(first, second, resultSelector);
 
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
@@ -6359,11 +6357,10 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.ZipLongest(first, second, third, resultSelector);
 
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -24,10 +24,9 @@ namespace MoreLinq
     {
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
-        /// element from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
@@ -67,11 +66,10 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
@@ -116,11 +114,10 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Returns a projection of tuples, where each tuple contains the N-th element
-        /// from each of the argument sequences.
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
+        /// Returns a projection of tuples, where each tuple contains the N-th
+        /// element from each of the argument sequences. The resulting sequence
+        /// will always be as long as the longest of input sequences where the
+        /// default value of each of the shorter sequence element types is used
         /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -25,6 +25,10 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th
         /// element from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="TFirst">Type of elements in first sequence.</typeparam>
         /// <typeparam name="TSecond">Type of elements in second sequence.</typeparam>
@@ -47,13 +51,7 @@ namespace MoreLinq
         /// "2B", "3C", "0D" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the two input sequences are of different lengths then the result
-        /// sequence will always be as long as the longer of the two input
-        /// sequences. The default value of the shorter sequence element type
-        /// is used for padding.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<TFirst, TSecond, TResult>(
@@ -71,6 +69,10 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th element
         /// from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence.</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence.</typeparam>
@@ -96,14 +98,7 @@ namespace MoreLinq
         /// "2Bb", "3Cc", "0Dd", "0e" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
-        /// for padding. This operator uses deferred execution and streams its
-        /// results.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<T1, T2, T3, TResult>(
@@ -123,6 +118,10 @@ namespace MoreLinq
         /// <summary>
         /// Returns a projection of tuples, where each tuple contains the N-th element
         /// from each of the argument sequences.
+        /// If the input sequences are of different lengths then the result
+        /// sequence will always be as long as the longest of input sequences.
+        /// The default value of the each shorter sequence element type is used
+        /// for padding.
         /// </summary>
         /// <typeparam name="T1">Type of elements in first sequence</typeparam>
         /// <typeparam name="T2">Type of elements in second sequence</typeparam>
@@ -151,13 +150,7 @@ namespace MoreLinq
         /// "2BbFalse", "3CcTrue", "0DdFalse", "0eTrue", "0\0False" in turn.
         /// </example>
         /// <remarks>
-        /// <para>
-        /// If the input sequences are of different lengths then the result
-        /// sequence will always be as long as the longest of input sequences.
-        /// The default value of the each shorter sequence element type is used
-        /// for padding.</para>
-        /// <para>
-        /// This operator uses deferred execution and streams its results.</para>
+        /// This operator uses deferred execution and streams its results.
         /// </remarks>
 
         public static IEnumerable<TResult> ZipLongest<T1, T2, T3, T4, TResult>(

--- a/README.md
+++ b/README.md
@@ -679,11 +679,11 @@ Creates a right-aligned sliding window over the source sequence of a given size.
 
 ### ZipLongest
 
-Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences. If the input sequences are of different
-lengths then the result sequence will always be as long as the longest of
-input sequences. The default value of the each shorter sequence element type
-is used for padding.
+Returns a projection of tuples, where each tuple contains the N-th
+element from each of the argument sequences. The resulting sequence
+will always be as long as the longest of input sequences where the
+default value of each of the shorter sequence element types is used
+for padding.
 
 This method has 3 overloads.
 

--- a/README.md
+++ b/README.md
@@ -680,7 +680,10 @@ Creates a right-aligned sliding window over the source sequence of a given size.
 ### ZipLongest
 
 Returns a projection of tuples, where each tuple contains the N-th element
-from each of the argument sequences
+from each of the argument sequences. If the input sequences are of different
+lengths then the result sequence will always be as long as the longest of
+input sequences. The default value of the each shorter sequence element type
+is used for padding.
 
 This method has 3 overloads.
 


### PR DESCRIPTION
Currently, all zip methods have the same summary, what is a bad thing because user can get confused thinkg they all do the same thing. 

The particular behavior of each opertator is being quoted on remarks sessions, but if the particular behaviors are important enough for morelinq have 3 different kinds of zip, then it should be discern on the summary session.