### PR TITLE
Deploy package only on CI build of "deploy"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+if: NOT branch = deploy
 language: csharp
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ deploy:
     secure: fhGwXyO35FSshRzs5GWmF1LJTrd1sIqmS/jNCSfO2LfOciuYAKiXuFMYZFGiTAl+
   symbol_server: https://www.myget.org/F/morelinq/symbols/api/v2/package
   on:
-    branch: master
+    branch: deploy
 notifications:
 - provider: Email
   to:


### PR DESCRIPTION
This addresses #681 by not publishing from `master` anymore but a `deploy` branch that can always be synchronized with a fast-forward merge of `master`.