### PR TITLE
Replace explicit type mentions with object pattern

### DIFF
--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -110,8 +110,8 @@ namespace MoreLinq.Test
                         0, (s, e) => s + e.Num,
                         0, (s, e) => e.Num % 2 == 0 ? s + e.Num : s,
                         0, (s, _) => s + 1,
-                        (int?)null, (s, e) => s is int n ? Math.Min(n, e.Num) : e.Num,
-                        (int?)null, (s, e) => s is int n ? Math.Max(n, e.Num) : e.Num,
+                        (int?)null, (s, e) => s is {} n ? Math.Min(n, e.Num) : e.Num,
+                        (int?)null, (s, e) => s is {} n ? Math.Max(n, e.Num) : e.Num,
                         new HashSet<int>(), (s, e) => { s.Add(e.Str.Length); return s; },
                         new List<(int Num, string Str)>(), (s, e) => { s.Add((e.Num, e.Str)); return s; },
                         (sum, esum, count, min, max, lengths, items) => new
@@ -120,8 +120,8 @@ namespace MoreLinq.Test
                             EvenSum       = esum,
                             Count         = count,
                             Average       = (double)sum / count,
-                            Min           = min is int mn ? mn : throw new InvalidOperationException(),
-                            Max           = max is int mx ? mx : throw new InvalidOperationException(),
+                            Min           = min is {} mn ? mn : throw new InvalidOperationException(),
+                            Max           = max is {} mx ? mx : throw new InvalidOperationException(),
                             UniqueLengths = lengths,
                             Items         = items,
                         }

--- a/MoreLinq.Test/ChooseTest.cs
+++ b/MoreLinq.Test/ChooseTest.cs
@@ -75,7 +75,7 @@ namespace MoreLinq.Test
         public void ThoseThatAreIntegers()
         {
             new int?[] { 0, 1, 2, null, 4, null, 6, null, null, 9 }
-                .Choose(e => e is int n ? Option.Some(n) : Option<int>.None)
+                .Choose(e => e is {} n ? Option.Some(n) : Option<int>.None)
                 .AssertSequenceEqual(0, 1, 2, 4, 6, 9);
         }
 

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -89,7 +89,7 @@ namespace MoreLinq
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
             return
-                source.TryGetCollectionCount() is int collectionCount
+                source.TryGetCollectionCount() is {} collectionCount
                 ? collectionCount == count
                   ? source
                   : From<TSource>(() => throw errorSelector(collectionCount.CompareTo(count), count))

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -72,7 +72,7 @@ namespace MoreLinq
                 if (e.MoveNext())
                 {
                     var (_, countdown) = e.Current;
-                    if (countdown is int n && n != index - 1)
+                    if (countdown is {} n && n != index - 1)
                         throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
 
                     do

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -57,9 +57,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return source.TryAsListLike() is IListLike<T> listLike
+            return source.TryAsListLike() is {} listLike
                    ? IterateList(listLike)
-                   : source.TryGetCollectionCount() is int collectionCount
+                   : source.TryGetCollectionCount() is {} collectionCount
                      ? IterateCollection(collectionCount)
                      : IterateSequence();
 

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -167,11 +167,11 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is int firstCount)
+            if (first.TryGetCollectionCount() is {} firstCount)
             {
                 return firstCount.CompareTo(second.TryGetCollectionCount() ?? second.CountUpTo(firstCount + 1));
             }
-            else if (second.TryGetCollectionCount() is int secondCount)
+            else if (second.TryGetCollectionCount() is {} secondCount)
             {
                 return first.CountUpTo(secondCount + 1).CompareTo(secondCount);
             }

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -74,8 +74,8 @@ namespace MoreLinq
             comparer ??= EqualityComparer<T>.Default;
 
             List<T> secondList;
-            return second.TryGetCollectionCount() is int secondCount
-                   ? first.TryGetCollectionCount() is int firstCount && secondCount > firstCount
+            return second.TryGetCollectionCount() is {} secondCount
+                   ? first.TryGetCollectionCount() is {} firstCount && secondCount > firstCount
                      ? false
                      : Impl(second, secondCount)
                    : Impl(secondList = second.ToList(), secondList.Count);

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -636,7 +636,7 @@ namespace MoreLinq.Experimental
                         onEnd();
                 }
 
-                var concurrencyGate = maxConcurrency is int count
+                var concurrencyGate = maxConcurrency is {} count
                                     ? new ConcurrencyGate(count)
                                     : ConcurrencyGate.Unbounded;
 

--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -115,7 +115,7 @@ namespace MoreLinq.Experimental
                     };
                     return resultSelector(one, item);
                 }
-                case int _:
+                case {}:
                     return resultSelector(many, default);
                 default:
                 {

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -161,7 +161,7 @@ namespace MoreLinq
             int? count, T fallback1, T fallback2, T fallback3, T fallback4,
             IEnumerable<T> fallback)
         {
-            return source.TryGetCollectionCount() is int collectionCount
+            return source.TryGetCollectionCount() is {} collectionCount
                  ? collectionCount == 0 ? Fallback() : source
                  : _();
 

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -110,7 +110,7 @@ namespace MoreLinq
 
                         while (e.MoveNext())
                         {
-                            if (selector(e.Current) is IEnumerable inner)
+                            if (selector(e.Current) is {} inner)
                             {
                                 stack.Push(e);
                                 e = inner.GetEnumerator();

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -119,7 +119,7 @@ namespace MoreLinq
             int width, T padding, Func<int, T> paddingSelector)
         {
             return
-                source.TryGetCollectionCount() is int collectionCount
+                source.TryGetCollectionCount() is {} collectionCount
                 ? collectionCount >= width
                   ? source
                   : Enumerable.Range(0, width - collectionCount)

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
                 return source;
 
             return
-                source.TryGetCollectionCount() is int collectionCount
+                source.TryGetCollectionCount() is {} collectionCount
                 ? source.Take(collectionCount - count)
                 : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd ))
                         .TakeWhile(e => e.Countdown == null)

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -73,8 +73,8 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is int firstCount &&
-                second.TryGetCollectionCount() is int secondCount &&
+            if (first.TryGetCollectionCount() is {} firstCount &&
+                second.TryGetCollectionCount() is {} secondCount &&
                 secondCount > firstCount)
             {
                 return false;

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -54,7 +54,7 @@ namespace MoreLinq
                 return Enumerable.Empty<TSource>();
 
             return
-                source.TryGetCollectionCount() is int collectionCount
+                source.TryGetCollectionCount() is {} collectionCount
                 ? source.Slice(Math.Max(0, collectionCount - count), int.MaxValue)
                 : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
                         .SkipWhile(e => e.Countdown == null)


### PR DESCRIPTION
This PR replaces all explicit (and now redundant) type mentions in patterns for sake of non-null testing (in addition to introducing a variable) with the _object_ or _empty property pattern_ `{}`.

From **Property patterns** section of the [**Do more with patterns in C# 8**](https://devblogs.microsoft.com/dotnet/do-more-with-patterns-in-c-8-0/) blog entry.
> One thing that remains true of all type patterns including property patterns, is that they require the value to be non-null. That opens the possibility of the “empty” property pattern {} being used as a compact “not-null” pattern.
