### PR TITLE
Fix a bug where ToHashSet() is implemented in .Net 4.7.1+ System.Linq, causing failure to compile

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6377,6 +6377,7 @@ namespace MoreLinq.Extensions
 
     }
 
+#if !NET471
     /// <summary><c>ToHashSet</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
@@ -6414,6 +6415,7 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.ToHashSet(source, comparer);
 
     }
+#endif
 
     /// <summary><c>ToLookup</c> extension.</summary>
 

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6377,7 +6377,7 @@ namespace MoreLinq.Extensions
 
     }
 
-#if !NET471
+#if !NET472
     /// <summary><c>ToHashSet</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -119,7 +119,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.3.1</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>net451;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net471;netstandard1.0;netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
@@ -184,7 +184,7 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net471'">
     <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
   </PropertyGroup>
 
@@ -197,7 +197,7 @@
     <Compile Remove="Extensions.ToDataTable.g.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net471'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -146,7 +146,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -119,7 +119,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.3.1</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>net451;net471;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard1.0;netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
@@ -184,7 +184,7 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net471'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
   </PropertyGroup>
 
@@ -197,7 +197,7 @@
     <Compile Remove="Extensions.ToDataTable.g.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net471'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -15,7 +15,7 @@
 // limitations under the License.
 #endregion
 
-#if !NET471
+#if !NET472
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -15,6 +15,7 @@
 // limitations under the License.
 #endregion
 
+#if !NET471
 namespace MoreLinq
 {
     using System;
@@ -60,3 +61,4 @@ namespace MoreLinq
         }
     }
 }
+#endif


### PR DESCRIPTION
Fix a bug where:
using System.Linq;
using MoreLINQ;

Causes calls to .ToHashSet() to fail to compile, because an identical implementation exists in .Net 4.7.1+