### PR TITLE
Test that sequences are not iterated past their end

### DIFF
--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -72,7 +72,13 @@ namespace MoreLinq.Test
                 Assert.That(_disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
                 _disposed = true;
             };
-            enumerator.MoveNextCalled += delegate { MoveNextCallCount++; };
+            var ended = false;
+            enumerator.MoveNextCalled += (_, moved) =>
+            {
+                Assert.That(ended, Is.False, "LINQ operators should not continue iterating a sequence that has terminated.");
+                ended = !moved;
+                MoveNextCallCount++;
+            };
             _sequence = null;
             return enumerator;
         }

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         readonly IEnumerator<T> _source;
 
         public event EventHandler Disposed;
-        public event EventHandler MoveNextCalled;
+        public event EventHandler<bool> MoveNextCalled;
 
         public WatchableEnumerator(IEnumerator<T> source) =>
             _source = source ?? throw new ArgumentNullException(nameof(source));
@@ -43,8 +43,9 @@ namespace MoreLinq.Test
 
         public bool MoveNext()
         {
-            MoveNextCalled?.Invoke(this, EventArgs.Empty);
-            return _source.MoveNext();
+            var moved = _source.MoveNext();
+            MoveNextCalled?.Invoke(this, moved);
+            return moved;
         }
 
         public void Dispose()


### PR DESCRIPTION
In other words, `MoveNext` on an `IEnumerator<>` isn't called once it has returned `false`.