### PR TITLE
Remove redundant package restore on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_install:
   - dotnet --info
 
 install:
-  - dotnet restore
   - npm install -g eclint
 
 before_script:


### PR DESCRIPTION
This PR removes package restoration on Travis CI as part of the installation step as it is redundant with `dotnet restore` in `build.sh`:

https://github.com/morelinq/MoreLINQ/blob/478218ace49794dc018dfe03d92fafae8ea77968/build.sh#L4