### PR TITLE
Replace Nullable with PolySharp

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -138,8 +138,6 @@
     <PackageOutputPath>..\dist</PackageOutputPath>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
-    <!-- Suppress NU5118 below, which is caused by IncludeSource=true and Nullable 1.3.1 -->
-    <NoWarn>$(NoWarn);NU5118</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -155,6 +153,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="PolySharp" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -244,13 +243,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ToDelimitedString.g.tt</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Nullable" Version="1.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <Target Name="_CollectTextTemplates">


### PR DESCRIPTION
This PR replaces the [**Nullable**](https://www.nuget.org/packages/Nullable) package with [**PolySharp**](https://www.nuget.org/packages/PolySharp/). It also allows removing the suppression of warning [NU5118](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5118).