### PR TITLE
Fix "TrySingle" signature with honest nullable annotations

### DIFF
--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -51,7 +51,7 @@ namespace MoreLinq.Experimental
         /// than two elements from the sequence.
         /// </remarks>
 
-        public static (TCardinality Cardinality, T Value)
+        public static (TCardinality Cardinality, T? Value)
             TrySingle<T, TCardinality>(this IEnumerable<T> source,
                 TCardinality zero, TCardinality one, TCardinality many) =>
             TrySingle(source, zero, one, many, ValueTuple.Create);
@@ -96,11 +96,7 @@ namespace MoreLinq.Experimental
 
         public static TResult TrySingle<T, TCardinality, TResult>(this IEnumerable<T> source,
             TCardinality zero, TCardinality one, TCardinality many,
-            // TODO review second argument of resultSelector
-            // ...that can be defaulted to null for nullable references
-            // so the signature is not quite accurate, but can we do
-            // something about that?
-            Func<TCardinality, T, TResult> resultSelector)
+            Func<TCardinality, T?, TResult> resultSelector)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
@@ -108,7 +104,7 @@ namespace MoreLinq.Experimental
             switch (source.TryGetCollectionCount())
             {
                 case 0:
-                    return resultSelector(zero, default!);
+                    return resultSelector(zero, default);
                 case 1:
                 {
                     var item = source switch
@@ -120,15 +116,15 @@ namespace MoreLinq.Experimental
                     return resultSelector(one, item);
                 }
                 case {}:
-                    return resultSelector(many, default!);
+                    return resultSelector(many, default);
                 default:
                 {
                     using var e = source.GetEnumerator();
                     if (!e.MoveNext())
-                        return resultSelector(zero, default!);
+                        return resultSelector(zero, default);
                     var current = e.Current;
                     return !e.MoveNext() ? resultSelector(one, current)
-                                         : resultSelector(many, default!);
+                                         : resultSelector(many, default);
                 }
             }
         }


### PR DESCRIPTION
There was a to-do comment pending since PR #582 that questioned whether we could be more honest with the signatures of `TrySingle` regarding `T` being `null` when cardinality isn't one. Starting with C# 9, it looks like we can finally address this with [unconstrained type parameter annotations](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/unconstrained-type-parameter-annotations#-annotation):

> In C#8, `?` annotations could only be applied to type parameters that were explicitly constrained to value types or reference types. In C#9, `?` annotations can be applied to any type parameter, regardless of constraints.

This PR fixes the signatures to be more honest and removes the need for the use of the dammit (`!`) operator within the implementation body.

We still can't express that `T` isn't `null` when cardinality is one (e.g. through some of [the helper attributes for the compiler](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis)) but the new annotations are far better than what was there before.