### PR TITLE
Replace using statement with declaration

### DIFF
--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -67,29 +67,27 @@ namespace MoreLinq
 
             return _(); IEnumerable<T> _()
             {
-                using (var e = first.CountDown(index, ValueTuple.Create)
-                                    .GetEnumerator())
+                using var e = first.CountDown(index, ValueTuple.Create).GetEnumerator();
+
+                if (e.MoveNext())
                 {
-                    if (e.MoveNext())
+                    var (_, countdown) = e.Current;
+                    if (countdown is int n && n != index - 1)
+                        throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
+
+                    do
                     {
-                        var (_, countdown) = e.Current;
-                        if (countdown is int n && n != index - 1)
-                            throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
-
-                        do
+                        T a;
+                        (a, countdown) = e.Current;
+                        if (countdown == index - 1)
                         {
-                            T a;
-                            (a, countdown) = e.Current;
-                            if (countdown == index - 1)
-                            {
-                                foreach (var b in second)
-                                    yield return b;
-                            }
-
-                            yield return a;
+                            foreach (var b in second)
+                                yield return b;
                         }
-                        while (e.MoveNext());
+
+                        yield return a;
                     }
+                    while (e.MoveNext());
                 }
             }
         }

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -180,7 +180,7 @@ namespace MoreLinq
                 bool firstHasNext;
                 bool secondHasNext;
 
-                using (var e1 = first.GetEnumerator())
+                using var e1 = first.GetEnumerator();
                 using (var e2 = second.GetEnumerator())
                 {
                     do

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -82,8 +82,8 @@ namespace MoreLinq
 
             bool Impl(IEnumerable<T> snd, int count)
             {
-                using (var firstIter = first.TakeLast(count).GetEnumerator())
-                    return snd.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
+                using var firstIter = first.TakeLast(count).GetEnumerator();
+                return snd.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
             }
         }
     }

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -45,18 +45,16 @@ namespace MoreLinq
             {
                 var index = -1;
                 var endIndex = startIndex + count;
-                using (var iter = sequence.GetEnumerator())
-                {
-                    // yield the first part of the sequence
-                    while (iter.MoveNext() && ++index < startIndex)
-                        yield return iter.Current;
-                    // skip the next part (up to count items)
-                    while (++index < endIndex && iter.MoveNext())
-                        continue;
-                    // yield the remainder of the sequence
-                    while (iter.MoveNext())
-                        yield return iter.Current;
-                }
+                var iter = sequence.GetEnumerator();
+                // yield the first part of the sequence
+                while (iter.MoveNext() && ++index < startIndex)
+                    yield return iter.Current;
+                // skip the next part (up to count items)
+                while (++index < endIndex && iter.MoveNext())
+                    continue;
+                // yield the remainder of the sequence
+                while (iter.MoveNext())
+                    yield return iter.Current;
             }
         }
     }

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -239,18 +239,17 @@ namespace MoreLinq
                     var key = firstKeySelector(fe);
                     firstKeys.Add(key);
 
-                    using (var se = secondLookup[key].GetEnumerator())
+                    using var se = secondLookup[key].GetEnumerator();
+
+                    if (se.MoveNext())
                     {
-                        if (se.MoveNext())
-                        {
-                            do { yield return bothSelector(fe, se.Current); }
-                            while (se.MoveNext());
-                        }
-                        else
-                        {
-                            se.Dispose();
-                            yield return firstSelector(fe);
-                        }
+                        do { yield return bothSelector(fe, se.Current); }
+                        while (se.MoveNext());
+                    }
+                    else
+                    {
+                        se.Dispose();
+                        yield return firstSelector(fe);
                     }
                 }
 

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -271,31 +271,30 @@ namespace MoreLinq
             Debug.Assert(resultSelector != null);
             Debug.Assert(comparer != null);
 
