### PR TITLE
Decompose `TagFirstLast` implementation for speed

### DIFF
--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -25,9 +25,8 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastDoesOneLookAhead()
         {
-            var source = MoreEnumerable.From(() => 123, () => 456, BreakingFunc.Of<int>());
-            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                                     .AsTestingSequence();
+            using var source = MoreEnumerable.From(() => 123, () => 456, BreakingFunc.Of<int>()).AsTestingSequence();
+            var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
 
             result.Take(1).Consume();
         }
@@ -41,9 +40,8 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastWithSourceSequenceOfZero()
         {
-            var source = Enumerable.Empty<int>();
-            using var result = source.TagFirstLast(BreakingFunc.Of<int, bool, bool, int>())
-                                     .AsTestingSequence();
+            using var source = Enumerable.Empty<int>().AsTestingSequence();
+            var result = source.TagFirstLast(BreakingFunc.Of<int, bool, bool, int>());
 
             Assert.That(result, Is.Empty);
         }
@@ -51,9 +49,8 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastWithSourceSequenceOfOne()
         {
-            var source = new[] { 123 };
-            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                                     .AsTestingSequence();
+            using var source = new[] { 123 }.AsTestingSequence();
+            var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
 
             result.AssertSequenceEqual(new { Item = 123, IsFirst = true, IsLast = true });
         }
@@ -61,9 +58,8 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastWithSourceSequenceOfTwo()
         {
-            var source = new[] { 123, 456 };
-            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                                     .AsTestingSequence();
+            using var source = new[] { 123, 456 }.AsTestingSequence();
+            var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
 
             result.AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
                                        new { Item = 456, IsFirst = false, IsLast = true });
@@ -72,9 +68,8 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastWithSourceSequenceOfThree()
         {
-            var source = new[] { 123, 456, 789 };
-            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                                     .AsTestingSequence();
+            using var source = new[] { 123, 456, 789 }.AsTestingSequence();
+            var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
 
             result.AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
                                        new { Item = 456, IsFirst = false, IsLast = false },

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -26,9 +26,10 @@ namespace MoreLinq.Test
         public void TagFirstLastDoesOneLookAhead()
         {
             var source = MoreEnumerable.From(() => 123, () => 456, BreakingFunc.Of<int>());
-            source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                  .Take(1)
-                  .Consume();
+            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
+                                     .AsTestingSequence();
+
+            result.Take(1).Consume();
         }
 
         [Test]
@@ -41,24 +42,30 @@ namespace MoreLinq.Test
         public void TagFirstLastWithSourceSequenceOfZero()
         {
             var source = Enumerable.Empty<int>();
-            var sut = source.TagFirstLast(BreakingFunc.Of<int, bool, bool, int>());
-            Assert.That(sut, Is.Empty);
+            using var result = source.TagFirstLast(BreakingFunc.Of<int, bool, bool, int>())
+                                     .AsTestingSequence();
+
+            Assert.That(result, Is.Empty);
         }
 
         [Test]
         public void TagFirstLastWithSourceSequenceOfOne()
         {
             var source = new[] { 123 };
-            source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                  .AssertSequenceEqual(new { Item = 123, IsFirst = true, IsLast = true });
+            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
+                                     .AsTestingSequence();
+
+            result.AssertSequenceEqual(new { Item = 123, IsFirst = true, IsLast = true });
         }
 
         [Test]
         public void TagFirstLastWithSourceSequenceOfTwo()
         {
             var source = new[] { 123, 456 };
-            source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                  .AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
+            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
+                                     .AsTestingSequence();
+
+            result.AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
                                        new { Item = 456, IsFirst = false, IsLast = true });
         }
 
@@ -66,8 +73,10 @@ namespace MoreLinq.Test
         public void TagFirstLastWithSourceSequenceOfThree()
         {
             var source = new[] { 123, 456, 789 };
-            source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
-                  .AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
+            using var result = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
+                                     .AsTestingSequence();
+
+            result.AssertSequenceEqual(new { Item = 123, IsFirst = true,  IsLast = false },
                                        new { Item = 456, IsFirst = false, IsLast = false },
                                        new { Item = 789, IsFirst = false, IsLast = true  });
         }

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -59,8 +59,24 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return source.Index() // count-up
-                         .CountDown(1, (e, cd) => resultSelector(e.Value, e.Key == 0, cd == 0));
+            return _(); IEnumerable<TResult> _()
+            {
+                using var enumerator = source.GetEnumerator();
+
+                if (!enumerator.MoveNext())
+                    yield break;
+
+                var current = enumerator.Current;
+                var hasNext = enumerator.MoveNext();
+                yield return resultSelector(current, true, !hasNext);
+
+                while (hasNext)
+                {
+                    current = enumerator.Current;
+                    hasNext = enumerator.MoveNext();
+                    yield return resultSelector(current, false, !hasNext);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This implementation avoid the creation of a `KeyValuePair` for each item of the sequence.

It improves evaluation of a 0 returning resultSelector by a factor of 3

![2019-11-05_14h13_39](https://user-images.githubusercontent.com/9695349/68212131-385b3b80-ffd9-11e9-8e14-6ad5b63326a7.png)
