### PR TITLE
Use consistent line-folding in CI YAML shell sections

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,21 +69,15 @@ build_script:
     } else {
         $LASTEXITCODE = 0
     }
-- ps: >-
+- ps: |
     $id = $env:APPVEYOR_REPO_COMMIT_TIMESTAMP -replace '([-:]|\.0+Z)', ''
-
     $id = $id.Substring(0, 13)
-
     if ($isWindows) { cmd /c call pack.cmd ci-$id } else { ./pack.sh ci-$id }
-
     if ($LASTEXITCODE -ne 0) {
         throw "Building/Packing failed with an exit code of $LASTEXITCODE."
     }
-
     $diff = git diff --ignore-all-space --exit-code 2>&1
-
     $diff | % { if ($_ -is [string]) { $_ } else { [string]$_ } } | echo
-
     if ($LASTEXITCODE -ne 0) {
         throw "New code was generated during build that's not been committed."
     }


### PR DESCRIPTION
Various shell sections in `appveyor.yml` used different line-folding. This PR makes them all consistent.