### PR TITLE
Add Step extension

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -5567,6 +5567,31 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>Step</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class StepExtension
+    {
+        /// <summary>
+        /// Iterates through a sequence based on another sequence of Boolean
+        /// values indicating when to step to the next element.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="steps">Sequence of Boolean values.</param>
+        /// <returns>
+        /// A sequence of elements from <paramref name="source"/> where
+        /// each element is duplicated while the Boolean from
+        /// <paramref name="steps"/> is <c>false</c>.
+        /// </returns>
+        /// <remarks>This operator uses deferred execution and streams its results.</remarks>
+
+        public static IEnumerable<(bool Moved, T Item)>
+            Step<T>(this IEnumerable<T> source, IEnumerable<bool> steps)
+            => MoreEnumerable.            Step(source, steps);
+
+    }
+
     /// <summary><c>Subsets</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]

--- a/MoreLinq/Step.cs
+++ b/MoreLinq/Step.cs
@@ -1,0 +1,69 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2021 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Iterates through a sequence based on another sequence of Boolean
+        /// values indicating when to step to the next element.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in <paramref name="source"/>.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="steps">Sequence of Boolean values.</param>
+        /// <returns>
+        /// A sequence of elements from <paramref name="source"/> where
+        /// each element is duplicated while the Boolean from
+        /// <paramref name="steps"/> is <c>false</c>.
+        /// </returns>
+        /// <remarks>This operator uses deferred execution and streams its results.</remarks>
+
+        public static IEnumerable<(bool Moved, T Item)>
+            Step<T>(this IEnumerable<T> source, IEnumerable<bool> steps)
+        {
+            if (source is null) throw new ArgumentNullException(nameof(source));
+            if (steps is null) throw new ArgumentNullException(nameof(steps));
+
+            return _(); IEnumerable<(bool, T)> _()
+            {
+                using var item = source.GetEnumerator();
+
+                if (!item.MoveNext())
+                    yield break;
+                yield return (true, item.Current);
+
+                foreach (var step in steps)
+                {
+                    if (step)
+                    {
+                        if (!item.MoveNext())
+                            break;
+                        yield return (true, item.Current);
+                    }
+                    else
+                    {
+                        yield return (false, item.Current);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an extensions that iterates or steps through a sequence based on moves (each element being a Boolean where `true` means move, `false` means stay). In other words, the a Boolean sequence drives when the iterator of the first sequence is moved. An example below shows how this could be used to generate a random walk through a sequence:

```c#
var randomWalk =
    MoreEnumerable.Unfold(new Random(), r => (Random: r, Step: r.Next(2) == 0), _ => true, s => s.Random, s => s.Step);
var result =
    from e in Enumerable.Range(1, 10).Step(randomWalk)
    select $"{(e.Moved ? "Moved" : "Still")}: {e.Item}";
foreach (var s in result)
    Console.WriteLine(s.ToString());
```

Sample output:

    Moved: 1
    Moved: 2
    Still: 2
    Moved: 3
    Moved: 4
    Moved: 5
    Still: 5
    Moved: 6
    Still: 6
    Moved: 7
    Still: 7
    Moved: 8
    Moved: 9
    Still: 9
    Moved: 10

