### PR TITLE
Removed unnecessary `null` check in `Batch` method

### DIFF
--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -144,7 +144,7 @@ namespace MoreLinq
                     }
 
                     // Return the last bucket with all remaining elements
-                    if (bucket != null && count > 0)
+                    if (count > 0)
                     {
                         Array.Resize(ref bucket, count);
                         yield return resultSelector(bucket);


### PR DESCRIPTION
If count is more than 0, then bucket is not null. If count is zero, then bucket is null. So check for null condition is not necessary here