### PR TITLE
SelectMany that merges async streams projected from a sequence

### DIFF
--- a/MoreLinq/Experimental/Async/AsyncQuery.cs
+++ b/MoreLinq/Experimental/Async/AsyncQuery.cs
@@ -1,0 +1,85 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2020 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+#if !NO_ASYNC_STREAMS
+
+namespace MoreLinq.Experimental.Async
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    /// <summary>
+    /// Represents an asynchronous stream that may internally have concurrent
+    /// yielding semantics.
+    /// </summary>
+    /// <inheritdoc />
+    /// <typeparam name="T">The type of the source elements.</typeparam>
+
+    public interface IAsyncQuery<out T> : IAsyncEnumerable<T>
+    {
+        /// <summary>
+        /// The options that determine how the sequence evaluation behaves when
+        /// it is iterated.
+        /// </summary>
+
+        AsyncQueryOptions Options { get; }
+
+        /// <summary>
+        /// Returns a new query that will use the given options.
+        /// </summary>
+        /// <param name="options">The new options to use.</param>
+        /// <returns>
+        /// Returns a new query using the supplied options.
+        /// </returns>
+
+        IAsyncQuery<T> WithOptions(AsyncQueryOptions options);
+    }
+
+    static class AsyncQuery
+    {
+        public static IAsyncQuery<T>
+            Create<T>(Func<AsyncQueryOptions, IAsyncEnumerable<T>> impl,
+                      AsyncQueryOptions? options = null) =>
+            new DelegatingAsyncQuery<T>(impl, options);
+
+        sealed class DelegatingAsyncQuery<T> : IAsyncQuery<T>
+        {
+            readonly Func<AsyncQueryOptions, IAsyncEnumerable<T>> _impl;
+
+            public DelegatingAsyncQuery(Func<AsyncQueryOptions, IAsyncEnumerable<T>> impl,
+                                        AsyncQueryOptions? options = null)
+            {
+                _impl = impl;
+                Options = options ?? AsyncQueryOptions.Default;
+            }
+
+            public AsyncQueryOptions Options { get; }
+
+            public IAsyncQuery<T> WithOptions(AsyncQueryOptions options)
+            {
+                if (options == null) throw new ArgumentNullException(nameof(options));
+                return Options == options ? this : new DelegatingAsyncQuery<T>(_impl, options);
+            }
+
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken) =>
+                _impl(Options).GetAsyncEnumerator(cancellationToken);
+        }
+    }
+}
+
+#endif // !NO_ASYNC_STREAMS

--- a/MoreLinq/Experimental/Async/AsyncQueryOptions.cs
+++ b/MoreLinq/Experimental/Async/AsyncQueryOptions.cs
@@ -1,0 +1,69 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2020 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+#if !NO_ASYNC_STREAMS
+
+namespace MoreLinq.Experimental.Async
+{
+    using System;
+
+    /// <summary>
+    /// Represents options for asynchronous queries that may have concurrent
+    /// execution semantics.
+    /// </summary>
+
+    public sealed class AsyncQueryOptions
+    {
+        /// <summary>
+        /// The default options used for a query whose results evaluate
+        /// asynchronously.
+        /// </summary>
+
+        public static readonly AsyncQueryOptions Default =
+            new AsyncQueryOptions(null /* = unbounded concurrency */);
+
+        /// <summary>
+        /// Gets a positive (non-zero) integer that specifies the maximum
+        /// number of asynchronous operations to have in-flight concurrently
+        /// or <c>null</c> to mean unlimited concurrency.
+        /// </summary>
+
+        public int? MaxConcurrency { get; }
+
+        AsyncQueryOptions(int? maxConcurrency)
+        {
+            MaxConcurrency = maxConcurrency == null || maxConcurrency > 0
+                ? maxConcurrency
+                : throw new ArgumentOutOfRangeException(
+                    nameof(maxConcurrency), maxConcurrency,
+                    "Maximum concurrency must be 1 or greater.");
+        }
+
+        /// <summary>
+        /// Returns new options with the given concurrency limit.
+        /// </summary>
+        /// <param name="value">
+        /// The maximum concurrent asynchronous operation to keep in flight.
+        /// Use <c>null</c> to mean unbounded concurrency.</param>
+        /// <returns>Options with the new setting.</returns>
+
+        public AsyncQueryOptions WithMaxConcurrency(int? value) =>
+            value == MaxConcurrency ? this : new AsyncQueryOptions(value);
+    }
+}
+
+#endif // !NO_ASYNC_STREAMS

