### PR TITLE
Deconstruct for sequences (🎬 take 2)

### DIFF
--- a/MoreLinq.Test/DeconstructTest.cs
+++ b/MoreLinq.Test/DeconstructTest.cs
@@ -1,0 +1,126 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+
+    [TestFixture]
+    public class DeconstructTest
+    {
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(5)]
+        [TestCase(6)]
+        [TestCase(7)]
+        [TestCase(8)]
+        [TestCase(9)]
+        [TestCase(10)]
+        [TestCase(11)]
+        [TestCase(12)]
+        [TestCase(13)]
+        [TestCase(14)]
+        [TestCase(15)]
+        [TestCase(16)]
+        public void WithNullSource(int width)
+        {
+            var source = (object[])null;
+
+            var e = Assert.Throws<ArgumentNullException>(() =>
+            {
+                switch (width)
+                {
+                    case 2: (_, _, _) = source; break;
+                    case 3: (_, _, _, _) = source; break;
+                    case 4: (_, _, _, _, _) = source; break;
+                    case 5: (_, _, _, _, _, _) = source; break;
+                    case 6: (_, _, _, _, _, _, _) = source; break;
+                    case 7: (_, _, _, _, _, _, _, _) = source; break;
+                    case 8: (_, _, _, _, _, _, _, _, _) = source; break;
+                    case 9: (_, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 10: (_, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 11: (_, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 12: (_, _, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 13: (_, _, _, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 14: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 15: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    case 16: (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) = source; break;
+                    default: throw new ArgumentOutOfRangeException(nameof(width), width, null);
+                }
+            });
+
+            Assert.That(e.ParamName, Is.EqualTo("source"));
+        }
+
+        static readonly IEnumerable<ITestCaseData> DeconstructCases =
+            from w in Enumerable.Range(2, 16 - 1)
+            from c in Enumerable.Range(0, w + 2)
+            select new TestCaseData(w, c);
+
+        [TestCaseSource(nameof(DeconstructCases))]
+        public void Deconstruct(int width, int count)
+        {
+            var xs = Enumerable.Range(1, count);
+            using (var ts = xs.AsTestingSequence())
+            {
+                int a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p;
+                c = d = e = f = g = h = i = j = k = l = m = n = o = p = 0;
+                int rc;
+
+                switch (width)
+                {
+                    case 2: (a, b, rc) = ts; break;
+                    case 3: (a, b, c, rc) = ts; break;
+                    case 4: (a, b, c, d, rc) = ts; break;
+                    case 5: (a, b, c, d, e, rc) = ts; break;
+                    case 6: (a, b, c, d, e, f, rc) = ts; break;
+                    case 7: (a, b, c, d, e, f, g, rc) = ts; break;
+                    case 8: (a, b, c, d, e, f, g, h, rc) = ts; break;
+                    case 9: (a, b, c, d, e, f, g, h, i, rc) = ts; break;
+                    case 10: (a, b, c, d, e, f, g, h, i, j, rc) = ts; break;
+                    case 11: (a, b, c, d, e, f, g, h, i, j, k, rc) = ts; break;
+                    case 12: (a, b, c, d, e, f, g, h, i, j, k, l, rc) = ts; break;
+                    case 13: (a, b, c, d, e, f, g, h, i, j, k, l, m, rc) = ts; break;
+                    case 14: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, rc) = ts; break;
+                    case 15: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, rc) = ts; break;
+                    case 16: (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, rc) = ts; break;
+                    default: throw new ArgumentOutOfRangeException(nameof(width), width, null);
+                }
+
+                var all = new[] { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, 0 };
+
+                foreach (var (alpha, exp, act) in
+                    from t in
+                        all.Zip(xs, (exp, act) => new { Expected = exp, Actual = act })
+                           .Take(width)
+                           .Index(0)
+                    select ((char)('a' + t.Key), t.Value.Expected, t.Value.Actual))
+                {
+                    Assert.That(act, Is.EqualTo(exp), alpha.ToString());
+                }
+
+                all.Skip(count).AssertSequenceEqual(Enumerable.Repeat(0, all.Length - count));
+
+                Assert.That(rc, Is.EqualTo(Math.Min(width, count)));
+            }
+        }
+    }
+}

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -67,6 +67,7 @@ namespace MoreLinq.Test
 
         static IEnumerable<ITestCaseData> GetTestCases(bool canBeNull, Func<MethodInfo, object[], string, Action> testCaseFactory) =>
             from m in typeof (MoreEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            where m.Name != nameof(MoreEnumerable.Deconstruct)
             from t in CreateTestCases(m, canBeNull, testCaseFactory)
             select t;
 

--- a/MoreLinq/Deconstruct.cs
+++ b/MoreLinq/Deconstruct.cs
@@ -1,0 +1,27 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System.Collections.Generic;
+
+    static partial class MoreEnumerable
+    {
+        static void ReadWithCount<T>(IEnumerator<T> e, ref int count, out T item) =>
+            (count, item) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+    }
+}

--- a/MoreLinq/Deconstruct.cs
+++ b/MoreLinq/Deconstruct.cs
@@ -18,10 +18,19 @@
 namespace MoreLinq
 {
     using System.Collections.Generic;
+    using System.Diagnostics;
 
     static partial class MoreEnumerable
     {
-        static void ReadWithCount<T>(IEnumerator<T> e, ref int count, out T item) =>
-            (count, item) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+        static T ReadWithCount<T>(this IEnumerator<T> enumerator, ref int count, ref bool ended)
+        {
+            Debug.Assert(enumerator != null);
+
+            if (ended || (ended = !enumerator.MoveNext()))
+                return default;
+
+            count++;
+            return enumerator.Current;
+        }
     }
 }

--- a/MoreLinq/Deconstruct.g.cs
+++ b/MoreLinq/Deconstruct.g.cs
@@ -39,12 +39,12 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -66,13 +66,13 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -95,14 +95,14 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -126,15 +126,15 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -159,16 +159,16 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -194,17 +194,17 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -231,18 +231,18 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -270,19 +270,19 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -311,20 +311,20 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -354,21 +354,21 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -399,22 +399,22 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
-                ReadWithCount(e, ref count, out item12);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
+                item12 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -446,23 +446,23 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
-                ReadWithCount(e, ref count, out item12);
-                ReadWithCount(e, ref count, out item13);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
+                item12 = e.ReadWithCount(ref count, ref ended);
+                item13 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -495,24 +495,24 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
-                ReadWithCount(e, ref count, out item12);
-                ReadWithCount(e, ref count, out item13);
-                ReadWithCount(e, ref count, out item14);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
+                item12 = e.ReadWithCount(ref count, ref ended);
+                item13 = e.ReadWithCount(ref count, ref ended);
+                item14 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -546,25 +546,25 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
-                ReadWithCount(e, ref count, out item12);
-                ReadWithCount(e, ref count, out item13);
-                ReadWithCount(e, ref count, out item14);
-                ReadWithCount(e, ref count, out item15);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
+                item12 = e.ReadWithCount(ref count, ref ended);
+                item13 = e.ReadWithCount(ref count, ref ended);
+                item14 = e.ReadWithCount(ref count, ref ended);
+                item15 = e.ReadWithCount(ref count, ref ended);
             }
         }
 
