### PR TITLE
Fix .NET Core version in test script

### DIFF
--- a/test.cmd
+++ b/test.cmd
@@ -9,8 +9,8 @@ setlocal
 call build ^
   && call :test netcoreapp2.1 Debug ^
   && call :test netcoreapp2.1 Release ^
-  && call :test netcoreapp3.0 Debug ^
-  && call :test netcoreapp3.0 Release ^
+  && call :test netcoreapp3.1 Debug ^
+  && call :test netcoreapp3.1 Release ^
   && call :test net451 Debug ^
   && call :test net451 Release
 goto :EOF


### PR DESCRIPTION
The Windows script was testing against the .NET Core 3.0 runtime instead of 3.1 whereas `MoreLinq.Test.csproj` doesn't list the former as a target. This PR fixes that.