### PR TITLE
Fix duplicate test runs on Windows

### DIFF
--- a/test.cmd
+++ b/test.cmd
@@ -24,6 +24,6 @@ if %2==Debug set COVERAGE_ARGS=-p:CollectCoverage=true ^
 if %1==net451 (
     MoreLinq.Test\bin\%2\net451\MoreLinq.Test.exe
 ) else (
-    dotnet test --no-build MoreLinq.Test -c %2 %COVERAGE_ARGS%
+    dotnet test --no-build MoreLinq.Test -f %1 -c %2 %COVERAGE_ARGS%
 )
 goto :EOF


### PR DESCRIPTION
This PR fixes `test.cmd` that was running same test configuration several times since the framework-specific flag was missing.
