### PR TITLE
Constrain key type param in `ToDictionary` to `notnull`

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -6364,7 +6364,8 @@ namespace MoreLinq.Extensions
         /// mapped to their keys.
         /// </returns>
 
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source)             => MoreEnumerable.ToDictionary(source);
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source)
+            where TKey : notnull             => MoreEnumerable.ToDictionary(source);
         /// <summary>
         /// Creates a <see cref="Dictionary{TKey,TValue}" /> from a sequence of
         /// <see cref="KeyValuePair{TKey,TValue}" /> elements.
@@ -6377,7 +6378,8 @@ namespace MoreLinq.Extensions
         /// mapped to their keys.
         /// </returns>
 
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)             => MoreEnumerable.ToDictionary(source);
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
+            where TKey : notnull             => MoreEnumerable.ToDictionary(source);
 
         /// <summary>
         /// Creates a <see cref="Dictionary{TKey,TValue}" /> from a sequence of
@@ -6395,6 +6397,7 @@ namespace MoreLinq.Extensions
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source,
             IEqualityComparer<TKey>? comparer)
+            where TKey : notnull
             => MoreEnumerable.ToDictionary(source, comparer);
 
         /// <summary>
@@ -6413,6 +6416,7 @@ namespace MoreLinq.Extensions
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
             IEqualityComparer<TKey>? comparer)
+            where TKey : notnull
             => MoreEnumerable.ToDictionary(source, comparer);
 
     }

--- a/MoreLinq/ToDictionary.cs
+++ b/MoreLinq/ToDictionary.cs
@@ -35,7 +35,8 @@ namespace MoreLinq
         /// mapped to their keys.
         /// </returns>
 
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source) =>
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
+            where TKey : notnull =>
             source.ToDictionary(null);
 
         /// <summary>
@@ -54,6 +55,7 @@ namespace MoreLinq
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
             IEqualityComparer<TKey>? comparer)
+            where TKey : notnull
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);
@@ -72,7 +74,8 @@ namespace MoreLinq
         /// mapped to their keys.
         /// </returns>
 
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source) =>
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source)
+            where TKey : notnull =>
             source.ToDictionary(null);
 
         /// <summary>
@@ -91,6 +94,7 @@ namespace MoreLinq
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source,
             IEqualityComparer<TKey>? comparer)
+            where TKey : notnull
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);


### PR DESCRIPTION
This PR adds to issue #803, but constraining the `TKey` type parameter of `ToDictionary` overloads to `notnull`.