### PR TITLE
Make `ToDataTable` implementation null-safer

### DIFF
--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -169,9 +169,8 @@ namespace MoreLinq
 
                 // Check if the member expression is valid and is a "first level"
                 // member access e.g. not a.b.c
-                return body is MemberExpression memberExpression
-                       && memberExpression.Expression.NodeType == ExpressionType.Parameter
-                     ? memberExpression.Member
+                return body is MemberExpression { Expression.NodeType: ExpressionType.Parameter, Member: var member }
+                     ? member
                      : throw new ArgumentException($"Illegal expression: {lambda}", nameof(lambda));
             }
         }


### PR DESCRIPTION
[`Expression` property of `System.Linq.Expressions.MemberExpression`]( https://learn.microsoft.com/en-us/dotnet/api/system.linq.expressions.memberexpression.expression?view=net-6.0#system-linq-expressions-memberexpression-expression) is defined to be nullable. This PR ensures that the property is always access in a null-safe manner; in other words only when it's not `null`.
