### PR TITLE
Add .NET 6 target while dropping .NET 5 & Core 2.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-t4": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "commands": [
         "t4"
       ]

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net451</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net451</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -33,15 +33,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.0" />
-    <PackageReference Include="NUnitLite" Version="3.13.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnitLite" Version="3.13.3" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1' And '$(TargetFramework)' != 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <Compile Include="Async\*.cs" />
   </ItemGroup>

--- a/MoreLinq.sln
+++ b/MoreLinq.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29102.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{835F8FFA-471F-4322-B721-A897F27872FA}"
 	ProjectSection(SolutionItems) = preProject

--- a/MoreLinq/Aggregate.g.tt
+++ b/MoreLinq/Aggregate.g.tt
@@ -1,7 +1,6 @@
 <#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".cs" #>
 <#@ assembly name="System.Core" #>
-<#@ assembly name="System.Collections" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.Linq" #>
 #region License and Terms

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -1,7 +1,6 @@
 <#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".cs" #>
 <#@ assembly name="System.Core" #>
-<#@ assembly name="System.Collections" #>
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.Linq" #>
 #region License and Terms

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 image:
-- Visual Studio 2019
+- Visual Studio 2022
 - Ubuntu1604
 - macos
 environment:
@@ -10,7 +10,7 @@ for:
 -
   matrix:
     only:
-      - image: Visual Studio 2019
+      - image: Visual Studio 2022
   environment:
     IMAGE_NAME: win
   deploy:
@@ -54,10 +54,8 @@ install:
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 3.1.10 -SkipNonVersionedFiles }
-- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 2.1.23 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 3.1.10 --skip-non-versioned-files
-- sh: ./tools/dotnet-install.sh --runtime dotnet --version 2.1.23 --skip-non-versioned-files
 - sh: export PATH="~/.dotnet:$PATH"
 before_build:
 - dotnet --info
@@ -84,13 +82,13 @@ build_script:
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh
-- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage.net5.0.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
+- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage.net6.0.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
 - ps: |
     cd tmp/cover
     tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *
 - sh: curl -sSL https://codecov.io/bash > codecov
 - sh: chmod +x codecov
-- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov -f ./MoreLinq.Test/coverage.net5.0.opencover.xml; fi
+- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov -f ./MoreLinq.Test/coverage.net6.0.opencover.xml; fi
 artifacts:
 - path: dist\*.nupkg
 - path: coverage-report-*

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/build.cmd
+++ b/build.cmd
@@ -27,7 +27,7 @@ exit /b 2
 
 :codegen
 echo | set /p=Generating extensions wrappers (%1)...
-dotnet run -p bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- %2 %3 %4 %5 %6 %7 %8 %9 > "%temp%\%~nx1" ^
+dotnet run --project bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- %2 %3 %4 %5 %6 %7 %8 %9 > "%temp%\%~nx1" ^
   && move "%temp%\%~nx1" "%~dp1" > nul ^
   && echo Done.
 goto :EOF

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ codegen() {
     dest="$1"
     printf "Generating extensions wrappers (%s)..." "$1"
     shift
-    dotnet run -p bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- "$@" > "$dest"
+    dotnet run --project bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- "$@" > "$dest"
     printf "Done.\n"
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.402",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.402",
+    "version": "6.0.400",
     "rollForward": "latestFeature"
   }
 }

--- a/test.cmd
+++ b/test.cmd
@@ -7,10 +7,8 @@ goto :EOF
 :main
 setlocal
 call build ^
-  && call :test net5.0 Debug ^
-  && call :test net5.0 Debug ^
-  && call :test netcoreapp2.1 Debug ^
-  && call :test netcoreapp2.1 Release ^
+  && call :test net6.0 Debug ^
+  && call :test net6.0 Release ^
   && call :test netcoreapp3.1 Debug ^
   && call :test netcoreapp3.1 Release ^
   && call :test net451 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in netcoreapp2.1 netcoreapp3.1 net5.0; do
+for f in netcoreapp3.1 net6.0; do
     for c in $configs; do
         if [[ "$c" == "Debug" ]]; then
             coverage_args="-p:CollectCoverage=true


### PR DESCRIPTION
This PR adds the .NET 6 as a target while dropping retired .NET (Core) versions:

- .NET Core 2.1 end-of-life was August 21, 2021
- .NET 5.0 end-of-life was May 10, 2022
