### PR TITLE
Remove look-up optimizations in `CountBy`/`ScanBy`

### DIFF
--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -82,19 +82,12 @@ namespace MoreLinq
 
                     keys = new List<TKey>();
                     counts = new List<int>();
-                    (bool, TKey) prevKey = default;
-                    var index = 0;
 
                     foreach (var item in source)
                     {
                         var key = keySelector(item);
 
-                        if (// key same as the previous? then re-use the index
-                            prevKey is (true, {} pk)
-                                && cmp.GetHashCode(pk) == cmp.GetHashCode(key)
-                                && cmp.Equals(pk, key)
-                            // otherwise try & find index of the key
-                            || dic.TryGetValue(key, out index))
+                        if (dic.TryGetValue(key, out var index))
                         {
                             counts[index]++;
                         }
@@ -105,8 +98,6 @@ namespace MoreLinq
                             keys.Add(key);
                             counts.Add(1);
                         }
-
-                        prevKey = (true, key);
                     }
                 }
             }

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -91,27 +91,13 @@ namespace MoreLinq
             {
                 var stateByKey = new Collections.Dictionary<TKey, TState>(comparer);
 
-                (bool, TKey, TState) prev = default;
-
                 foreach (var item in source)
                 {
                     var key = keySelector(item);
-
-                    var state = // key same as the previous? then re-use the state
-                                prev is (true, {} pk, {} ps)
-                                && comparer.GetHashCode(pk) == comparer.GetHashCode(key)
-                                && comparer.Equals(pk, key) ? ps
-                              : // otherwise try & find state of the key
-                                stateByKey.TryGetValue(key, out var ns) ? ns
-                              : seedSelector(key);
-
+                    var state = stateByKey.TryGetValue(key, out var s) ? s : seedSelector(key);
                     state = accumulator(state, key, item);
-
                     stateByKey[key] = state;
-
                     yield return new KeyValuePair<TKey, TState>(key, state);
-
-                    prev = (true, key, state);
                 }
             }
         }


### PR DESCRIPTION
`CountBy` and `ScanBy` have a [look-up optimisation](https://github.com/morelinq/MoreLINQ/pull/207#issuecomment-258132466) (premature in hindsight?) that don't seem to be better/faster than a simpler version without any look-up optimisation, as demonstrated by the [benchmarks for `CountBy`](https://github.com/morelinq/MoreLINQ/files/9873267/benchmark.zip) below. In all instances, the unoptimised versions are faster for ordered _and_ unordered sequence inputs. This PR therefore removes the optimisations.

|                            Method |            Runtime |      Mean |    Error |    StdDev |    Gen0 |   Gen1 | Allocated |
|---------------------------------- |------------------- |----------:|---------:|----------:|--------:|-------:|----------:|
|               `CountBySortedNums` |           .NET 6.0 | 128.32 us | 2.452 us |  2.293 us | 21.4844 | 3.4180 |  88.04 KB |
|             `CountByUnsortedNums` |           .NET 6.0 | 178.77 us | 4.231 us | 12.003 us | 21.4844 | 3.4180 |  88.04 KB |
|    `UnoptimizedCountBySortedNums` |           .NET 6.0 | 110.80 us | 2.069 us |  1.936 us | 21.4844 |      - |  88.04 KB |
|  `UnoptimizedCountByUnsortedNums` |           .NET 6.0 | 117.91 us | 1.939 us |  1.719 us | 21.4844 | 3.5400 |  88.04 KB |
|              `CountBySortedWords` |           .NET 6.0 | 121.00 us | 1.625 us |  1.357 us |  3.9063 |      - |  16.44 KB |
|            `CountByUnsortedWords` |           .NET 6.0 | 223.79 us | 3.731 us |  3.490 us |  3.9063 |      - |  16.44 KB |
|   `UnoptimizedCountBySortedWords` |           .NET 6.0 |  87.78 us | 1.020 us |  0.796 us |  3.9063 |      - |  16.44 KB |
| `UnoptimizedCountByUnsortedWords` |           .NET 6.0 | 150.23 us | 2.765 us |  2.309 us |  3.9063 |      - |  16.44 KB |
|               `CountBySortedNums` |      .NET Core 3.1 | 131.21 us | 2.437 us |  2.160 us | 21.4844 |      - |  88.03 KB |
|             `CountByUnsortedNums` |      .NET Core 3.1 | 175.69 us | 2.923 us |  2.592 us | 21.4844 |      - |  88.03 KB |
|    `UnoptimizedCountBySortedNums` |      .NET Core 3.1 | 125.99 us | 2.278 us |  3.194 us | 21.4844 |      - |  88.03 KB |
|  `UnoptimizedCountByUnsortedNums` |      .NET Core 3.1 | 134.52 us | 2.177 us |  1.930 us | 21.4844 |      - |  88.03 KB |
|              `CountBySortedWords` |      .NET Core 3.1 | 156.86 us | 2.136 us |  1.998 us |  3.9063 |      - |  16.43 KB |
|            `CountByUnsortedWords` |      .NET Core 3.1 | 265.49 us | 3.754 us |  3.328 us |  3.9063 |      - |  16.43 KB |
|   `UnoptimizedCountBySortedWords` |      .NET Core 3.1 | 111.92 us | 1.819 us |  1.701 us |  3.9063 |      - |  16.43 KB |
| `UnoptimizedCountByUnsortedWords` |      .NET Core 3.1 | 189.82 us | 3.653 us |  3.051 us |  3.9063 |      - |  16.43 KB |
|               `CountBySortedNums` | .NET Framework 4.8 | 154.13 us | 1.698 us |  1.589 us | 21.4844 |      - |  88.24 KB |
|             `CountByUnsortedNums` | .NET Framework 4.8 | 218.52 us | 2.423 us |  2.267 us | 21.4844 |      - |  88.24 KB |
|    `UnoptimizedCountBySortedNums` | .NET Framework 4.8 | 182.84 us | 2.476 us |  2.316 us | 21.4844 |      - |  88.24 KB |
|  `UnoptimizedCountByUnsortedNums` | .NET Framework 4.8 | 173.50 us | 2.577 us |  2.284 us | 21.4844 |      - |  88.24 KB |
|              `CountBySortedWords` | .NET Framework 4.8 | 176.44 us | 3.349 us |  2.969 us |  3.9063 |      - |   16.5 KB |
|            `CountByUnsortedWords` | .NET Framework 4.8 | 300.49 us | 3.006 us |  2.665 us |  3.9063 |      - |   16.5 KB |
|   `UnoptimizedCountBySortedWords` | .NET Framework 4.8 | 128.09 us | 2.235 us |  2.391 us |  3.9063 |      - |   16.5 KB |
| `UnoptimizedCountByUnsortedWords` | .NET Framework 4.8 | 184.50 us | 3.556 us |  3.493 us |  3.9063 |      - |   16.5 KB |
