### PR TITLE
UnionBy extension method

### DIFF
--- a/MoreLinq.Test/UnionByTest.cs
+++ b/MoreLinq.Test/UnionByTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace MoreLinq.Test
+{
+    [TestFixture]
+    public class UnionByTest
+    {
+        [Test]
+        public void UnionBy()
+        {
+            string[] first = { "one", "two", "three", "five" };
+            string[] second = { "alice", "tom", "joe" };
+
+            var result = first.UnionBy(second, s => s.First());
+            result.AssertSequenceEqual("one", "two", "five", "alice", "joe");
+        }
+
+        [Test]
+        public void UnionByIsLazy()
+        {
+            new BreakingSequence<string>().UnionBy(new BreakingSequence<string>(), BreakingFunc.Of<string, int>());
+        }
+    }
+}

--- a/MoreLinq/UnionBy.cs
+++ b/MoreLinq/UnionBy.cs
@@ -1,0 +1,63 @@
+#region License and Terms
+
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Linq;
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Produces the set union of two sequences by using the keySelector provided.
+        /// </summary>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="first">A sequence whose distinct elements form the first set for the union.</param>
+        /// <param name="second">A sequence whose distinct elements form the second set for the union.</param>
+        /// <param name="keySelector">Projection for determining "uniqueness"</param>
+        /// <returns>A sequence that contains the elements from both input sequences, excluding duplicates.</returns>
+        public static IEnumerable<TSource> UnionBy<TSource, TKey>(
+            this IEnumerable<TSource> first,
+            IEnumerable<TSource> second,
+            Func<TSource, TKey> keySelector)
+        {
+            if (first == null)
+                throw new ArgumentNullException(nameof(first));
+            if (second == null)
+                throw new ArgumentNullException(nameof(second));
+            if (keySelector == null)
+                throw new ArgumentNullException(nameof(keySelector));
+
+            return _();
+
+            IEnumerable<TSource> _()
+            {
+                var knownKeys = new HashSet<TKey>();
+                foreach (var element in first.Concat(second))
+                {
+                    if (knownKeys.Add(keySelector(element)))
+                        yield return element;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have added a UnionBy extension method. The purpose is to remove the necessity of creating IEqualityComparer when using Union method.