### PR TITLE
Fix bug in LastOrDefault for extrema sequence

### DIFF
--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -68,16 +68,16 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).First(), Is.EqualTo("hello"));
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.First(maxima), Is.EqualTo("hello"));
             }
 
             [Test]
             public void WithComparerReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .First(),
-                            Is.EqualTo("ax"));
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.First(maxima), Is.EqualTo("ax"));
             }
 
             [Test]
@@ -85,7 +85,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MaxBy(s => s.Length).First());
+                    MoreEnumerable.First(strings.MaxBy(s => s.Length)));
             }
 
             [Test]
@@ -93,7 +93,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer).First());
+                    MoreEnumerable.First(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)));
             }
         }
 
@@ -103,32 +103,32 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).FirstOrDefault(), Is.EqualTo("hello"));
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.EqualTo("hello"));
             }
 
             [Test]
             public void WithComparerReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .FirstOrDefault(),
-                            Is.EqualTo("ax"));
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.EqualTo("ax"));
             }
 
             [Test]
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).FirstOrDefault(), Is.Null);
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.Null);
             }
 
             [Test]
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .FirstOrDefault(),
-                            Is.Null);
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.Null);
             }
         }
 
@@ -138,16 +138,16 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).Last(), Is.EqualTo("world"));
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.Last(maxima), Is.EqualTo("world"));
             }
 
             [Test]
             public void WithComparerReturnsMaximumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .Last(),
-                            Is.EqualTo("az"));
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.Last(maxima), Is.EqualTo("az"));
             }
 
             [Test]
@@ -155,7 +155,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MaxBy(s => s.Length).Last());
+                    MoreEnumerable.Last(strings.MaxBy(s => s.Length)));
             }
 
             [Test]
@@ -163,7 +163,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer).Last());
+                    MoreEnumerable.Last(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)));
             }
         }
 
@@ -173,32 +173,32 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).LastOrDefault(), Is.EqualTo("world"));
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.EqualTo("world"));
             }
 
             [Test]
             public void WithComparerReturnsMaximumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .LastOrDefault(),
-                            Is.EqualTo("az"));
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.EqualTo("az"));
             }
 
             [Test]
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length).LastOrDefault(), Is.Null);
+                var maxima = strings.MaxBy(s => s.Length);
+                Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.Null);
             }
 
             [Test]
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .LastOrDefault(),
-                            Is.Null);
+                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.Null);
             }
         }
 

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -68,16 +68,16 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).First(), Is.EqualTo("ax"));
+                var minima = MoreEnumerable.First(strings.MinBy(s => s.Length));
+                Assert.That(minima, Is.EqualTo("ax"));
             }
 
             [Test]
             public void WithComparerReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .First(),
-                            Is.EqualTo("hello"));
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.First(minima), Is.EqualTo("hello"));
             }
 
             [Test]
@@ -85,7 +85,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MinBy(s => s.Length).First());
+                    MoreEnumerable.First(strings.MinBy(s => s.Length)));
             }
 
             [Test]
@@ -93,7 +93,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer).First());
+                    MoreEnumerable.First(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)));
             }
         }
 
@@ -103,32 +103,32 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).FirstOrDefault(), Is.EqualTo("ax"));
+                var minima = strings.MinBy(s => s.Length);
+                Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.EqualTo("ax"));
             }
 
             [Test]
             public void WithComparerReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .FirstOrDefault(),
-                            Is.EqualTo("hello"));
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.EqualTo("hello"));
             }
 
             [Test]
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).FirstOrDefault(), Is.Null);
+                var minima = strings.MinBy(s => s.Length);
+                Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.Null);
             }
 
             [Test]
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .FirstOrDefault(),
-                            Is.Null);
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.Null);
             }
         }
 
@@ -138,16 +138,16 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).Last(), Is.EqualTo("az"));
+                var minima = strings.MinBy(s => s.Length);
+                Assert.That(MoreEnumerable.Last(minima), Is.EqualTo("az"));
             }
 
             [Test]
             public void WithComparerReturnsMinimumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .Last(),
-                            Is.EqualTo("world"));
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.Last(minima), Is.EqualTo("world"));
             }
 
             [Test]
@@ -155,7 +155,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MinBy(s => s.Length).Last());
+                    MoreEnumerable.Last(strings.MinBy(s => s.Length)));
             }
 
             [Test]
@@ -163,7 +163,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.Throws<InvalidOperationException>(() =>
-                    strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer).Last());
+                    MoreEnumerable.Last(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)));
             }
         }
 
@@ -173,32 +173,32 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).LastOrDefault(), Is.EqualTo("az"));
+                var minima = strings.MinBy(s => s.Length);
+                Assert.That(MoreEnumerable.LastOrDefault(minima), Is.EqualTo("az"));
             }
 
             [Test]
             public void WithComparerReturnsMinimumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .LastOrDefault(),
-                            Is.EqualTo("world"));
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.LastOrDefault(minima), Is.EqualTo("world"));
             }
 
             [Test]
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length).LastOrDefault(), Is.Null);
+                var minima = strings.MinBy(s => s.Length);
+                Assert.That(MoreEnumerable.LastOrDefault(minima), Is.Null);
             }
 
             [Test]
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                                   .LastOrDefault(),
-                            Is.Null);
+                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                Assert.That(MoreEnumerable.LastOrDefault(minima), Is.Null);
             }
         }
 

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -126,7 +126,7 @@ namespace MoreLinq
         public static T LastOrDefault<T>(this IExtremaEnumerable<T> source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return source.Take(1).AsEnumerable().LastOrDefault();
+            return source.TakeLast(1).AsEnumerable().LastOrDefault();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes the bug reported in #760.

Note that the tests added in 86f6f5807a2bb84ecd40b482c9b0bce3f9ea3147 were testing `First`, `FirstOrDefault`, `Last` and `LastOrDefault` members of `System.Linq.Enumerable` rather than those from MoreLINQ that extend `IExtremaEnumerable<>`. This PR fixes that too. In fact, the bug only surfaced after realising that 86f6f5807a2bb84ecd40b482c9b0bce3f9ea3147 wasn't testing the right implementation.