--- a/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
+++ b/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
@@ -1,0 +1,24 @@
+#if !NO_ASYNC_STREAMS
+
+namespace MoreLinq.Experimental.Async
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// <para>
+    /// Provides a set of static methods for querying objects that
+    /// implement <see cref="IAsyncEnumerable{T}" />.</para>
+    /// <para>
+    /// <strong>THE METHODS ARE EXPERIMENTAL. THEY MAY BE UNSTABLE AND
+    /// UNTESTED. THEY MAY BE REMOVED FROM A FUTURE MAJOR OR MINOR RELEASE AND
+    /// POSSIBLY WITHOUT NOTICE. USE THEM AT YOUR OWN RISK. THE METHODS ARE
+    /// PUBLISHED FOR FIELD EXPERIMENTATION TO SOLICIT FEEDBACK ON THEIR
+    /// UTILITY AND DESIGN/IMPLEMENTATION DEFECTS.</strong></para>
+    /// </summary>
+
+    public static partial class ExperimentalEnumerable
+    {
+    }
+}
+
+#endif // !NO_ASYNC_STREAMS

--- a/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
+++ b/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
@@ -18,6 +18,30 @@ namespace MoreLinq.Experimental.Async
 
     public static partial class ExperimentalEnumerable
     {
+        /// <summary>
+        /// Converts a query whose results evaluate asynchronously to use
+        /// sequential instead of concurrent evaluation.
+        /// </summary>
+        /// <typeparam name="T">The type of the source elements.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <returns>The converted sequence.</returns>
+
+        public static IAsyncEnumerable<T> AsSequential<T>(this IAsyncQuery<T> source) =>
+            source.MaxConcurrency(1);
+
+        /// <summary>
+        /// Returns a query whose results evaluate asynchronously to use a
+        /// concurrency limit.
+        /// </summary>
+        /// <typeparam name="T">The type of the source elements.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="value"></param>
+        /// <returns>
+        /// A query whose results evaluate asynchronously using the given
+        /// concurrency limit.</returns>
+
+        public static IAsyncQuery<T> MaxConcurrency<T>(this IAsyncQuery<T> source, int value) =>
+            source.WithOptions(source.Options.WithMaxConcurrency(value));
     }
 }
 

--- a/MoreLinq/Experimental/Async/SelectMany.cs
+++ b/MoreLinq/Experimental/Async/SelectMany.cs
@@ -55,7 +55,7 @@ namespace MoreLinq.Experimental.Async
 
         public static IAsyncQuery<TResult>
             SelectMany<TSource, TCollection, TResult>(
-                IEnumerable<TSource> source,
+                this IEnumerable<TSource> source,
                 Func<TSource, IAsyncEnumerable<TCollection>> collectionSelector,
                 Func<TSource, TCollection, TResult> resultSelector)
         {

--- a/MoreLinq/Experimental/Async/SelectMany.cs
+++ b/MoreLinq/Experimental/Async/SelectMany.cs
@@ -177,7 +177,7 @@ namespace MoreLinq.Experimental.Async
         }
 
         static async ValueTask<(T1, T2, T3)> And<T1, T2, T3>(this ValueTask<T1> task, T2 second, T3 third) =>
-            (await task, second, third);
+            (await task.ConfigureAwait(false), second, third);
     }
 }
 

