### PR TITLE
Fix Batch regression when source is an empty collection

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -117,5 +117,15 @@ namespace MoreLinq.Test
             reader.Read().AssertSequenceEqual(1, 2, 3, 4, 5);
             reader.ReadEnd();
         }
+
+        [TestCase(SourceKind.Sequence)]
+        [TestCase(SourceKind.BreakingList)]
+        [TestCase(SourceKind.BreakingReadOnlyList)]
+        [TestCase(SourceKind.BreakingCollection)]
+        public void BatchEmptySource(SourceKind kind)
+        {
+            var batches = Enumerable.Empty<int>().ToSourceKind(kind).Batch(100);
+            Assert.That(batches, Is.Empty);
+        }
     }
 }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -19,6 +19,7 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     static partial class MoreEnumerable
     {
@@ -86,6 +87,10 @@ namespace MoreLinq
 
             switch (source)
             {
+                case ICollection<TSource> collection when collection.Count == 0:
+                {
+                    return Enumerable.Empty<TResult>();
+                }
                 case ICollection<TSource> collection when collection.Count <= size:
                 {
                     return _(); IEnumerable<TResult> _()
@@ -94,6 +99,10 @@ namespace MoreLinq
                         collection.CopyTo(bucket, 0);
                         yield return resultSelector(bucket);
                     }
+                }
+                case IReadOnlyList<TSource> list when list.Count == 0:
+                {
+                    return Enumerable.Empty<TResult>();
                 }
                 case IReadOnlyList<TSource> list when list.Count <= size:
                 {


### PR DESCRIPTION
This PR is for fixing issue #741. 