### PR TITLE
Drop .NET 5 + Core 2.1 targets that have reached end-of-life

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net451</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net451</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' And '$(TargetFramework)' != 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <Compile Include="Async\*.cs" />
   </ItemGroup>

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net451</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh
-- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage.net5.0.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
+- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage.netcoreapp3.1.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
 - ps: |
     cd tmp/cover
     tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,10 +54,8 @@ install:
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 3.1.10 -SkipNonVersionedFiles }
-- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 2.1.23 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 3.1.10 --skip-non-versioned-files
-- sh: ./tools/dotnet-install.sh --runtime dotnet --version 2.1.23 --skip-non-versioned-files
 - sh: export PATH="~/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/test.cmd
+++ b/test.cmd
@@ -7,8 +7,6 @@ goto :EOF
 :main
 setlocal
 call build ^
-  && call :test net5.0 Debug ^
-  && call :test net5.0 Debug ^
   && call :test netcoreapp3.1 Debug ^
   && call :test netcoreapp3.1 Release ^
   && call :test net451 Debug ^

--- a/test.cmd
+++ b/test.cmd
@@ -9,8 +9,6 @@ setlocal
 call build ^
   && call :test net5.0 Debug ^
   && call :test net5.0 Debug ^
-  && call :test netcoreapp2.1 Debug ^
-  && call :test netcoreapp2.1 Release ^
   && call :test netcoreapp3.1 Debug ^
   && call :test netcoreapp3.1 Release ^
   && call :test net451 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in netcoreapp2.1 netcoreapp3.1 net5.0; do
+for f in netcoreapp3.1 net5.0; do
     for c in $configs; do
         if [[ "$c" == "Debug" ]]; then
             coverage_args="-p:CollectCoverage=true

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in netcoreapp3.1 net5.0; do
+for f in netcoreapp3.1; do
     for c in $configs; do
         if [[ "$c" == "Debug" ]]; then
             coverage_args="-p:CollectCoverage=true


### PR DESCRIPTION
- End-of-life for [.NET Core 2.1](https://dotnet.microsoft.com/en-us/download/dotnet/2.1) was August 21, 2021.
- End-of-life for [.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet/2.1) was May 10, 2022.