### PR TITLE
Fix typo in Partition return value documentation

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4127,7 +4127,7 @@ namespace MoreLinq.Extensions
         /// <param name="predicate">The predicate function.</param>
         /// <typeparam name="T">Type of source elements.</typeparam>
         /// <returns>
-        /// A tuple of elements staisfying the predicate and those that do not,
+        /// A tuple of elements satisfying the predicate and those that do not,
         /// respectively.
         /// </returns>
         /// <example>

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -31,7 +31,7 @@ namespace MoreLinq
         /// <param name="predicate">The predicate function.</param>
         /// <typeparam name="T">Type of source elements.</typeparam>
         /// <returns>
-        /// A tuple of elements staisfying the predicate and those that do not,
+        /// A tuple of elements satisfying the predicate and those that do not,
         /// respectively.
         /// </returns>
         /// <example>


### PR DESCRIPTION
Replaced "staisfying" with "satisfying" in documentation for the `Partition` extension method.