### PR TITLE
Fix code coverage using latest coverlet collector

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/MoreLinq.Test/coverlet.runsettings
+++ b/MoreLinq.Test/coverlet.runsettings
@@ -5,6 +5,7 @@
         <Configuration>
           <Format>opencover</Format>
           <Exclude>[NUnit*]*,[MoreLinq]MoreLinq.Extensions.*,[MoreLinq]MoreLinq.Experimental.*</Exclude>
+          <ExcludeByFile>**/System.*.g.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
This PR updates to the latest version of [**coverlet.collector**](https://www.nuget.org/packages/coverlet.collector), which seems to restore coverage reporting.

Before this PR, run:

    git checkout ac88c7ffdb943c88595bd47d36cf2b07ea941ae6
    test.cmd

The coverage report at the end says no assemblies were covered:

    Summary
      Generated on: 30/10/2022 - 22:30:30
      Parser: MultiReportParser (4x OpenCoverParser)
      Assemblies: 0
      Classes: 0
      Files: 0
      Line coverage:
      Covered lines: 0
      Uncovered lines: 0
      Coverable lines: 0
      Total lines: 0
    No assemblies have been covered.

After applying this PR, the report instead reads:

    Summary
      Generated on: 30/10/2022 - 22:44:27
      Parser: MultiReportParser (4x OpenCoverParser)
      Assemblies: 1
      Classes: 15
      Files: 108
      Line coverage: 93.1%
      Covered lines: 3216
      Uncovered lines: 237
      Coverable lines: 3453
      Total lines: 15030

    MoreLinq                              93.1%
      Delegating.Delegate                100.0%
      Delegating.DelegatingDisposable     87.5%
      Delegating.DelegatingObserver`1     90.9%
      MoreLinq.Collections.Dictionary`2  100.0%
      MoreLinq.Disposable                  0.0%
      MoreLinq.EmptyArray`1              100.0%
      MoreLinq.Grouping`2                 47.6%
      MoreLinq.ListLike                   92.8%
      MoreLinq.Lookup`2                   62.1%
      MoreLinq.MoreEnumerable             94.8%
      MoreLinq.PendNode`1                 98.4%
      MoreLinq.Reactive.Observable       100.0%
      MoreLinq.Reactive.Subject`1         81.5%
      MoreLinq.ReverseComparer`1         100.0%
      MoreLinq.SequenceException          50.0%

---
See also:

- 📄 [`log.txt`](https://github.com/morelinq/MoreLINQ/files/9896912/log.txt)
