### PR TITLE
Disable parallel building due to T4 for simplicity

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -123,6 +123,9 @@
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Parallel build is disabled to avoid file locking issues during T4 code generation.
+         See also: https://github.com/dotnet/msbuild/issues/2781 -->
+    <BuildInParallel>false</BuildInParallel>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MoreLinq</AssemblyName>
@@ -263,10 +266,6 @@
   </Target>
 
   <Target Name="_TransformTextTemplate" Inputs="$(TextTemplate)" Outputs="$(TextTemplateOutput)">
-    <!-- Parallel build is unsupported here to avoid file locking issues.
-         See also: https://github.com/dotnet/msbuild/issues/2781 -->
-    <Error Condition="'$(BuildInParallel)' == 'true'"
-           Text="Parallel build is unsupported for T4 code generation. Re-build with the switch &#34;-p:BuildInParallel=false&#34;." />
     <Exec Command="dotnet t4 -h > /dev/null" IgnoreExitCode="True" Condition="'$(WINDIR)' == ''">
       <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
     </Exec>

--- a/build.cmd
+++ b/build.cmd
@@ -13,7 +13,6 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
-  && dotnet build MoreLinq -t:TransformTextTemplates -p:BuildInParallel=false ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,6 @@ codegen() {
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq
 codegen MoreLinq/Extensions.ToDataTable.g.cs -i "[/\\\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq
-dotnet build MoreLinq -t:TransformTextTemplates -p:BuildInParallel=false
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else


### PR DESCRIPTION
This is a follow-up PR from PR #776. It disables parallel builds for `MoreLinq.csproj` for overall simplicity with respect to observed corner cases. It does not seem to slow down building in a noticeable way, but goes a long way to simplify the T4 code generation integration into the project file by not requiring a separate and special mode of execution with `-p:BuildInParallel=false`.