@@ -599,26 +599,26 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
-                ReadWithCount(e, ref count, out item1);
-                ReadWithCount(e, ref count, out item2);
-                ReadWithCount(e, ref count, out item3);
-                ReadWithCount(e, ref count, out item4);
-                ReadWithCount(e, ref count, out item5);
-                ReadWithCount(e, ref count, out item6);
-                ReadWithCount(e, ref count, out item7);
-                ReadWithCount(e, ref count, out item8);
-                ReadWithCount(e, ref count, out item9);
-                ReadWithCount(e, ref count, out item10);
-                ReadWithCount(e, ref count, out item11);
-                ReadWithCount(e, ref count, out item12);
-                ReadWithCount(e, ref count, out item13);
-                ReadWithCount(e, ref count, out item14);
-                ReadWithCount(e, ref count, out item15);
-                ReadWithCount(e, ref count, out item16);
+                item1 = e.ReadWithCount(ref count, ref ended);
+                item2 = e.ReadWithCount(ref count, ref ended);
+                item3 = e.ReadWithCount(ref count, ref ended);
+                item4 = e.ReadWithCount(ref count, ref ended);
+                item5 = e.ReadWithCount(ref count, ref ended);
+                item6 = e.ReadWithCount(ref count, ref ended);
+                item7 = e.ReadWithCount(ref count, ref ended);
+                item8 = e.ReadWithCount(ref count, ref ended);
+                item9 = e.ReadWithCount(ref count, ref ended);
+                item10 = e.ReadWithCount(ref count, ref ended);
+                item11 = e.ReadWithCount(ref count, ref ended);
+                item12 = e.ReadWithCount(ref count, ref ended);
+                item13 = e.ReadWithCount(ref count, ref ended);
+                item14 = e.ReadWithCount(ref count, ref ended);
+                item15 = e.ReadWithCount(ref count, ref ended);
+                item16 = e.ReadWithCount(ref count, ref ended);
             }
         }
     }

