### PR TITLE
add new batch overload (bucket factory)

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -64,15 +64,14 @@ namespace MoreLinq.Test
         [Test]
         public void BatchFactoryUnevenlyDivisibleSequence()
         {
-            int size = 4;
-            int requested = 0;
+            int lastSize = 0;
             int[] temp = null;
 
-            var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(size,
-            x => x.Take(requested),
-            i =>
+            var result = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 }.Batch(4,
+            x => x.Take(lastSize),
+            size =>
             {
-                requested = i;
+                lastSize = size;
 
                 return temp ??= new int[size];
             });

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -710,6 +710,36 @@ namespace MoreLinq.Extensions
             Func<IEnumerable<TSource>, TResult> resultSelector)
             => MoreEnumerable.Batch(source, size, resultSelector);
 
+        /// <summary>
+        /// Batches the source sequence into sized buckets and applies a projection to each bucket.
+        /// </summary>
+        /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+        /// <typeparam name="TResult">Type of result returned by <paramref name="resultSelector"/>.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="size">Size of buckets.</param>
+        /// <param name="resultSelector">The projection to apply to each bucket.</param>
+        /// <param name="bucketFactory">A function that receive the requested size for the next bucket and return the array where elements will be placed.</param>
+        /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
+        /// <para>
+        /// This operator uses deferred execution and streams its results
+        /// (buckets are streamed but their content buffered).</para>
+        /// <para>
+        /// <para>
+        /// When more than one bucket is streamed, all buckets except the last
+        /// is guaranteed to have <paramref name="size"/> elements. The last
+        /// bucket may be smaller depending on the remaining elements in the
+        /// <paramref name="source"/> sequence.</para>
+        /// Each bucket is pre-allocated to <paramref name="size"/> elements.
+        /// If <paramref name="size"/> is set to a very large value, e.g.
+        /// <see cref="int.MaxValue"/> to effectively disable batching by just
+        /// hoping for a single bucket, then it can lead to memory exhaustion
+        /// (<see cref="OutOfMemoryException"/>).
+        /// </para>
+
+        public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
+            Func<IEnumerable<TSource>, TResult> resultSelector, Func<int, TSource[]> bucketFactory)
+            => MoreEnumerable.Batch(source, size, resultSelector, bucketFactory);
+
     }
 
     /// <summary><c>Cartesian</c> extension.</summary>


### PR DESCRIPTION
It is useful to have an overload where user can pass the bucket factory. Pratical example:
- user can customize to get arrays from ArrayPool
- user can customize to reuse the array when consume each bucket once, always foward

In both cases are desirable to have the option to custome Batch behaviour, expecially when dealing with large arrays (e.g. +100k elements) where allocate a new array for every new batch is expensive.

Once added this new overload, users are able to create their customizated `Batch` version in their own applications, like the bellow for example.

```c#
public IEnumerable<IEnumerable<T>> BatchFoward<T>(this IEnumerable<T> source, int size)
{
    int lastSize = 0;
    T[] temp = null;

    try
    {
        var result = source.Batch(size, x => x.Take(lastSize), count =>
        {
            lastSize = count;

            return temp ??= ArrayPool<T>.Shared.Rent(count);
        });

        foreach (var batch in result)
            yield return batch;
    }
    finally
    {
        if (temp is { })
            ArrayPool<T>.Shared.Return(temp);
    }
}
```