### PR TITLE
Update README.md overloads count for GroupAdjacent

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Returns a sequence of values based on indexes
 Groups the adjacent elements of a sequence according to a specified key
 selector function.
 
-This method has 4 overloads.
+This method has 6 overloads.
 
 ### ~~Incremental~~
 


### PR DESCRIPTION
There are 6 public overloads of GroupAdjacent
https://github.com/morelinq/MoreLINQ/blob/master/MoreLinq/GroupAdjacent.cs