### PR TITLE
Fix code coverage with new collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.opencover.xml
+**/TestResults/
 
 ### VisualStudio ###
 ## Ignore Visual Studio temporary files, build results, and

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -47,9 +47,10 @@
   </ItemGroup>
 
   <ItemGroup>
+      <None Remove="TestResult.xml" />
+      <None Remove="TestResults\**" />
       <Compile Include="*Test.cs" />
       <Compile Include="Test*.cs" />
-      <None Remove="TestResult.xml" />
       <Compile Include="..\MoreLinq\Disposable.cs" Link="Disposable.cs" />
       <Compile Include="..\MoreLinq\Reactive\Subject.cs" Link="Subject.cs" />
       <Compile Include="AssertThrowsArgument.cs" />

--- a/MoreLinq.Test/coverlet.runsettings
+++ b/MoreLinq.Test/coverlet.runsettings
@@ -1,0 +1,12 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <Exclude>[NUnit*]*,[MoreLinq]MoreLinq.Extensions.*,[MoreLinq]MoreLinq.Experimental.*</Exclude>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ test_script:
 - ps: dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
 - ps: |
     cd tmp/cover
-    tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *
+    tar -cz -f "../../coverage-report-${env:IMAGE_NAME}.tar.gz" *
 - sh: curl -sSL https://codecov.io/bash > codecov
 - sh: chmod +x codecov
 - sh: if [ "$CI_LINUX" = "true" ]; then ./codecov; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh
-- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage-*.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
+- ps: dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
 - ps: |
     cd tmp/cover
     tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ test_script:
     tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *
 - sh: curl -sSL https://codecov.io/bash > codecov
 - sh: chmod +x codecov
-- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov -d ./MoreLinq.Test/TestResults; fi
+- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov; fi
 artifacts:
 - path: dist\*.nupkg
 - path: coverage-report-*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,13 +82,13 @@ build_script:
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh
-- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage.net6.0.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
+- ps: dotnet reportgenerator -reports:MoreLinq.Test/coverage-*.opencover.xml -targetdir:tmp/cover -tag:(git show -q --pretty=%H)
 - ps: |
     cd tmp/cover
     tar -cz -f "../../coverage-report-${IMAGE_NAME}.tar.gz" *
 - sh: curl -sSL https://codecov.io/bash > codecov
 - sh: chmod +x codecov
-- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov -f ./MoreLinq.Test/coverage.net6.0.opencover.xml; fi
+- sh: if [ "$CI_LINUX" = "true" ]; then ./codecov -d ./MoreLinq.Test/TestResults; fi
 artifacts:
 - path: dist\*.nupkg
 - path: coverage-report-*

--- a/test.cmd
+++ b/test.cmd
@@ -7,23 +7,47 @@ goto :EOF
 :main
 setlocal
 call build ^
+  && call :clean ^
   && call :test net6.0 Debug ^
   && call :test net6.0 Release ^
   && call :test netcoreapp3.1 Debug ^
   && call :test netcoreapp3.1 Release ^
   && call :test net451 Debug ^
-  && call :test net451 Release
+  && call :test net451 Release ^
+  && call :report-cover
+goto :EOF
+
+:clean
+setlocal
+cd MoreLinq.Test
+if exist TestResults rd /s /q TestResults || exit /b 1
+if exist TestResult.xml del TestResult.xml || exit /b 1
 goto :EOF
 
 :test
 setlocal
+cd MoreLinq.Test
 echo Testing %1 (%2)...
-if %2==Debug set COVERAGE_ARGS=-p:CollectCoverage=true ^
-                               -p:CoverletOutputFormat=opencover ^
-                               -p:Exclude=\"[NUnit*]*,[MoreLinq]MoreLinq.Extensions.*,[MoreLinq]MoreLinq.Experimental.*\"
 if %1==net451 (
-    MoreLinq.Test\bin\%2\net451\MoreLinq.Test.exe
-) else (
-    dotnet test --no-build MoreLinq.Test -f %1 -c %2 %COVERAGE_ARGS%
+    bin\%2\net451\MoreLinq.Test.exe
+    exit /b %ERRORLEVEL%
 )
+dotnet test --no-build -f %1 -c %2 --settings coverlet.runsettings || exit /b 1
+cd TestResults
+set TEST_RESULTS_DIR=
+for /f %%d in ('dir /b /od /ad') do if not defined TEST_RESULTS_DIR set TEST_RESULTS_DIR=%%~d
+if not defined TEST_RESULTS_DIR (
+    echo>&2 Test coverage XML not found!
+    exit /b 1
+)
+copy "%TEST_RESULTS_DIR%\coverage.opencover.xml" coverage-%1-%2.opencover.xml > nul
+goto :EOF
+
+:report-cover
+setlocal
+cd MoreLinq.Test\TestResults
+dotnet reportgenerator -reports:coverage-*.opencover.xml ^
+                       -reporttypes:Html;TextSummary ^
+                       -targetdir:reports ^
+  && type reports\Summary.txt
 goto :EOF

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,9 @@
 set -e
 cd "$(dirname "$0")"
 ./build.sh $c
+if [[ -d "MoreLinq.Test/TestResults" ]]; then
+    rm -rf MoreLinq.Test/TestResults
+fi
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else
@@ -9,16 +12,15 @@ else
 fi
 for f in netcoreapp3.1 net6.0; do
     for c in $configs; do
-        if [[ "$c" == "Debug" ]]; then
-            coverage_args="-p:CollectCoverage=true
-                           -p:CoverletOutputFormat=opencover
-                           -p:Exclude=\"[NUnit*]*,[MoreLinq]MoreLinq.Extensions.*,[MoreLinq]MoreLinq.Experimental.*\""
-        else
-            unset coverage_args
-        fi
-        dotnet test --no-build -c $c -f $f MoreLinq.Test $coverage_args
+        dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
+        TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"
+        cp "$TEST_RESULTS_DIR/coverage.opencover.xml" "MoreLinq.Test/TestResults/coverage-$f-$c.opencover.xml"
     done
 done
+dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.xml \
+                       -reporttypes:Html\;TextSummary \
+                       -targetdir:MoreLinq.Test/TestResults/reports
+cat MoreLinq.Test/TestResults/reports/Summary.txt
 if [[ -z `which mono 2>/dev/null` ]]; then
     echo>&2 NOTE! Mono does not appear to be installed so unit tests
     echo>&2 against the Mono runtime will be skipped.


### PR DESCRIPTION
This PR fixes code coverage by migrating from **coverlet.msbuild** to the new **coverlet.collector**.