-            using (var iterator = source.GetEnumerator())
+            using var iterator = source.GetEnumerator();
+
+            var group = default(TKey);
+            var members = (List<TElement>) null;
+
+            while (iterator.MoveNext())
             {
-                var group = default(TKey);
-                var members = (List<TElement>) null;
-
-                while (iterator.MoveNext())
+                var key = keySelector(iterator.Current);
+                var element = elementSelector(iterator.Current);
+                if (members != null && comparer.Equals(group, key))
                 {
-                    var key = keySelector(iterator.Current);
-                    var element = elementSelector(iterator.Current);
-                    if (members != null && comparer.Equals(group, key))
-                    {
-                        members.Add(element);
-                    }
-                    else
-                    {
-                        if (members != null)
-                            yield return resultSelector(group, members);
-                        group = key;
-                        members = new List<TElement> { element };
-                    }
+                    members.Add(element);
                 }
-
-                if (members != null)
-                    yield return resultSelector(group, members);
+                else
+                {
+                    if (members != null)
+                        yield return resultSelector(group, members);
+                    group = key;
+                    members = new List<TElement> { element };
+                }
             }
+
+            if (members != null)
+                yield return resultSelector(group, members);
         }
 
         static IGrouping<TKey, TElement> CreateGroupAdjacentGrouping<TKey, TElement>(TKey key, IList<TElement> members)

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -59,20 +59,19 @@ namespace MoreLinq
             {
                 var i = -1;
 
-                using (var iter = first.GetEnumerator())
-                {
-                    while (++i < index && iter.MoveNext())
-                        yield return iter.Current;
+                using var iter = first.GetEnumerator();
 
-                    if (i < index)
-                       throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
+                while (++i < index && iter.MoveNext())
+                    yield return iter.Current;
 
-                    foreach (var item in second)
-                        yield return item;
+                if (i < index)
+                   throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
 
-                    while (iter.MoveNext())
-                        yield return iter.Current;
-                }
+                foreach (var item in second)
+                    yield return item;
+
+                while (iter.MoveNext())
+                    yield return iter.Current;
             }
         }
     }

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -65,25 +65,24 @@ namespace MoreLinq
             return _(); IEnumerable<TResult> _()
             {
                 var leadQueue = new Queue<TSource>(offset);
-                using (var iter = source.GetEnumerator())
+                var iter = source.GetEnumerator();
+
+                bool hasMore;
+                // first, prefetch and populate the lead queue with the next step of
+                // items to be streamed out to the consumer of the sequence
+                while ((hasMore = iter.MoveNext()) && leadQueue.Count < offset)
+                    leadQueue.Enqueue(iter.Current);
+                // next, while the source sequence has items, yield the result of
+                // the projection function applied to the top of queue and current item
+                while (hasMore)
                 {
-                    bool hasMore;
-                    // first, prefetch and populate the lead queue with the next step of
-                    // items to be streamed out to the consumer of the sequence
-                    while ((hasMore = iter.MoveNext()) && leadQueue.Count < offset)
-                        leadQueue.Enqueue(iter.Current);
-                    // next, while the source sequence has items, yield the result of
-                    // the projection function applied to the top of queue and current item
-                    while (hasMore)
-                    {
-                        yield return resultSelector(leadQueue.Dequeue(), iter.Current);
-                        leadQueue.Enqueue(iter.Current);
-                        hasMore = iter.MoveNext();
-                    }
-                    // yield the remaining values in the lead queue with the default lead value
-                    while (leadQueue.Count > 0)
-                        yield return resultSelector(leadQueue.Dequeue(), defaultLeadValue);
+                    yield return resultSelector(leadQueue.Dequeue(), iter.Current);
+                    leadQueue.Enqueue(iter.Current);
+                    hasMore = iter.MoveNext();
                 }
+                // yield the remaining values in the lead queue with the default lead value
+                while (leadQueue.Count > 0)
+                    yield return resultSelector(leadQueue.Dequeue(), defaultLeadValue);
             }
         }
     }

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -308,34 +308,33 @@ namespace MoreLinq
 
             IEnumerable<TSource> Extrema()
             {
-                using (var e = source.GetEnumerator())
+                using var e = source.GetEnumerator();
+
+                if (!e.MoveNext())
+                    return new List<TSource>();
+
+                var store = extrema.New();
+                extrema.Add(ref store, limit, e.Current);
+                var extremaKey = selector(e.Current);
+
+                while (e.MoveNext())
                 {
-                    if (!e.MoveNext())
-                        return new List<TSource>();
-
-                    var store = extrema.New();
-                    extrema.Add(ref store, limit, e.Current);
-                    var extremaKey = selector(e.Current);
-
-                    while (e.MoveNext())
+                    var item = e.Current;
+                    var key = selector(item);
+                    var comparison = comparer(key, extremaKey);
+                    if (comparison > 0)
                     {
-                        var item = e.Current;
-                        var key = selector(item);
-                        var comparison = comparer(key, extremaKey);
-                        if (comparison > 0)
-                        {
-                            extrema.Restart(ref store);
-                            extrema.Add(ref store, limit, item);
-                            extremaKey = key;
-                        }
-                        else if (comparison == 0)
-                        {
-                            extrema.Add(ref store, limit, item);
-                        }
+                        extrema.Restart(ref store);
+                        extrema.Add(ref store, limit, item);
+                        extremaKey = key;
                     }
-
-                    return extrema.GetEnumerable(store);
+                    else if (comparison == 0)
+                    {
+                        extrema.Add(ref store, limit, item);
+                    }
                 }
+
+                return extrema.GetEnumerable(store);
             }
         }
 

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -285,49 +285,48 @@ namespace MoreLinq
             comparer = comparer ?? Comparer<TKey>.Default;
             return _(); IEnumerable<TResult> _()
             {
-                using (var e1 = first.GetEnumerator())
-                using (var e2 = second.GetEnumerator())
+                using var e1 = first.GetEnumerator();
+                using var e2 = second.GetEnumerator();
+
+                var gotFirst = e1.MoveNext();
+                var gotSecond = e2.MoveNext();
+
+                while (gotFirst || gotSecond)
                 {
-                    var gotFirst = e1.MoveNext();
-                    var gotSecond = e2.MoveNext();
-
-                    while (gotFirst || gotSecond)
+                    if (gotFirst && gotSecond)
                     {
-                        if (gotFirst && gotSecond)
-                        {
-                            var element1 = e1.Current;
-                            var key1 = firstKeySelector(element1);
-                            var element2 = e2.Current;
-                            var key2 = secondKeySelector(element2);
-                            var comparison = comparer.Compare(key1, key2);
+                        var element1 = e1.Current;
+                        var key1 = firstKeySelector(element1);
+                        var element2 = e2.Current;
+                        var key2 = secondKeySelector(element2);
+                        var comparison = comparer.Compare(key1, key2);
 
-                            if (comparison < 0)
-                            {
-                                yield return firstSelector(element1);
-                                gotFirst = e1.MoveNext();
-                            }
-                            else if (comparison > 0)
-                            {
-                                yield return secondSelector(element2);
-                                gotSecond = e2.MoveNext();
-                            }
-                            else
-                            {
-                                yield return bothSelector(element1, element2);
-                                gotFirst = e1.MoveNext();
-                                gotSecond = e2.MoveNext();
-                            }
-                        }
-                        else if (gotSecond)
+                        if (comparison < 0)
                         {
-                            yield return secondSelector(e2.Current);
-                            gotSecond = e2.MoveNext();
-                        }
-                        else // (gotFirst)
-                        {
-                            yield return firstSelector(e1.Current);
+                            yield return firstSelector(element1);
                             gotFirst = e1.MoveNext();
                         }
+                        else if (comparison > 0)
+                        {
+                            yield return secondSelector(element2);
+                            gotSecond = e2.MoveNext();
+                        }
+                        else
+                        {
+                            yield return bothSelector(element1, element2);
+                            gotFirst = e1.MoveNext();
+                            gotSecond = e2.MoveNext();
+                        }
+                    }
+                    else if (gotSecond)
+                    {
+                        yield return secondSelector(e2.Current);
+                        gotSecond = e2.MoveNext();
+                    }
+                    else // (gotFirst)
+                    {
+                        yield return firstSelector(e1.Current);
+                        gotFirst = e1.MoveNext();
                     }
                 }
             }

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -55,17 +55,16 @@ namespace MoreLinq
 
             return _(); IEnumerable<TResult> _()
             {
-                using (var e = source.GetEnumerator())
-                {
-                    if (!e.MoveNext())
-                        yield break;
+                using var e = source.GetEnumerator();
 
-                    var previous = e.Current;
-                    while (e.MoveNext())
-                    {
-                        yield return resultSelector(previous, e.Current);
-                        previous = e.Current;
-                    }
+                if (!e.MoveNext())
+                    yield break;
+
+                var previous = e.Current;
+                while (e.MoveNext())
+                {
+                    yield return resultSelector(previous, e.Current);
+                    previous = e.Current;
                 }
             }
         }

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -198,11 +198,10 @@ namespace MoreLinq
 
             return _(); IEnumerable<IList<T>> _()
             {
-                using (var iter = new PermutationEnumerator<T>(sequence))
-                {
-                    while (iter.MoveNext())
-                        yield return iter.Current;
-                }
+                using var iter = new PermutationEnumerator<T>(sequence);
+
+                while (iter.MoveNext())
+                    yield return iter.Current;
             }
         }
     }

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -62,20 +62,18 @@ namespace MoreLinq
             return _(); IEnumerable<TSource> _()
             {
                 var aggregator = identity;
+                using var e = source.GetEnumerator();
 
-                using (var e = source.GetEnumerator())
+                if (e.MoveNext())
                 {
-                    if (e.MoveNext())
-                    {
-                        yield return aggregator;
-                        var current = e.Current;
+                    yield return aggregator;
+                    var current = e.Current;
 
-                        while (e.MoveNext())
-                        {
-                            aggregator = transformation(aggregator, current);
-                            yield return aggregator;
-                            current = e.Current;
-                        }
+                    while (e.MoveNext())
+                    {
+                        aggregator = transformation(aggregator, current);
+                        yield return aggregator;
+                        current = e.Current;
                     }
                 }
             }

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -57,29 +57,28 @@ namespace MoreLinq
                 // but it proved to be easier to deal with edge certain cases that occur
                 // (such as empty sequences) using an explicit iterator and a while loop.
 
-                using (var iter = sequence.GetEnumerator())
+                using var iter = sequence.GetEnumerator();
+
+                if (iter.MoveNext())
                 {
-                    if (iter.MoveNext())
+                    var prevItem = iter.Current;
+                    var runCount = 1;
+
+                    while (iter.MoveNext())
                     {
-                        var prevItem = iter.Current;
-                        var runCount = 1;
-
-                        while (iter.MoveNext())
+                        if (comparer.Equals(prevItem, iter.Current))
                         {
-                            if (comparer.Equals(prevItem, iter.Current))
-                            {
-                                ++runCount;
-                            }
-                            else
-                            {
-                                yield return new KeyValuePair<T, int>(prevItem, runCount);
-                                prevItem = iter.Current;
-                                runCount = 1;
-                            }
+                            ++runCount;
                         }
-
-                        yield return new KeyValuePair<T, int>(prevItem, runCount);
+                        else
+                        {
+                            yield return new KeyValuePair<T, int>(prevItem, runCount);
+                            prevItem = iter.Current;
+                            runCount = 1;
+                        }
                     }
+
+                    yield return new KeyValuePair<T, int>(prevItem, runCount);
                 }
             }
         }