--- a/MoreLinq/Experimental/Async/SelectMany.cs
+++ b/MoreLinq/Experimental/Async/SelectMany.cs
@@ -1,0 +1,160 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2020 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+#if !NO_ASYNC_STREAMS
+
+namespace MoreLinq.Experimental.Async
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    partial class ExperimentalEnumerable
+    {
+        /// <summary>
+        /// Projects each element of a sequence to an asynchronous stream,
+        /// flattens the resulting asynchronous stream into one asynchronous stream,
+        /// and invokes a result selector function on each element therein.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TCollection">
+        /// The type of the intermediate elements collected by
+        /// <paramref name="collectionSelector"/>.</typeparam>
+        /// <typeparam name="TResult">
+        /// The type of the elements of the resulting sequence.</typeparam>
+        /// <param name="source">A sequence of values to project.</param>
+        /// <param name="collectionSelector">
+        /// A transform function to apply to each element of the input sequence.</param>
+        /// <param name="resultSelector">
+        /// A transform function to apply to each element of the intermediate
+        /// asynchronous stream.</param>
+        /// <returns>
+        /// An <see cref="IAsyncEnumerable{T}"/> whose elements are the result of
+        /// invoking the one-to-many transform function <paramref name="collectionSelector"/>
+        /// on each element of source and then mapping each of those sequence elements
+        /// and their corresponding source element to a result element.
+        /// </returns>
+
+        public static IAsyncEnumerable<TResult>
+            SelectMany<TSource, TCollection, TResult>(
+                IEnumerable<TSource> source,
+                Func<TSource, IAsyncEnumerable<TCollection>> collectionSelector,
+                Func<TSource, TCollection, TResult> resultSelector)
+        {
+            if (source is null) throw new ArgumentNullException(nameof(source));
+            if (collectionSelector is null) throw new ArgumentNullException(nameof(collectionSelector));
+            if (resultSelector is null) throw new ArgumentNullException(nameof(resultSelector));
+
+            return SelectMany(source, collectionSelector, resultSelector, default);
+        }
+
+        // TODO Convert to local function when moving to C# 9 or later
+
+        static async IAsyncEnumerable<TResult>
+            SelectMany<TSource, TCollection, TResult>(
+                IEnumerable<TSource> source,
+                Func<TSource, IAsyncEnumerable<TCollection>> collectionSelector,
+                Func<TSource, TCollection, TResult> resultSelector,
+                [EnumeratorCancellation]CancellationToken cancellationToken)
+        {
+            var enumeratorList = new List<(TSource, IAsyncEnumerator<TCollection>)>();
+
+            try
+            {
+                var enumerators =
+                    from item in source
+                    select (item, collectionSelector(item).GetAsyncEnumerator(cancellationToken));
+
+                enumeratorList.AddRange(enumerators);
+
+                var pendingTaskList = new List<Task<(bool, TSource, IAsyncEnumerator<TCollection>)>>();
+
+                const bool some = true;
+
+                async ValueTask<(bool, TResult)>
+                    ReadAsync(TSource item, IAsyncEnumerator<TCollection> enumerator)
+                {
+                    var task = enumerator.MoveNextAsync();
+
+                    if (task.IsCompleted)
+                    {
+                        if (await task.ConfigureAwait(false))
+                            return (some, resultSelector(item, enumerator.Current));
+
+                        await enumerator.DisposeAsync().ConfigureAwait(false);
+                        enumeratorList.Remove((item, enumerator));
+                    }
+                    else
+                    {
+                        pendingTaskList.Add(task.And(item, enumerator).AsTask());
+                    }
+
+                    return default;
+                }
+
+                while (pendingTaskList.Count < enumeratorList.Count)
+                {
+                    var i = pendingTaskList.Count;
+                    var (item, enumerator) = enumeratorList[i];
+
+                    while (await ReadAsync(item, enumerator).ConfigureAwait(false)
+                           is (some, var resultItem))
+                    {
+                        yield return resultItem;
+                    }
+                }
+
+                while (pendingTaskList.Count > 0)
+                {
+                    var completedTask = await Task.WhenAny(pendingTaskList).ConfigureAwait(false);
+                    var (moved, item, enumerator) = await completedTask.ConfigureAwait(false);
+                    pendingTaskList.Remove(completedTask);
+
+                    if (moved)
+                    {
+                        yield return resultSelector(item, enumerator.Current);
+
+                        while (await ReadAsync(item, enumerator).ConfigureAwait(false)
+                               is (some, var resultItem))
+                        {
+                            yield return resultItem;
+                        }
+                    }
+                    else
+                    {
+                        await enumerator.DisposeAsync().ConfigureAwait(false);
+                        enumeratorList.Remove((item, enumerator));
+                    }
+                }
+            }
+            finally
+            {
+                foreach (var (_, enumerator) in enumeratorList)
+                    await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        static async ValueTask<(T1, T2, T3)> And<T1, T2, T3>(this ValueTask<T1> task, T2 second, T3 third) =>
+            (await task, second, third);
+    }
+}
+
+#endif // !NO_ASYNC_STREAMS

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -81,6 +81,7 @@
         - ScanBy
         - ScanRight
         - Segment
+        - SelectMany (EXPERIMENTAL)
         - Sequence
         - Shuffle
         - SkipLast
@@ -119,10 +120,11 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.3.2</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>net451;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MoreLinq</AssemblyName>
@@ -185,12 +187,12 @@
     <Reference Include="System" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' ">
-    <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+    <DefineConstants>$(DefineConstants);NO_ASYNC_STREAMS;NO_SERIALIZATION_ATTRIBUTES;NO_EXCEPTION_SERIALIZATION;NO_TRACING;NO_COM;NO_ASYNC</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <DefineConstants>$(DefineConstants);MORELINQ;NO_SERIALIZATION_ATTRIBUTES;NO_EXCEPTION_SERIALIZATION;NO_TRACING;NO_COM;NO_ASYNC</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NO_ASYNC_STREAMS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">


### PR DESCRIPTION
This PR is an implementation of `SelectMany` that projects asynchronous stream from each element of a source sequence and merges the elements of the projected asynchronous stream into a single asynchronous stream result.

By default, the projected asynchronous streams are consumed concurrently. Additional options permit setting maximum desired concurrency.

### Demo

```c#
using System;
using System.Collections.Generic;
using System.Linq;
using System.Threading.Tasks;
using MoreLinq.Experimental.Async;

var q =
    from x in Enumerable.Range(1, 5)
    from e in AsyncEnumerable.Range(x, 5)
                             .Zip(Interval(TimeSpan.FromSeconds(0.2)), (y, _) => (Y: y, Time: DateTime.Now))
    select new { X = x, e.Y, e.Time };

var qq = args.Length > 0
       ? q.MaxConcurrency(int.Parse(args[0]))
       : q;

await foreach (var e in qq)
    Console.WriteLine($"{e.Time:HH:mm:ss.fff}: x = {e.X}, y = {e.Y}");

static async IAsyncEnumerable<int> Interval(TimeSpan interval)
{
    for (var i = 0; ; i++)
    {
        await Task.Delay(interval).ConfigureAwait(false);
        yield return i;
    }
}
```
