### PR TITLE
Fix `Flatten` signature parts to be null-oblivious

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1926,7 +1926,13 @@ namespace MoreLinq.Extensions
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source)             => MoreEnumerable.Flatten(source);
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source)             => MoreEnumerable.            Flatten(source);
 
         /// <summary>
         /// Flattens a sequence containing arbitrarily-nested sequences. An
@@ -1950,8 +1956,14 @@ namespace MoreLinq.Extensions
         /// <exception cref="ArgumentNullException">
         /// <paramref name="predicate"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
-            => MoreEnumerable.Flatten(source, predicate);
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
+            => MoreEnumerable.            Flatten(source, predicate);
 
         /// <summary>
         /// Flattens a sequence containing arbitrarily-nested sequences. An
@@ -1975,8 +1987,20 @@ namespace MoreLinq.Extensions
         /// <exception cref="ArgumentNullException">
         /// <paramref name="selector"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source, Func<object, IEnumerable?> selector)
-            => MoreEnumerable.Flatten(source, selector);
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source,
+                    Func<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*....................*/ object,
+#nullable restore
+/*....................*/ IEnumerable?> selector)
+            => MoreEnumerable.            Flatten(source, selector);
 
     }
 

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -34,7 +34,13 @@ namespace MoreLinq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source) =>
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source) =>
             Flatten(source, obj => !(obj is string));
 
         /// <summary>
@@ -59,7 +65,13 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException">
         /// <paramref name="predicate"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
@@ -88,12 +100,31 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException">
         /// <paramref name="selector"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<object> Flatten(this IEnumerable source, Func<object, IEnumerable?> selector)
+        public static IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*.............................*/ object
+#nullable restore
+/*...................................*/ >
+            Flatten(this IEnumerable source,
+                    Func<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*....................*/ object,
+#nullable restore
+/*....................*/ IEnumerable?> selector)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (selector == null) throw new ArgumentNullException(nameof(selector));
 
-            return _(); IEnumerable<object> _()
+            return _();
+
+            IEnumerable<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*...................*/ object
+#nullable restore
+/*.........................*/ > _()
             {
                 var e = source.GetEnumerator();
                 var stack = new Stack<IEnumerator>();


### PR DESCRIPTION
This PR adds to #803. If fixes _parts_ of `Flatten` to be _null-oblivious_. Since [`IEnumerator.Current`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.ienumerator.current) is [null-oblivious](https://github.com/dotnet/runtime/blob/5a400c212afdf8e675c9a1d38442e6d2f19f7b74/src/libraries/System.Private.CoreLib/src/System/Collections/IEnumerator.cs#L25-L27), the right call here seems to be to mark the `object` parameter of `IEnumerable<>` and `Func<,>` to be null-oblivious too (rather than `object?`).