--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -93,20 +93,19 @@ namespace MoreLinq
             Func<TState, TSource, TState> transformation,
             Func<IEnumerator<TSource>, (bool, TState)> seeder)
         {
-            using (var e = source.GetEnumerator())
+            using var e = source.GetEnumerator();
+
+            var (seeded, aggregator) = seeder(e);
+
+            if (!seeded)
+                yield break;
+
+            yield return aggregator;
+
+            while (e.MoveNext())
             {
-                var (seeded, aggregator) = seeder(e);
-
-                if (!seeded)
-                    yield break;
-
+                aggregator = transformation(aggregator, e.Current);
                 yield return aggregator;
-
-                while (e.MoveNext())
-                {
-                    aggregator = transformation(aggregator, e.Current);
-                    yield return aggregator;
-                }
             }
         }
     }

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -77,44 +77,43 @@ namespace MoreLinq
             return _(); IEnumerable<IEnumerable<T>> _()
             {
                 var index = -1;
-                using (var iter = source.GetEnumerator())
+                using var iter = source.GetEnumerator();
+
+                var segment = new List<T>();
+                var prevItem = default(T);
+
+                // ensure that the first item is always part
+                // of the first segment. This is an intentional
+                // behavior. Segmentation always begins with
+                // the second element in the sequence.
+                if (iter.MoveNext())
                 {
-                    var segment = new List<T>();
-                    var prevItem = default(T);
-
-                    // ensure that the first item is always part
-                    // of the first segment. This is an intentional
-                    // behavior. Segmentation always begins with
-                    // the second element in the sequence.
-                    if (iter.MoveNext())
-                    {
-                        ++index;
-                        segment.Add(iter.Current);
-                        prevItem = iter.Current;
-                    }
-
-                    while (iter.MoveNext())
-                    {
-                        ++index;
-                        // check if the item represents the start of a new segment
-                        var isNewSegment = newSegmentPredicate(iter.Current, prevItem, index);
-                        prevItem = iter.Current;
-
-                        if (!isNewSegment)
-                        {
-                            // if not a new segment, append and continue
-                            segment.Add(iter.Current);
-                            continue;
-                        }
-                        yield return segment; // yield the completed segment
-
-                        // start a new segment...
-                        segment = new List<T> { iter.Current };
-                    }
-                    // handle the case of the sequence ending before new segment is detected
-                    if (segment.Count > 0)
-                        yield return segment;
+                    ++index;
+                    segment.Add(iter.Current);
+                    prevItem = iter.Current;
                 }
+
+                while (iter.MoveNext())
+                {
+                    ++index;
+                    // check if the item represents the start of a new segment
+                    var isNewSegment = newSegmentPredicate(iter.Current, prevItem, index);
+                    prevItem = iter.Current;
+
+                    if (!isNewSegment)
+                    {
+                        // if not a new segment, append and continue
+                        segment.Add(iter.Current);
+                        continue;
+                    }
+                    yield return segment; // yield the completed segment
+
+                    // start a new segment...
+                    segment = new List<T> { iter.Current };
+                }
+                // handle the case of the sequence ending before new segment is detected
+                if (segment.Count > 0)
+                    yield return segment;
             }
         }
     }

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -59,16 +59,16 @@ namespace MoreLinq
 
             return _(); IEnumerable<TSource> _()
             {
-                using (var iterator = source.GetEnumerator())
+                using var iterator = source.GetEnumerator();
+
+                while (iterator.MoveNext())
                 {
-                    while (iterator.MoveNext())
-                    {
-                        if (predicate(iterator.Current))
-                            break;
-                    }
-                    while (iterator.MoveNext())
-                        yield return iterator.Current;
+                    if (predicate(iterator.Current))
+                        break;
                 }
+
+                while (iterator.MoveNext())
+                    yield return iterator.Current;
             }
         }
     }

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -98,43 +98,42 @@ namespace MoreLinq
 
             IEnumerable<TSource> Impl(IEnumerable<IEnumerable<TSource>> sequences)
             {
-                using (var disposables = new DisposableGroup<TSource>(sequences.Select(e => e.GetEnumerator()).Acquire()))
+                using var disposables = new DisposableGroup<TSource>(sequences.Select(e => e.GetEnumerator()).Acquire());
+
+                var iterators = disposables.Iterators;
+
+                // prime all of the iterators by advancing them to their first element (if any)
+                // NOTE: We start with the last index to simplify the removal of an iterator if
+                //       it happens to be terminal (no items) before we start merging
+                for (var i = iterators.Count - 1; i >= 0; i--)
                 {
-                    var iterators = disposables.Iterators;
+                    if (!iterators[i].MoveNext())
+                        disposables.Exclude(i);
+                }
 
-                    // prime all of the iterators by advancing them to their first element (if any)
-                    // NOTE: We start with the last index to simplify the removal of an iterator if
-                    //       it happens to be terminal (no items) before we start merging
-                    for (var i = iterators.Count - 1; i >= 0; i--)
+                // while all iterators have not yet been consumed...
+                while (iterators.Count > 0)
+                {
+                    var nextIndex = 0;
+                    var nextValue = disposables[0].Current;
+
+                    // find the next least element to return
+                    for (var i = 1; i < iterators.Count; i++)
                     {
-                        if (!iterators[i].MoveNext())
-                            disposables.Exclude(i);
-                    }
-
-                    // while all iterators have not yet been consumed...
-                    while (iterators.Count > 0)
-                    {
-                        var nextIndex = 0;
-                        var nextValue = disposables[0].Current;
-
-                        // find the next least element to return
-                        for (var i = 1; i < iterators.Count; i++)
+                        var anotherElement = disposables[i].Current;
+                        // determine which element follows based on ordering function
+                        if (precedenceFunc(nextValue, anotherElement))
                         {
-                            var anotherElement = disposables[i].Current;
-                            // determine which element follows based on ordering function
-                            if (precedenceFunc(nextValue, anotherElement))
-                            {
-                                nextIndex = i;
-                                nextValue = anotherElement;
-                            }
+                            nextIndex = i;
+                            nextValue = anotherElement;
                         }
-
-                        yield return nextValue; // next value in precedence order
-
-                        // advance iterator that yielded element, excluding it when consumed
-                        if (!iterators[nextIndex].MoveNext())
-                            disposables.Exclude(nextIndex);
                     }
+
+                    yield return nextValue; // next value in precedence order
+
+                    // advance iterator that yielded element, excluding it when consumed
+                    if (!iterators[nextIndex].MoveNext())
+                        disposables.Exclude(nextIndex);
                 }
             }
         }

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -82,10 +82,8 @@ namespace MoreLinq
 
             comparer = comparer ?? EqualityComparer<T>.Default;
 
