### PR TITLE
Cleanup ! operator usage in FallbackIfEmpty

### DIFF
--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -46,7 +46,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 1, fallback, default!, default!, default!, null);
+            return FallbackIfEmptyImpl(source, 1, fallback, default, default, default, null);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 2, fallback1, fallback2, default!, default!, null);
+            return FallbackIfEmptyImpl(source, 2, fallback1, fallback2, default, default, null);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace MoreLinq
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2, T fallback3)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            return FallbackIfEmptyImpl(source, 3, fallback1, fallback2, fallback3, default!, null);
+            return FallbackIfEmptyImpl(source, 3, fallback1, fallback2, fallback3, default, null);
         }
 
         /// <summary>
@@ -155,11 +155,11 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
-            return FallbackIfEmptyImpl(source, null, default!, default!, default!, default!, fallback);
+            return FallbackIfEmptyImpl(source, null, default, default, default, default, fallback);
         }
 
         static IEnumerable<T> FallbackIfEmptyImpl<T>(IEnumerable<T> source,
-            int? count, T fallback1, T fallback2, T fallback3, T fallback4,
+            int? count, T? fallback1, T? fallback2, T? fallback3, T? fallback4,
             IEnumerable<T>? fallback)
         {
             return source.TryGetCollectionCount() is {} collectionCount
@@ -190,10 +190,10 @@ namespace MoreLinq
                 {
                     Debug.Assert(count >= 1 && count <= 4);
 
-                    yield return fallback1;
-                    if (count > 1) yield return fallback2;
-                    if (count > 2) yield return fallback3;
-                    if (count > 3) yield return fallback4;
+                    yield return fallback1!;
+                    if (count > 1) yield return fallback2!;
+                    if (count > 2) yield return fallback3!;
+                    if (count > 3) yield return fallback4!;
                 }
             }
         }


### PR DESCRIPTION
As part of reviewing nullable reference annotations (#803), this PR attempts to simplify usage of the `!` operator in the internals of `FallbackIfEmpty.cs`. No public APIs are affected.

The following line from the code prior to this PR will cause a compiler warning CS8619 (nullability of reference types in source type doesn't match target type):

```cs
return FallbackIfEmptyImpl(source, 1, fallback, default!, default!, default!, null);
```

Because potential null values are passed to `FallbackIfEmptyImpl`, the return value will be `IEnumerable<T?>`.

One solution would be to use another `!` at the end of the method call. However, the overuse of `!` doesn't feel very clean. Also, the signature of `FallbackIfEmptyImpl` doesn't seem to signal intent as clearly as making the fallback values nullable. This PR also brings some consistency, since the `fallback` collection is already nullable.

Now that the fallback values are nullable, we can remove the `!` from each of the defaults passed to `FallbackIfEmptyImpl`, but we need to use the `!` operator on the fallback values when returning them. This seems a reasonable tradeoff to clean up this file, and should be safe considering the private accessibility of the method.
