### PR TITLE
Drop targets for end-of-life .NET Core versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ addons:
     - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main'
       key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
     packages:
-    - dotnet-hostfxr-1.0.1
-    - dotnet-sharedframework-microsoft.netcore.app-1.0.5
-    - dotnet-runtime-2.0.9
     - dotnet-runtime-2.1
 
 before_install:
@@ -27,12 +24,6 @@ before_install:
     if [ "$TRAVIS_OS_NAME" == "osx" ] || [ `uname` == "Darwin" ]; then
       # Handle too many files on OS X
       ulimit -n 4096
-      # Install dotnet core 1 sdk
-      wget --retry-connrefused --waitretry=1 -O /tmp/dn1.pkg 'https://download.microsoft.com/download/B/9/F/B9F1AF57-C14A-4670-9973-CDF47209B5BF/dotnet-dev-osx-x64.1.0.4.pkg'
-      sudo installer -pkg /tmp/dn1.pkg -target /
-      # Install dotnet core 2.0 runtime
-      wget --retry-connrefused --waitretry=1 -O /tmp/dn2.pkg 'https://download.microsoft.com/download/3/a/3/3a3bda26-560d-4d8e-922e-6f6bc4553a84/dotnet-runtime-2.0.9-osx-x64.pkg'
-      sudo installer -pkg /tmp/dn2.pkg -target /
       # Install dotnet core 2.1 runtime
       wget --retry-connrefused --waitretry=1 -O /tmp/dn21.pkg 'https://download.visualstudio.microsoft.com/download/pr/9314da31-774c-4d2b-8743-998f2a21f5ab/bc918ca05ab6b650f2991b205c04f623/dotnet-runtime-2.1.13-osx-x64.pkg'
       sudo installer -pkg /tmp/dn21.pkg -target /
@@ -55,8 +46,6 @@ script:
         exit 1
     fi
   - ./build.sh $CONFIGURATION
-  - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp1.0/MoreLinq.Test.dll
-  - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp2.0/MoreLinq.Test.dll
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp2.1/MoreLinq.Test.dll
   - dotnet exec MoreLinq.Test/bin/$CONFIGURATION/netcoreapp3.0/MoreLinq.Test.dll
   - mono MoreLinq.Test/bin/$CONFIGURATION/net451/MoreLinq.Test.exe

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net451</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>

--- a/test.cmd
+++ b/test.cmd
@@ -7,10 +7,6 @@ goto :EOF
 :main
 setlocal
 call build ^
-  && call :test netcoreapp1.0 Debug ^
-  && call :test netcoreapp1.0 Release ^
-  && call :test netcoreapp2.0 Debug ^
-  && call :test netcoreapp2.0 Release ^
   && call :test netcoreapp2.1 Debug ^
   && call :test netcoreapp2.1 Release ^
   && call :test netcoreapp3.0 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -e
 cd "$(dirname "$0")"
 ./build.sh
-for v in 1.0 2.0 2.1 3.0; do
+for v in 2.1 3.0; do
     for c in Debug Release; do
         dotnet exec MoreLinq.Test/bin/$c/netcoreapp$v/MoreLinq.Test.dll
     done


### PR DESCRIPTION
This PR addresses issue #674 that drops support for following .NET Core runtimes that have reached end of life/support:

- .NET Core 2.0 end of support was 2018-10-01
- .NET Core 1.1 end of support was 2019-06-27
- .NET Core 1.0 end of support was 2019-06-27
