### PR TITLE
From doesn't throw immediately on null parameter.

### DIFF
--- a/MoreLinq.Test/FromTest.cs
+++ b/MoreLinq.Test/FromTest.cs
@@ -33,6 +33,62 @@ namespace MoreLinq.Test
             MoreEnumerable.From(breakingFunc, breakingFunc, breakingFunc, breakingFunc);
         }
 
+        /// <summary>
+        /// Verify that From with one parameter early throw ArgumentNullException.
+        /// </summary>
+        [Test]
+        public void TestFromWithOneParameterEarlyThrowOnNullParameter()
+        {
+            void Code()
+            {
+                MoreEnumerable.From((Func<int>)null);
+            }
+
+            Assert.Throws<ArgumentNullException>(Code);
+        }
+
+        /// <summary>
+        /// Verify that From with two parameters early throw ArgumentNullException.
+        /// </summary>
+        [Test]
+        public void TestFromWithTwoParametersEarlyThrowOnNullParameter()
+        {
+            void Code()
+            {
+                MoreEnumerable.From(() => 1, null);
+            }
+
+            Assert.Throws<ArgumentNullException>(Code);
+        }
+
+        /// <summary>
+        /// Verify that From with three parameters early throw ArgumentNullException.
+        /// </summary>
+        [Test]
+        public void TestFromWithThreeParametersEarlyThrowOnNullParameter()
+        {
+            void Code()
+            {
+                MoreEnumerable.From(() => 1, () => 1, null);
+            }
+
+            Assert.Throws<ArgumentNullException>(Code);
+        }
+
+        /// <summary>
+        /// Verify that From with many parameters early throw ArgumentNullException.
+        /// </summary>
+        [Test]
+        public void TestFromWithManyParametersEarlyThrowOnNullParameter()
+        {
+            void Code()
+            {
+                MoreEnumerable.From(() => 1, () => 1, () => 1, null);
+            }
+
+            Assert.Throws<ArgumentNullException>(Code);
+        }
+
         [TestCase(1)]
         [TestCase(2)]
         [TestCase(3)]

--- a/MoreLinq.Test/FromTest.cs
+++ b/MoreLinq.Test/FromTest.cs
@@ -34,48 +34,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that From with one parameter early throw ArgumentNullException.
-        /// </summary>
-        [Test]
-        public void TestFromWithOneParameterEarlyThrowOnNullParameter()
-        {
-            void Code()
-            {
-                MoreEnumerable.From((Func<int>)null);
-            }
-
-            Assert.Throws<ArgumentNullException>(Code);
-        }
-
-        /// <summary>
-        /// Verify that From with two parameters early throw ArgumentNullException.
-        /// </summary>
-        [Test]
-        public void TestFromWithTwoParametersEarlyThrowOnNullParameter()
-        {
-            void Code()
-            {
-                MoreEnumerable.From(() => 1, null);
-            }
-
-            Assert.Throws<ArgumentNullException>(Code);
-        }
-
-        /// <summary>
-        /// Verify that From with three parameters early throw ArgumentNullException.
-        /// </summary>
-        [Test]
-        public void TestFromWithThreeParametersEarlyThrowOnNullParameter()
-        {
-            void Code()
-            {
-                MoreEnumerable.From(() => 1, () => 1, null);
-            }
-
-            Assert.Throws<ArgumentNullException>(Code);
-        }
-
-        /// <summary>
         /// Verify that From with many parameters early throw ArgumentNullException.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -116,10 +116,6 @@ namespace MoreLinq.Test
             var nullableParameters = new[]
             {
                 nameof(MoreEnumerable.Assert) + ".errorSelector",
-                nameof(MoreEnumerable.From) + ".function",
-                nameof(MoreEnumerable.From) + ".function1",
-                nameof(MoreEnumerable.From) + ".function2",
-                nameof(MoreEnumerable.From) + ".function3",
                 nameof(MoreEnumerable.ToDataTable) + ".expressions",
                 nameof(MoreEnumerable.Trace) + ".format"
             };

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -116,7 +116,7 @@ namespace MoreLinq
             if (functions == null) throw new ArgumentNullException(nameof(functions));
             if (functions.Any(f => f == null)) throw new ArgumentNullException(nameof(functions), "At least one of the provided functions is null.");
 
-            return Evaluate(functions);
+            return functions.Select(f => f());
         }
     }
 }

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -19,6 +19,7 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     partial class MoreEnumerable
     {
@@ -36,6 +37,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function)
         {
+            if (function == null) throw new ArgumentNullException(nameof(function));
+
             return _(); IEnumerable<T> _()
             {
                 yield return function();
@@ -57,6 +60,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2)
         {
+            if (function1 == null) throw new ArgumentNullException(nameof(function1));
+            if (function2 == null) throw new ArgumentNullException(nameof(function2));
+
             return _(); IEnumerable<T> _()
             {
                 yield return function1();
@@ -80,6 +86,10 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2, Func<T> function3)
         {
+            if (function1 == null) throw new ArgumentNullException(nameof(function1));
+            if (function2 == null) throw new ArgumentNullException(nameof(function2));
+            if (function3 == null) throw new ArgumentNullException(nameof(function3));
+
             return _(); IEnumerable<T> _()
             {
                 yield return function1();
@@ -104,6 +114,8 @@ namespace MoreLinq
         public static IEnumerable<T> From<T>(params Func<T>[] functions)
         {
             if (functions == null) throw new ArgumentNullException(nameof(functions));
+            if (functions.Any(f => f == null)) throw new ArgumentNullException(nameof(functions), "At least one of the provided functions is null.");
+
             return Evaluate(functions);
         }
     }


### PR DESCRIPTION
This PR addresses #721.

The first commit add TestFromWithXParametersEarlyThrowOnNullParameter that show the flaw.

From should not depend on Evaluate that re-test for functions to not be null.