### PR TITLE
Fix "FullGroupJoin" signature with more honest nullable annotations

### DIFF
--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;
@@ -135,7 +137,7 @@ namespace MoreLinq.Test
             switch (overloadCase)
             {
                 case CustomResult:
-                    return listA.FullGroupJoin(listB, getKey, getKey, ValueTuple.Create);
+                    return listA.FullGroupJoin(listB, getKey, getKey, ValueTuple.Create, comparer: null);
                 case TupleResult:
                     return listA.FullGroupJoin(listB, getKey, getKey);
                 default:

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -2391,7 +2391,7 @@ namespace MoreLinq.Extensions
             IEnumerable<TSecond> second,
             Func<TFirst, TKey> firstKeySelector,
             Func<TSecond, TKey> secondKeySelector,
-            IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey>? comparer)
             => MoreEnumerable.FullGroupJoin(first, second, firstKeySelector, secondKeySelector, comparer);
 
         /// <summary>
@@ -2450,7 +2450,7 @@ namespace MoreLinq.Extensions
             Func<TFirst, TKey> firstKeySelector,
             Func<TSecond, TKey> secondKeySelector,
             Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
-            IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey>? comparer)
             => MoreEnumerable.FullGroupJoin(first, second, firstKeySelector, secondKeySelector, resultSelector, comparer);
 
     }

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -76,7 +76,7 @@ namespace MoreLinq
             IEnumerable<TSecond> second,
             Func<TFirst, TKey> firstKeySelector,
             Func<TSecond, TKey> secondKeySelector,
-            IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey>? comparer)
         {
             return FullGroupJoin(first, second, firstKeySelector, secondKeySelector, ValueTuple.Create, comparer);
         }
@@ -139,7 +139,7 @@ namespace MoreLinq
             Func<TFirst, TKey> firstKeySelector,
             Func<TSecond, TKey> secondKeySelector,
             Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
-            IEqualityComparer<TKey> comparer)
+            IEqualityComparer<TKey>? comparer)
         {
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
@@ -151,7 +151,7 @@ namespace MoreLinq
 
             IEnumerable<TResult> _(IEqualityComparer<TKey> comparer)
             {
-                var alookup = Lookup<TKey,TFirst>.CreateForJoin(first, firstKeySelector, comparer);
+                var alookup = Lookup<TKey, TFirst>.CreateForJoin(first, firstKeySelector, comparer);
                 var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);
 
                 foreach (var a in alookup)

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -151,7 +151,7 @@ namespace MoreLinq
 
             IEnumerable<TResult> _(IEqualityComparer<TKey> comparer)
             {
-                var alookup = Lookup<TKey, TFirst>.CreateForJoin(first, firstKeySelector, comparer);
+                var alookup = Lookup<TKey,TFirst>.CreateForJoin(first, firstKeySelector, comparer);
                 var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);
 
                 foreach (var a in alookup)


### PR DESCRIPTION
Adding to morelinq#803. This PR fixes nullable annotations for comparers that are allowed to be null as per the documentation comments.