### PR TITLE
Fix "ReverseComparer" signature with more honest nullable annotations

### DIFF
--- a/MoreLinq/ReverseComparer.cs
+++ b/MoreLinq/ReverseComparer.cs
@@ -23,7 +23,7 @@ namespace MoreLinq
     {
         readonly IComparer<T> _underlying;
 
-        public ReverseComparer(IComparer<T> underlying)
+        public ReverseComparer(IComparer<T>? underlying)
         {
             _underlying = underlying ?? Comparer<T>.Default;
         }


### PR DESCRIPTION
This PR fixes the nullable annotation for the underlying comparer supplied to the `ReverseComparer` constructor. This class is not part of the public API, but the PR is part of the overall effort of correcting nullable annotations.