### PR TITLE
Integrate templated code generation into project file

### DIFF
--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -25,6 +25,8 @@ namespace MoreLinq
     using System;
     using System.Collections.Generic;
 
+    // This is a test
+
     partial class MoreEnumerable
     {
 <#      const int max = 16;

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -25,8 +25,6 @@ namespace MoreLinq
     using System;
     using System.Collections.Generic;
 
-    // This is a test
-
     partial class MoreEnumerable
     {
 <#      const int max = 16;

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -253,4 +253,23 @@
     </PackageReference>
   </ItemGroup>
 
+  <Target Name="_CollectTextTemplates">
+    <ItemGroup>
+      <TextTemplate Include="%(None.Identity)" Condition="%(None.Generator) == 'TextTemplatingFileGenerator'">
+        <LastGenOutput>%(None.LastGenOutput)</LastGenOutput>
+      </TextTemplate>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="TransformTextTemplate"
+          AfterTargets="BeforeBuild" DependsOnTargets="_CollectTextTemplates"
+          Inputs="@(TextTemplate -> '%(Identity)')"
+          Outputs="@(TextTemplate -> '%(LastGenOutput)')">
+    <Exec Command="dotnet t4 -h &gt; NUL" IgnoreExitCode="True">
+      <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
+    </Exec>
+    <Exec Command="dotnet tool restore" Condition="$(_TestExitCode) != 0" />
+    <Exec Command="dotnet t4 %(TextTemplate.Identity)" />
+  </Target>
+
 </Project>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -156,6 +156,7 @@
 
   <ItemGroup>
     <None Include="..\COPYING.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+    <None Include="*.g.tt" />
     <None Update="Aggregate.g.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Aggregate.g.cs</LastGenOutput>
@@ -262,14 +263,18 @@
   </Target>
 
   <Target Name="TransformTextTemplate"
-          AfterTargets="BeforeBuild" DependsOnTargets="_CollectTextTemplates"
+          DependsOnTargets="_CollectTextTemplates"
           Inputs="@(TextTemplate -> '%(Identity)')"
           Outputs="@(TextTemplate -> '%(LastGenOutput)')">
+    <Error Condition="'$(BuildInParallel)' == 'true'" Text="Parallel build is unsupported for T4 code generation. Re-build with the switch &#34;/p:BuildInParallel&#34;." />
     <Exec Command="dotnet t4 -h &gt; NUL" IgnoreExitCode="True">
       <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
     </Exec>
     <Exec Command="dotnet tool restore" Condition="$(_TestExitCode) != 0" />
     <Exec Command="dotnet t4 %(TextTemplate.Identity)" />
   </Target>
+
+  <Target Name="_TransformTextTemplate"
+          AfterTargets="BeforeBuild" DependsOnTargets="TransformTextTemplate" />
 
 </Project>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -262,19 +262,26 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="TransformTextTemplate"
-          DependsOnTargets="_CollectTextTemplates"
-          Inputs="@(TextTemplate -> '%(Identity)')"
-          Outputs="@(TextTemplate -> '%(LastGenOutput)')">
-    <Error Condition="'$(BuildInParallel)' == 'true'" Text="Parallel build is unsupported for T4 code generation. Re-build with the switch &#34;/p:BuildInParallel&#34;." />
+  <Target Name="_TransformTextTemplate" Inputs="$(TextTemplate)" Outputs="$(TextTemplateOutput)">
+    <!-- Parallel build is unsupported here to avoid file locking issues.
+         See also: https://github.com/dotnet/msbuild/issues/2781 -->
+    <Error Condition="'$(BuildInParallel)' == 'true'"
+           Text="Parallel build is unsupported for T4 code generation. Re-build with the switch &#34;-p:BuildInParallel=false&#34;." />
     <Exec Command="dotnet t4 -h &gt; NUL" IgnoreExitCode="True">
       <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
     </Exec>
     <Exec Command="dotnet tool restore" Condition="$(_TestExitCode) != 0" />
-    <Exec Command="dotnet t4 %(TextTemplate.Identity)" />
+    <Exec Command="dotnet t4 $(TextTemplate)" />
   </Target>
 
-  <Target Name="_TransformTextTemplate"
-          AfterTargets="BeforeBuild" DependsOnTargets="TransformTextTemplate" />
+  <Target Name="TransformTextTemplates"
+          DependsOnTargets="_CollectTextTemplates">
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_TransformTextTemplate"
+             Properties="TextTemplate=%(TextTemplate.Identity);TextTemplateOutput=%(TextTemplate.LastGenOutput)"  />
+  </Target>
+
+  <Target Name="_TransformTextTemplates"
+          AfterTargets="BeforeBuild" DependsOnTargets="TransformTextTemplates" />
 
 </Project>

--- a/MoreLinq/tt.cmd
+++ b/MoreLinq/tt.cmd
@@ -1,8 +1,0 @@
-@echo off
-pushd "%~dp0"
-for /f "tokens=*" %%f in ('dir /s /b *.tt') do (
-    echo>&2 dotnet t4 "%%f"
-    dotnet t4 "%%f" || goto :end
-)
-:end
-popd

--- a/MoreLinq/tt.sh
+++ b/MoreLinq/tt.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-cd "$(dirname "$0")"
-find . -name "*.tt" -print0 | xargs -0 -t -L 1 sh -c '(dotnet t4 "$0" || exit 255)'

--- a/build.cmd
+++ b/build.cmd
@@ -13,7 +13,6 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
-  && call MoreLinq\tt ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.cmd
+++ b/build.cmd
@@ -13,7 +13,7 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
-  && dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false ^
+  && dotnet build MoreLinq -t:TransformTextTemplates -p:BuildInParallel=false ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.cmd
+++ b/build.cmd
@@ -13,6 +13,7 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
+  && dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.cmd
+++ b/build.cmd
@@ -13,7 +13,7 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
-  && dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false
+  && dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,6 @@ codegen() {
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq
 codegen MoreLinq/Extensions.ToDataTable.g.cs -i "[/\\\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq
-MoreLinq/tt.sh
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ codegen() {
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq
 codegen MoreLinq/Extensions.ToDataTable.g.cs -i "[/\\\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq
+dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ codegen() {
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq
 codegen MoreLinq/Extensions.ToDataTable.g.cs -i "[/\\\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq
-dotnet build MoreLinq /t:TransformTextTemplate /p:BuildInParallel=false
+dotnet build MoreLinq -t:TransformTextTemplates -p:BuildInParallel=false
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else


### PR DESCRIPTION
This PR integrates `dotnet t4` invocation directly into `MoreLinq.csproj` for the following benefits:

- Works with `dotnet build`
- Shell scripts like `tt.*` are not needed anymore
- Uses incremental building built-into MSBuild; `dotnet t4` is not invoked unless one of the `*.g.tt` files is touched