--- a/MoreLinq/Deconstruct.g.cs
+++ b/MoreLinq/Deconstruct.g.cs
@@ -43,8 +43,8 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
             }
         }
 
@@ -70,9 +70,9 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
             }
         }
 
@@ -99,10 +99,10 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
             }
         }
 
@@ -130,11 +130,11 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
             }
         }
 
@@ -163,12 +163,12 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
             }
         }
 
@@ -198,13 +198,13 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
             }
         }
 
@@ -235,14 +235,14 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
             }
         }
 
@@ -274,15 +274,15 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
             }
         }
 
@@ -315,16 +315,16 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
             }
         }
 
@@ -358,17 +358,17 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
             }
         }
 
@@ -403,18 +403,18 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
+                ReadWithCount(e, ref count, out item12);
             }
         }
 
@@ -450,19 +450,19 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
+                ReadWithCount(e, ref count, out item12);
+                ReadWithCount(e, ref count, out item13);
             }
         }
 
@@ -499,20 +499,20 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
+                ReadWithCount(e, ref count, out item12);
+                ReadWithCount(e, ref count, out item13);
+                ReadWithCount(e, ref count, out item14);
             }
         }
 
@@ -550,21 +550,21 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item15) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
+                ReadWithCount(e, ref count, out item12);
+                ReadWithCount(e, ref count, out item13);
+                ReadWithCount(e, ref count, out item14);
+                ReadWithCount(e, ref count, out item15);
             }
         }
 
@@ -603,22 +603,22 @@ namespace MoreLinq
 
             using (var e = source.GetEnumerator())
             {
-                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item15) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
-                (count, item16) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item1);
+                ReadWithCount(e, ref count, out item2);
+                ReadWithCount(e, ref count, out item3);
+                ReadWithCount(e, ref count, out item4);
+                ReadWithCount(e, ref count, out item5);
+                ReadWithCount(e, ref count, out item6);
+                ReadWithCount(e, ref count, out item7);
+                ReadWithCount(e, ref count, out item8);
+                ReadWithCount(e, ref count, out item9);
+                ReadWithCount(e, ref count, out item10);
+                ReadWithCount(e, ref count, out item11);
+                ReadWithCount(e, ref count, out item12);
+                ReadWithCount(e, ref count, out item13);
+                ReadWithCount(e, ref count, out item14);
+                ReadWithCount(e, ref count, out item15);
+                ReadWithCount(e, ref count, out item16);
             }
         }
     }

--- a/MoreLinq/Deconstruct.g.cs
+++ b/MoreLinq/Deconstruct.g.cs
@@ -1,0 +1,625 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Deconstructs first 2 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 3 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 4 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 5 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 6 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 7 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 8 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 9 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 10 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 11 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 12 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 13 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 14 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 15 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="item15">The value of the fifteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out T item15, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item15) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+
+        /// <summary>
+        /// Deconstructs first 16 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="item15">The value of the fifteenth element.</param>
+        /// <param name="item16">The value of the sixteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out T item15, out T item16, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+                (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item5) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item6) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item7) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item8) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item9) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item10) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item11) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item12) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item13) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item14) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item15) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                (count, item16) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+            }
+        }
+    }
+}

