### PR TITLE
SortedMerge: Test do not call MoveNext eagerly

### DIFF
--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -55,6 +55,17 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
+        /// Verify that SortedMerge do not call MoveNext method eagerly
+        /// </summary>
+        [Test]
+        public void TestSortedMergeDoNotCallMoveNextEagerly()
+        {
+            var sequenceA = TestingSequence.Of(1, 3);
+            var sequenceB = MoreEnumerable.From(() => 2, () => throw new TestException());
+            sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB).Take(2).Consume();
+        }
+
+        /// <summary>
         /// Verify that SortedMerge throws an exception if invoked on a <c>null</c> sequence.
         /// </summary>
         [Test]

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -60,9 +60,13 @@ namespace MoreLinq.Test
         [Test]
         public void TestSortedMergeDoNotCallMoveNextEagerly()
         {
-            var sequenceA = TestingSequence.Of(1, 3);
-            var sequenceB = MoreEnumerable.From(() => 2, () => throw new TestException());
-            sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB).Take(2).Consume();
+            using var sequenceA = TestingSequence.Of(1, 3);
+            using var sequenceB = MoreEnumerable.From(() => 2, () => throw new TestException())
+                                                .AsTestingSequence();
+
+            var result = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB).Take(2);
+
+            Assert.That(() => result.Consume(), Throws.Nothing);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR add `TestSortedMergeDoNotCallMoveNextEagerly`.
Unlike for `Interleave` (#694), this test pass.