### PR TITLE
Optimize Batch for collection fitting a single bucket

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -87,5 +87,27 @@ namespace MoreLinq.Test
         {
             new BreakingSequence<object>().Batch(1);
         }
+
+        [TestCase(SourceKind.BreakingCollection)]
+        [TestCase(SourceKind.BreakingList)]
+        [TestCase(SourceKind.BreakingReadOnlyList)]
+        public void BatchCollectionSmallerThanSize(SourceKind kind)
+        {
+            var xs = new[] { 1, 2, 3, 4, 5 };
+            var result = xs.ToSourceKind(kind).Batch(xs.Length * 2);
+            using var reader = result.Read();
+            reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
+            reader.ReadEnd();
+        }
+
+        [Test]
+        public void BatchReadOnlyCollectionSmallerThanSize()
+        {
+            var collection = ReadOnlyCollection.From(1, 2, 3, 4, 5);
+            var result = collection.Batch(collection.Count * 2);
+            using var reader = result.Read();
+            reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
+            reader.ReadEnd();
+        }
     }
 }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -88,20 +88,28 @@ namespace MoreLinq.Test
             new BreakingSequence<object>().Batch(1);
         }
 
-        [TestCase(SourceKind.BreakingCollection)]
-        [TestCase(SourceKind.BreakingList)]
-        [TestCase(SourceKind.BreakingReadOnlyList)]
-        public void BatchCollectionSmallerThanSize(SourceKind kind)
+        [TestCase(SourceKind.BreakingCollection  , 0)]
+        [TestCase(SourceKind.BreakingList        , 0)]
+        [TestCase(SourceKind.BreakingReadOnlyList, 0)]
+        [TestCase(SourceKind.BreakingCollection  , 1)]
+        [TestCase(SourceKind.BreakingList        , 1)]
+        [TestCase(SourceKind.BreakingReadOnlyList, 1)]
+        [TestCase(SourceKind.BreakingCollection  , 2)]
+        [TestCase(SourceKind.BreakingList        , 2)]
+        [TestCase(SourceKind.BreakingReadOnlyList, 2)]
+        public void BatchCollectionSmallerThanSize(SourceKind kind, int oversize)
         {
             var xs = new[] { 1, 2, 3, 4, 5 };
-            var result = xs.ToSourceKind(kind).Batch(xs.Length * 2);
+            var result = xs.ToSourceKind(kind).Batch(xs.Length + oversize);
             using var reader = result.Read();
             reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
             reader.ReadEnd();
         }
 
-        [Test]
-        public void BatchReadOnlyCollectionSmallerThanSize()
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        public void BatchReadOnlyCollectionSmallerThanSize(int oversize)
         {
             var collection = ReadOnlyCollection.From(1, 2, 3, 4, 5);
             var result = collection.Batch(collection.Count * 2);

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -62,6 +62,7 @@
       <Compile Include="EqualityComparer.cs" />
       <Compile Include="KeyValuePair.cs" />
       <Compile Include="Program.cs" />
+      <Compile Include="ReadOnlyCollection.cs" />
       <Compile Include="SampleData.cs" />
       <Compile Include="Scope.cs" />
       <Compile Include="SequenceReader.cs" />

--- a/MoreLinq.Test/ReadOnlyCollection.cs
+++ b/MoreLinq.Test/ReadOnlyCollection.cs
@@ -1,0 +1,41 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    static class ReadOnlyCollection
+    {
+        public static IReadOnlyCollection<T> From<T>(params T[] items) =>
+            new ListCollection<T[], T>(items);
+
+        sealed class ListCollection<TList, T> : IReadOnlyCollection<T>
+            where TList : IList<T>
+        {
+            readonly TList _list;
+
+            public ListCollection(TList list) => _list = list;
+
+            public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public int Count => _list.Count;
+        }
+    }
+}

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -60,7 +60,7 @@ namespace MoreLinq
 
             switch (source)
             {
-                case ICollection<TSource> collection when collection.Count < size:
+                case ICollection<TSource> collection when collection.Count <= size:
                 {
                     return _(); IEnumerable<TResult> _()
                     {
@@ -69,7 +69,7 @@ namespace MoreLinq
                         yield return resultSelector(bucket);
                     }
                 }
-                case IReadOnlyList<TSource> list when list.Count < size:
+                case IReadOnlyList<TSource> list when list.Count <= size:
                 {
                     return _(); IEnumerable<TResult> _()
                     {
@@ -79,7 +79,7 @@ namespace MoreLinq
                         yield return resultSelector(bucket);
                     }
                 }
-                case IReadOnlyCollection<TSource> collection when collection.Count < size:
+                case IReadOnlyCollection<TSource> collection when collection.Count <= size:
                 {
                     return _(); IEnumerable<TResult> _()
                     {

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -74,8 +74,8 @@ namespace MoreLinq
                     return _(); IEnumerable<TResult> _()
                     {
                         var bucket = new TSource[list.Count];
-                        for (var index = 0; index < list.Count; index++)
-                            bucket[index] = list[index];
+                        for (var i = 0; i < list.Count; i++)
+                            bucket[i] = list[i];
                         yield return resultSelector(bucket);
                     }
                 }


### PR DESCRIPTION
This PR came out of the discussion in #619 but _does not_ address #619. It adds optimisations to `Batch` for collections (and lists) and specifically when a collection can entirely fit in a single bucket. It avoids eagerly allocating to the size argument only to trim down later.

This is an optimisation of `Batch` and not a defined behaviour.

/cc @kcragin