--- a/MoreLinq/Deconstruct.g.tt
+++ b/MoreLinq/Deconstruct.g.tt
@@ -77,12 +77,12 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            count = 0;
+            count = 0; var ended = false;
 
             using (var e = source.GetEnumerator())
             {
 <#          foreach (var i in Enumerable.Range(1, e.Count)) { #>
-                ReadWithCount(e, ref count, out item<#= i.ToString(CultureInfo.InvariantCulture) #>);
+                item<#= i.ToString(CultureInfo.InvariantCulture) #> = e.ReadWithCount(ref count, ref ended);
 <#          } #>
             }
         }

--- a/MoreLinq/Deconstruct.g.tt
+++ b/MoreLinq/Deconstruct.g.tt
@@ -82,7 +82,7 @@ namespace MoreLinq
             using (var e = source.GetEnumerator())
             {
 <#          foreach (var i in Enumerable.Range(1, e.Count)) { #>
-                (count, item<#= i.ToString(CultureInfo.InvariantCulture) #>) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+                ReadWithCount(e, ref count, out item<#= i.ToString(CultureInfo.InvariantCulture) #>);
 <#          } #>
             }
         }

--- a/MoreLinq/Deconstruct.g.tt
+++ b/MoreLinq/Deconstruct.g.tt
@@ -1,0 +1,91 @@
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Globalization" #>
+<#@ import namespace="System.Linq" #>
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    partial class MoreEnumerable
+    {<#
+        var ordinalNumbers = new[]
+        {
+            "first",
+            "second",
+            "third",
+            "fourth",
+            "fifth",
+            "sixth",
+            "seventh",
+            "eighth",
+            "ninth",
+            "tenth",
+            "eleventh",
+            "twelfth",
+            "thirteenth",
+            "fourteenth",
+            "fifteenth",
+            "sixteenth",
+        };
+
+        var overloads =
+            from i in Enumerable.Range(2, 15)
+            let istr = i.ToString(CultureInfo.InvariantCulture)
+            select new
+            {
+                Count         = i,
+                CountElements = istr + " " + (i == 1 ? "element" : "elements"),
+                CountArg      = istr,
+            };
+
+        foreach (var e in overloads) { #>
+
+        /// <summary>
+        /// Deconstructs first <#= e.CountArg #> elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+<#          foreach (var i in Enumerable.Range(0, e.Count)) { #>
+        /// <param name="item<#= (i + 1).ToString(CultureInfo.InvariantCulture) #>">The value of the <#= ordinalNumbers[i] #> element.</param>
+<#          } #>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, <#= string.Join(", ", from i in Enumerable.Range(1, e.Count) select "out T item" + i.ToString(CultureInfo.InvariantCulture))#>, out int count)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            count = 0;
+
+            using (var e = source.GetEnumerator())
+            {
+<#          foreach (var i in Enumerable.Range(1, e.Count)) { #>
+                (count, item<#= i.ToString(CultureInfo.InvariantCulture) #>) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
+<#          } #>
+            }
+        }
+<#      } #>
+    }
+}

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -907,6 +907,358 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>Deconstruct</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class DeconstructExtension
+    {
+        /// <summary>
+        /// Deconstructs first 2 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out count);
+
+        /// <summary>
+        /// Deconstructs first 3 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out count);
+
+        /// <summary>
+        /// Deconstructs first 4 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out count);
+
+        /// <summary>
+        /// Deconstructs first 5 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out count);
+
+        /// <summary>
+        /// Deconstructs first 6 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out count);
+
+        /// <summary>
+        /// Deconstructs first 7 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out count);
+
+        /// <summary>
+        /// Deconstructs first 8 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out count);
+
+        /// <summary>
+        /// Deconstructs first 9 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out count);
+
+        /// <summary>
+        /// Deconstructs first 10 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out count);
+
+        /// <summary>
+        /// Deconstructs first 11 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out count);
+
+        /// <summary>
+        /// Deconstructs first 12 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out item12, out count);
+
+        /// <summary>
+        /// Deconstructs first 13 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out item12, out item13, out count);
+
+        /// <summary>
+        /// Deconstructs first 14 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out item12, out item13, out item14, out count);
+
+        /// <summary>
+        /// Deconstructs first 15 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="item15">The value of the fifteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out T item15, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out item12, out item13, out item14, out item15, out count);
+
+        /// <summary>
+        /// Deconstructs first 16 elements of the sequence into given variables.
+        /// </summary>
+        /// <param name="source">The sequence to deconstruct.</param>
+        /// <param name="item1">The value of the first element.</param>
+        /// <param name="item2">The value of the second element.</param>
+        /// <param name="item3">The value of the third element.</param>
+        /// <param name="item4">The value of the fourth element.</param>
+        /// <param name="item5">The value of the fifth element.</param>
+        /// <param name="item6">The value of the sixth element.</param>
+        /// <param name="item7">The value of the seventh element.</param>
+        /// <param name="item8">The value of the eighth element.</param>
+        /// <param name="item9">The value of the ninth element.</param>
+        /// <param name="item10">The value of the tenth element.</param>
+        /// <param name="item11">The value of the eleventh element.</param>
+        /// <param name="item12">The value of the twelfth element.</param>
+        /// <param name="item13">The value of the thirteenth element.</param>
+        /// <param name="item14">The value of the fourteenth element.</param>
+        /// <param name="item15">The value of the fifteenth element.</param>
+        /// <param name="item16">The value of the sixteenth element.</param>
+        /// <param name="count">The actual count of elements deconstructed.</param>
+        /// <remarks>
+        /// If <paramref name="source"/> contains fewer elements then the
+        /// remaining item variables will be initialized to the default value
+        /// of <typeparamref name="T"/>.
+        /// </remarks>
+
+        public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out T item5, out T item6, out T item7, out T item8, out T item9, out T item10, out T item11, out T item12, out T item13, out T item14, out T item15, out T item16, out int count)
+            => MoreEnumerable.Deconstruct(source, out item1, out item2, out item3, out item4, out item5, out item6, out item7, out item8, out item9, out item10, out item11, out item12, out item13, out item14, out item15, out item16, out count);
+
+    }
+
     /// <summary><c>DistinctBy</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -26,6 +26,7 @@
         - CountBy
         - CountDown
         - Consume
