### PR TITLE
fix Move operartor returns empty on second iteration

### DIFF
--- a/MoreLinq.Test/MoveTest.cs
+++ b/MoreLinq.Test/MoveTest.cs
@@ -103,6 +103,15 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void MoveCanBeIteratedTwice()
+        {
+            var source = Enumerable.Range(0, 10);
+            var result = source.Move(0, 5, 10);
+
+            Assert.That(result.ToArray(), Is.EqualTo(result));
+        }
+
+        [Test]
         public void MoveWithFromIndexEqualsToIndex()
         {
             var source = Enumerable.Range(0, 10);

--- a/MoreLinq.Test/MoveTest.cs
+++ b/MoreLinq.Test/MoveTest.cs
@@ -103,7 +103,7 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void MoveCanBeIteratedTwice()
+        public void MoveIsRepeatable()
         {
             var source = Enumerable.Range(0, 10);
             var result = source.Move(0, 5, 10);

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -57,15 +57,15 @@ namespace MoreLinq
             if (toIndex == fromIndex || count == 0)
                 return source;
 
-            bool hasMore = true;
-            bool MoveNext(IEnumerator<T> e) => hasMore && (hasMore = e.MoveNext());
-
             return toIndex < fromIndex
                  ? _(toIndex, fromIndex - toIndex, count)
                  : _(fromIndex, count, toIndex - fromIndex);
 
             IEnumerable<T> _(int bufferStartIndex, int bufferSize, int bufferYieldIndex)
             {
+                bool hasMore = true;
+                bool MoveNext(IEnumerator<T> e) => hasMore && (hasMore = e.MoveNext());
+
                 using (var e = source.GetEnumerator())
                 {
                     for (var i = 0; i < bufferStartIndex && MoveNext(e); i++)


### PR DESCRIPTION
this fix issue https://github.com/morelinq/MoreLINQ/issues/605