-            using (var firstIter = first.GetEnumerator())
-            {
-                return second.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
-            }
+            var firstIter = first.GetEnumerator();
+            return second.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
         }
     }
 }

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -82,7 +82,7 @@ namespace MoreLinq
 
             comparer = comparer ?? EqualityComparer<T>.Default;
 
-            var firstIter = first.GetEnumerator();
+            using var firstIter = first.GetEnumerator();
             return second.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
         }
     }

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -41,32 +41,31 @@ namespace MoreLinq
 
             return _(); IEnumerable<IList<TSource>> _()
             {
-                using (var iter = source.GetEnumerator())
+                using var iter = source.GetEnumerator();
+
+                // generate the first window of items
+                var window = new TSource[size];
+                int i;
+                for (i = 0; i < size && iter.MoveNext(); i++)
+                    window[i] = iter.Current;
+
+                if (i < size)
+                    yield break;
+
+                // return the first window (whatever size it may be)
+                yield return window;
+
+                // generate the next window by shifting forward by one item
+                while (iter.MoveNext())
                 {
-                    // generate the first window of items
-                    var window = new TSource[size];
-                    int i;
-                    for (i = 0; i < size && iter.MoveNext(); i++)
-                        window[i] = iter.Current;
-
-                    if (i < size)
-                        yield break;
-
-                    // return the first window (whatever size it may be)
-                    yield return window;
-
-                    // generate the next window by shifting forward by one item
-                    while (iter.MoveNext())
-                    {
-                        // NOTE: If we used a circular queue rather than a list,
-                        //       we could make this quite a bit more efficient.
-                        //       Sadly the BCL does not offer such a collection.
-                        var newWindow = new TSource[size];
-                        Array.Copy(window, 1, newWindow, 0, size - 1);
-                        newWindow[size - 1] = iter.Current;
-                        yield return newWindow;
-                        window = newWindow;
-                    }
+                    // NOTE: If we used a circular queue rather than a list,
+                    //       we could make this quite a bit more efficient.
+                    //       Sadly the BCL does not offer such a collection.
+                    var newWindow = new TSource[size];
+                    Array.Copy(window, 1, newWindow, 0, size - 1);
+                    newWindow[size - 1] = iter.Current;
+                    yield return newWindow;
+                    window = newWindow;
                 }
             }
         }


### PR DESCRIPTION
This PR replaces [using statements](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) with [declarations](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#using-declarations) for the benefit of having less indented code. Most using statements in iterator blocks usually extend and scoped until the end of the block.