+        - Deconstruct
         - DistinctBy
         - EndsWith
         - EquiZip
@@ -150,6 +151,10 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Cartesian.g.cs</LastGenOutput>
     </None>
+    <None Update="Deconstruct.g.tt">
+      <LastGenOutput>Deconstruct.g.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
     <None Update="Fold.g.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Fold.g.cs</LastGenOutput>
@@ -195,6 +200,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Cartesian.g.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Deconstruct.g.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Deconstruct.g.tt</DependentUpon>
     </Compile>
     <Compile Update="Fold.g.cs">
       <DesignTime>True</DesignTime>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ This method has 3 overloads.
 
 Returns a sequence consisting of the head element and the given tail elements.
 
+### Deconstruct
+
+Deconstructs initial elements (up to 16) of a sequence into given variables.
+
+This method has 15 overloads.
+
 ### Assert
 
 Asserts that all elements of a sequence meet a given condition otherwise

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -265,9 +265,12 @@ namespace MoreLinq.ExtensionsGenerator
                                             ArgumentList(
                                                 SeparatedList(
                                                     from p in md.ParameterList.Parameters
-                                                    select Argument(IdentifierName(p.Identifier)),
-                                                    Enumerable.Repeat(ParseToken(",").WithTrailingTrivia(Space),
-                                                                      md.ParameterList.Parameters.Count - 1))))
+                                                    let arg = Argument(IdentifierName(p.Identifier))
+                                                    select p.Modifiers.Any(pm => pm.IsKind(SyntaxKind.OutKeyword))
+                                                         ? arg.WithRefKindKeyword(Token(SyntaxKind.OutKeyword))
+                                                         : arg,
+                                                    Enumerable.Repeat(ParseToken(","),
+                                                                      md.ParameterList.Parameters.Count - 1))).NormalizeWhitespace())
                                             .WithLeadingTrivia(Space))
                                         .WithLeadingTrivia(Whitespace(indent3)))
                                 .WithSemicolonToken(ParseToken(";").WithTrailingTrivia(LineFeed))


