### PR TITLE
Add test to ensure Batch does not reuse internal array

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -80,6 +80,22 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void BatchSequencesAreIndependentInstances()
+        {
+            var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(4);
+
+            using var reader = result.Read();
+            var first = reader.Read();
+            var second = reader.Read();
+            var third = reader.Read();
+            reader.ReadEnd();
+
+            first.AssertSequenceEqual(1, 2, 3, 4);
+            second.AssertSequenceEqual(5, 6, 7, 8);
+            third.AssertSequenceEqual(9);
+        }
+
+        [Test]
         public void BatchIsLazy()
         {
             new BreakingSequence<object>().Batch(1);

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -125,7 +125,7 @@ namespace MoreLinq
 
                 IEnumerable<TResult> Batch(int size)
                 {
-                    TSource[]? bucket = null;
+                    TSource[]? bucket = new TSource[size];
                     var count = 0;
 
                     foreach (var item in source)
@@ -139,7 +139,6 @@ namespace MoreLinq
 
                         yield return resultSelector(bucket);
 
-                        bucket = null;
                         count = 0;
                     }
 

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -125,7 +125,7 @@ namespace MoreLinq
 
                 IEnumerable<TResult> Batch(int size)
                 {
-                    TSource[]? bucket = new TSource[size];
+                    TSource[]? bucket = null;
                     var count = 0;
 
                     foreach (var item in source)
@@ -139,6 +139,7 @@ namespace MoreLinq
 
                         yield return resultSelector(bucket);
 
+                        bucket = null;
                         count = 0;
                     }
 


### PR DESCRIPTION
add test to ensure that if someone try to reuse the internal array in batch (break change) the unit test will not pass