### PR TITLE
Update README.md overloads count for Aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ acquired till that point are disposed.
 
 Applies multiple accumulators sequentially in a single pass over a sequence.
 
-This method has 8 overloads.
+This method has 7 overloads.
 
 ### AggregateRight
 


### PR DESCRIPTION
There is only 7 public overloads of Aggregate (<T1, T2> to <T1, ..., T8>)
https://github.com/morelinq/MoreLINQ/blob/master/MoreLinq/Aggregate.g.cs