### PR TITLE
Fix dictionary bug when null key has null value

### DIFF
--- a/MoreLinq.Test/ScanByTest.cs
+++ b/MoreLinq.Test/ScanByTest.cs
@@ -116,6 +116,21 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void ScanByWithNullSeed()
+        {
+            var nil = (object)null;
+            var source = new[] { "foo", null, "bar", null, "baz" };
+            var result = source.ScanBy(c => c, k => nil, (i, k, e) => nil);
+
+            result.AssertSequenceEqual(
+                KeyValuePair.Create("foo"       , nil),
+                KeyValuePair.Create((string)null, nil),
+                KeyValuePair.Create("bar"       , nil),
+                KeyValuePair.Create((string)null, nil),
+                KeyValuePair.Create("baz"       , nil));
+        }
+
+        [Test]
         public void ScanByDoesNotIterateUnnecessaryElements()
         {
             var source = MoreEnumerable.From(() => "ana",

--- a/MoreLinq/Collections/Dictionary.cs
+++ b/MoreLinq/Collections/Dictionary.cs
@@ -56,7 +56,7 @@ namespace MoreLinq.Collections
             {
                 switch (_null)
                 {
-                    case (true, {} v):
+                    case (true, var v):
                         value = v;
                         return true;
                     case (false, _):


### PR DESCRIPTION
This PR fixes a bug introduced by PR #582 in our dictionary implementation that accepts `null` keys. The bug can be observed via `ScanBy`:

```c#
var nil = (object)null;
var source = new[] { "foo", null, "bar", null, "baz" };
var result = source.ScanBy(c => c, k => nil, (i, k, e) => nil);
foreach (var item in result)
    Console.WriteLine(item);
```

It prints the following:

    [foo, ]
    [, ]
    [bar, ]

before throwing an `ArgumentNullException`:

    System.ArgumentNullException: Value cannot be null. (Parameter 'key')
       at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
       at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
       at MoreLinq.Collections.Dictionary`2.TryGetValue(TKey key, TValue& value) in C:\projects\morelinq\MoreLinq\Collections\Dictionary.cs:line 69
       at MoreLinq.MoreEnumerable.<>c__DisplayClass226_0`3.<<ScanBy>g___|0>d.MoveNext() in C:\projects\morelinq\MoreLinq\ScanBy.cs:line 100