### PR DESCRIPTION
This is a second take on issue #538 and possibly supersedes #586 pending discussion and review. 

PR #586 implements a strict version that throws an exception unless the sequence contains the exact number of elements being deconstructed. The version proposed here is simpler. It extends `IEnumerable<>` directly with `Deconstruct` that outputs, in addition to elements, a count of the elements actually read. This in turn lets the caller decide what to do. The background, thought-process and benefits were laid out in [my following comment on issue #538](https://github.com/morelinq/MoreLINQ/issues/538#issuecomment-493042590):

> I'd like to give the choice of strict or non-struct deconstruction semantics another crack. If we provide a count of how many items were actually deconstructed, like so:
> 
> ```c#
> public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out int count)
> {
>     count = 0;
>     using var e = source.GetEnumerator();
>     (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
> }
> 
> public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out int count)
> {
>     count = 0;
>     using var e = source.GetEnumerator();
>     (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
> }
> 
> public static void Deconstruct<T>(this IEnumerable<T> source, out T item1, out T item2, out T item3, out T item4, out int count)
> {
>     count = 0;
>     using var e = source.GetEnumerator();
>     (count, item1) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item2) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item3) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
>     (count, item4) = e.MoveNext() ? (count + 1, e.Current) : (count, default);
> }
> ```
> 
> then the caller has all the information and flexibility to decide what to do without having to worry about exceptions (and then also throwing an exception becomes a choice of the caller):
> 
> ```c#
> var result =
>     from s in new[]
>     {
>         "12",
>         "12,34",
>         "12,34,56",
>         "12,34,56,78",
>     }
>     select new
>     {
>         Input = s,
>         Result = s.Split(',').Select(int.Parse) switch
>         {
>             var (x, y, _, rc)    when rc == 2 => $"Point2D({x}, {y})",
>             var (x, y, z, _, rc) when rc == 3 => $"Point3D({x}, {y}, {z})",
>             _ => "?"
>         }
>     };
> 
> result.ForEach(Console.WriteLine);
> 
> /* prints:
> { Input = 12, Result = ? }
> { Input = 12,34, Result = Point2D(12, 34) }
> { Input = 12,34,56, Result = Point3D(12, 34, 56) }
> { Input = 12,34,56,78, Result = ? }
> */
> ```
> 
> Notice the use of [discard](https://docs.microsoft.com/en-us/dotnet/csharp/discards) (`_`) to probe an extra element so as to capture the case when there are more elements than desired.
> 
> With this approach, we don't need to hop over an additional method like `AsDeconstructible`, [as proposed earlier](https://github.com/morelinq/MoreLINQ/issues/538#issuecomment-487918865), just for sake of communicating the potential surprise of an exception due strict semantics.
> 
> I only see benefits:
> 
> - Back to simple `Deconstruct` extensions for sequences (that can be optimised for other collection types)
> - No semantic hop method like `AsDeconstructible`
> - No new superficial type like `DeconstructibleEnumerable` (as we have in PR #586 at this time) is needed
> - No exceptions
> - Caller has all control
> 

Moreover:

> the…example can be written with a constant pattern for the (read) count (`rc`) instead of using `when`:
> 
> ```cs
> var result =
>     from s in new[]
>     {
>         "12",
>         "12,34",
>         "12,34,56",
>         "12,34,56,78",
>     }
>     select new
>     {
>         Input = s,
>         Result = s.Split(',').Select(int.Parse) switch
>         {
>             (var x, var y, _, 2)        => $"Point2D({x}, {y})",
>             (var x, var y, var z, _, 3) => $"Point3D({x}, {y}, {z})",
>             _ => "?"
>         }
>     };
> 
> result.ForEach(Console.WriteLine);
> ```
> 
> While it may not be clear what 2 and 3 mean, one can use comments, as in `(var x, var y, _, /* count = */ 2)`, or revert to the `when` form and use a more meaningful variable name like `count`. Where immaterial, the count can be discarded. Whichever way you cut it, the choice is up to the developer. 🙌
