### PR TITLE
Add `If` method to do conditional application

### DIFF
--- a/MoreLinq.Test/IfTest.cs
+++ b/MoreLinq.Test/IfTest.cs
@@ -1,0 +1,44 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Vegard Løkken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class IfTest
+    {
+        [Test]
+        [TestCase(true, ExpectedResult = new[] { "FIRST", "SECOND" })]
+        [TestCase(false, ExpectedResult = new[] { "first", "second" })]
+        public IEnumerable<string> IfConditionThenToUpper(bool condition)
+        {
+            var sequence = new[] { "first", "second" };
+            return sequence.If(condition, s => s.Select(i => i.ToUpper()));
+        }
+
+        [Test]
+        [TestCase("first", ExpectedResult = new[] { "FIRST", "SECOND" })]
+        [TestCase("second", ExpectedResult = new[] { "first", "second" })]
+        public IEnumerable<string> IfFirstElementMatchesThenToUpper(string match)
+        {
+            var sequence = new[] { "first", "second" };
+            return sequence.If(s => s.First() == match, s => s.Select(i => i.ToUpper()));
+        }
+    }
+}

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -2837,6 +2837,37 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>If</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class IfExtension
+    {
+        /// <summary>
+        /// Applies a conditional mapping of the sequence.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in sequence</typeparam>
+        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="condition">The condition of when to apply the map</param>
+        /// <param name="then">Mapping function</param>
+        /// <returns>The mapped sequence or the same based on the condition</returns>
+
+        public static IEnumerable<T> If<T>(this IEnumerable<T> sequence, bool condition, Func<IEnumerable<T>, IEnumerable<T>> then)
+            => MoreEnumerable.If(sequence, condition, then);
+
+        /// <summary>
+        /// Applies a conditional mapping of the sequence.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in sequence</typeparam>
+        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="predicate">The condition of when to apply the map</param>
+        /// <param name="then">Mapping function</param>
+        /// <returns>The mapped sequence or the same based on the predicate</returns>
+
+        public static IEnumerable<T> If<T>(this IEnumerable<T> sequence, Func<IEnumerable<T>, bool> predicate, Func<IEnumerable<T>, IEnumerable<T>> then)
+            => MoreEnumerable.If(sequence, predicate, then);
+
+    }
+
     /// <summary><c>Index</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -2846,7 +2846,7 @@ namespace MoreLinq.Extensions
         /// Applies a conditional mapping of the sequence.
         /// </summary>
         /// <typeparam name="T">Type of elements in sequence</typeparam>
-        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="sequence">The sequence to conditionally map</param>
         /// <param name="condition">The condition of when to apply the map</param>
         /// <param name="then">Mapping function</param>
         /// <returns>The mapped sequence or the same based on the condition</returns>
@@ -2855,10 +2855,10 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.If(sequence, condition, then);
 
         /// <summary>
-        /// Applies a conditional mapping of the sequence.
+        /// Applies a conditional mapping of the sequence based on a predicate.
         /// </summary>
         /// <typeparam name="T">Type of elements in sequence</typeparam>
-        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="sequence">The sequence to conditionally map</param>
         /// <param name="predicate">The condition of when to apply the map</param>
         /// <param name="then">Mapping function</param>
         /// <returns>The mapped sequence or the same based on the predicate</returns>

--- a/MoreLinq/If.cs
+++ b/MoreLinq/If.cs
@@ -26,7 +26,7 @@ namespace MoreLinq
         /// Applies a conditional mapping of the sequence.
         /// </summary>
         /// <typeparam name="T">Type of elements in sequence</typeparam>
-        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="sequence">The sequence to conditionally map</param>
         /// <param name="condition">The condition of when to apply the map</param>
         /// <param name="then">Mapping function</param>
         /// <returns>The mapped sequence or the same based on the condition</returns>
@@ -43,7 +43,7 @@ namespace MoreLinq
         /// Applies a conditional mapping of the sequence based on a predicate.
         /// </summary>
         /// <typeparam name="T">Type of elements in sequence</typeparam>
-        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="sequence">The sequence to conditionally map</param>
         /// <param name="predicate">The condition of when to apply the map</param>
         /// <param name="then">Mapping function</param>
         /// <returns>The mapped sequence or the same based on the predicate</returns>

--- a/MoreLinq/If.cs
+++ b/MoreLinq/If.cs
@@ -1,0 +1,60 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2019 Vegard Løkken. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Applies a conditional mapping of the sequence.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in sequence</typeparam>
+        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="condition">The condition of when to apply the map</param>
+        /// <param name="then">Mapping function</param>
+        /// <returns>The mapped sequence or the same based on the condition</returns>
+
+        public static IEnumerable<T> If<T>(this IEnumerable<T> sequence, bool condition, Func<IEnumerable<T>, IEnumerable<T>> then)
+        {
+            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            if (then == null) throw new ArgumentNullException(nameof(then));
+
+            return condition ? then(sequence) : sequence;
+        }
+
+        /// <summary>
+        /// Applies a conditional mapping of the sequence based on a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of elements in sequence</typeparam>
+        /// <param name="sequence">The sequence to repeat</param>
+        /// <param name="predicate">The condition of when to apply the map</param>
+        /// <param name="then">Mapping function</param>
+        /// <returns>The mapped sequence or the same based on the predicate</returns>
+
+        public static IEnumerable<T> If<T>(this IEnumerable<T> sequence, Func<IEnumerable<T>, bool> predicate, Func<IEnumerable<T>, IEnumerable<T>> then)
+        {
+            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (then == null) throw new ArgumentNullException(nameof(then));
+
+            return predicate(sequence) ? then(sequence) : sequence;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ selector function.
 
 This method has 6 overloads.
 
+### If
+
+Applies a conditional mapping of a sequence based on a given condition or
+predicate.
+
 ### ~~Incremental~~
 
 `Incremental` was redundant with `Pairwise` and so deprecated since version


### PR DESCRIPTION
This new "helper" method will make it possible to have conditional parts of a LINQ chain. See #716 for more information about the problem it's meant to solve.

I'm not too familiar with the code base, but I've tried to keep it similar to the other methods in the project.