### PR TITLE
Add missing remarks tags on `Batch` overload

### DIFF
--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -62,6 +62,7 @@ namespace MoreLinq
         /// <param name="size">Size of buckets.</param>
         /// <param name="resultSelector">The projection to apply to each bucket.</param>
         /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
+        /// <remarks>
         /// <para>
         /// This operator uses deferred execution and streams its results
         /// (buckets are streamed but their content buffered).</para>
@@ -77,6 +78,7 @@ namespace MoreLinq
         /// hoping for a single bucket, then it can lead to memory exhaustion
         /// (<see cref="OutOfMemoryException"/>).
         /// </para>
+        /// </remarks>
 
         public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
             Func<IEnumerable<TSource>, TResult> resultSelector)

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -690,6 +690,7 @@ namespace MoreLinq.Extensions
         /// <param name="size">Size of buckets.</param>
         /// <param name="resultSelector">The projection to apply to each bucket.</param>
         /// <returns>A sequence of projections on equally sized buckets containing elements of the source collection.</returns>
+        /// <remarks>
         /// <para>
         /// This operator uses deferred execution and streams its results
         /// (buckets are streamed but their content buffered).</para>
@@ -705,6 +706,7 @@ namespace MoreLinq.Extensions
         /// hoping for a single bucket, then it can lead to memory exhaustion
         /// (<see cref="OutOfMemoryException"/>).
         /// </para>
+        /// </remarks>
 
         public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
             Func<IEnumerable<TSource>, TResult> resultSelector)


### PR DESCRIPTION
One of the `Batch` overloads was missing the `<remarks>` tags in the doc comments. This PR adds them.