### PR TITLE
Revert to C# 7.3

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -115,7 +115,7 @@
     <VersionPrefix>3.3.0</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
     <TargetFrameworks>net451;netstandard1.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -156,7 +156,7 @@ namespace MoreLinq
                 throw new ArgumentException("One of the supplied expressions is not allowed.", nameof(expressions), e);
             }
 
-            static MemberInfo GetAccessedMember(LambdaExpression lambda)
+            MemberInfo GetAccessedMember(LambdaExpression lambda)
             {
                 var body = lambda.Body;
 


### PR DESCRIPTION
This reverts to using C# 7.3 instead of 8. It is not a complete undoing of PR #604. We maintain the update to .NET Core SDK 2.2.200 and corresponding changes to build scripts and CI configurations.

The main development line of the project can't benefit enough from C# 8 features at the moment that were mentioned as the main motivation for PR #604 so there is no point in imposing a preview on other contributors. It also prevents people from source-embedding some operators in projects.

While this reverts the C# version, most of the infrastructure is in place for any experimentation with C# 8 in a branch. All it requires changing the `LangVersion` element in the project file.
