### PR TITLE
Fix "Lag" & "Lead" signatures with more honest nullable annotations

### DIFF
--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
@@ -130,6 +132,31 @@ namespace MoreLinq.Test
             Assert.AreEqual(count, result.Count());
             Assert.IsTrue(result.Skip(2).All(x => x.B == (x.A - 2)));
             Assert.IsTrue(result.Take(2).All(x => (x.A - x.B) == x.A));
+        }
+
+        [Test]
+        public void TestLagWithNullableReferences()
+        {
+            var words = new[] { "foo", "bar", "baz", "qux" };
+            var result = words.Lag(2, (a, b) => new { A = a, B = b });
+            result.AssertSequenceEqual(
+                new { A = "foo", B = (string?)null  },
+                new { A = "bar", B = (string?)null  },
+                new { A = "baz", B = (string?)"foo" },
+                new { A = "qux", B = (string?)"bar" });
+        }
+
+        [Test]
+        public void TestLagWithNonNullableReferences()
+        {
+            var words = new[] { "foo", "bar", "baz", "qux" };
+            var empty = string.Empty;
+            var result = words.Lag(2, empty, (a, b) => new { A = a, B = b });
+            result.AssertSequenceEqual(
+                new { A = "foo", B = empty },
+                new { A = "bar", B = empty },
+                new { A = "baz", B = "foo" },
+                new { A = "qux", B = "bar" });
         }
     }
 }

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
@@ -132,6 +134,31 @@ namespace MoreLinq.Test
             Assert.AreEqual(count, result.Count());
             Assert.IsTrue(result.Take(count - 2).All(x => x.B == (x.A + 2)));
             Assert.IsTrue(result.Skip(count - 2).All(x => x.B == leadDefault && (x.A == count || x.A == count - 1)));
+        }
+
+        [Test]
+        public void TestLagWithNullableReferences()
+        {
+            var words = new[] { "foo", "bar", "baz", "qux" };
+            var result = words.Lead(2, (a, b) => new { A = a, B = b });
+            result.AssertSequenceEqual(
+                new { A = "foo", B = (string?)"baz" },
+                new { A = "bar", B = (string?)"qux" },
+                new { A = "baz", B = (string?)null  },
+                new { A = "qux", B = (string?)null  });
+        }
+
+        [Test]
+        public void TestLagWithNonNullableReferences()
+        {
+            var words = new[] { "foo", "bar", "baz", "qux" };
+            var empty = string.Empty;
+            var result = words.Lead(2, empty, (a, b) => new { A = a, B = b });
+            result.AssertSequenceEqual(
+                new { A = "foo", B = "baz" },
+                new { A = "bar", B = "qux" },
+                new { A = "baz", B = empty },
+                new { A = "qux", B = empty });
         }
     }
 }

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -3011,7 +3011,6 @@ namespace MoreLinq.Extensions
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
     public static partial class LagExtension
     {
-
         /// <summary>
         /// Produces a projection of a sequence by evaluating pairs of elements separated by a negative offset.
         /// </summary>

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -3011,6 +3011,7 @@ namespace MoreLinq.Extensions
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
     public static partial class LagExtension
     {
+
         /// <summary>
         /// Produces a projection of a sequence by evaluating pairs of elements separated by a negative offset.
         /// </summary>
@@ -3025,7 +3026,7 @@ namespace MoreLinq.Extensions
         /// <param name="resultSelector">A projection function which accepts the current and lagged items (in that order) and returns a result</param>
         /// <returns>A sequence produced by projecting each element of the sequence with its lagged pairing</returns>
 
-        public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
+        public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
             => MoreEnumerable.Lag(source, offset, resultSelector);
 
         /// <summary>
@@ -3114,7 +3115,7 @@ namespace MoreLinq.Extensions
         /// <param name="resultSelector">A projection function which accepts the current and subsequent (lead) element (in that order) and produces a result</param>
         /// <returns>A sequence produced by projecting each element of the sequence with its lead pairing</returns>
 
-        public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
+        public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
             => MoreEnumerable.Lead(source, offset, resultSelector);
 
         /// <summary>

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -19,6 +19,7 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     public static partial class MoreEnumerable
     {
@@ -36,9 +37,13 @@ namespace MoreLinq
         /// <param name="resultSelector">A projection function which accepts the current and lagged items (in that order) and returns a result</param>
         /// <returns>A sequence produced by projecting each element of the sequence with its lagged pairing</returns>
 
-        public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
+        public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
         {
-            return Lag(source, offset, default!, resultSelector);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (resultSelector is null) throw new ArgumentNullException(nameof(resultSelector));
+
+            return source.Select(Some)
+                         .Lag(offset, default, (curr, lag) => resultSelector(curr.Value, lag is (true, var some) ? some : default));
         }
 
         /// <summary>

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -19,6 +19,7 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     public static partial class MoreEnumerable
     {
@@ -37,9 +38,13 @@ namespace MoreLinq
         /// <param name="resultSelector">A projection function which accepts the current and subsequent (lead) element (in that order) and produces a result</param>
         /// <returns>A sequence produced by projecting each element of the sequence with its lead pairing</returns>
 
-        public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource, TResult> resultSelector)
+        public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
         {
-            return Lead(source, offset, default!, resultSelector);
+            if (source is null) throw new ArgumentNullException(nameof(source));
+            if (resultSelector is null) throw new ArgumentNullException(nameof(resultSelector));
+
+            return source.Select(Some)
+                         .Lead(offset, default, (curr, lead) => resultSelector(curr.Value, lead is (true, var some) ? some : default));
         }
 
         /// <summary>

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -53,5 +53,9 @@ namespace MoreLinq
 
             return count;
         }
+
+        // See https://github.com/atifaziz/Optuple
+
+        static (bool HasValue, T Value) Some<T>(T value) => (true, value);
     }
 }


### PR DESCRIPTION
This PR adds to #803. Where a `TSource` is defaulted for missing lead/lag value, the signature now clearly says `TSource?`.

Unfortunately, this requires a small projection hop (via `Select`) of an [_optuple_](https://github.com/atifaziz/Optuple).
