### PR TITLE
Use string interpolation

### DIFF
--- a/MoreLinq.Test/AggregateRightTest.cs
+++ b/MoreLinq.Test/AggregateRightTest.cs
@@ -49,7 +49,7 @@ namespace MoreLinq.Test
         {
             var enumerable = Enumerable.Range(1, 5).Select(x => x.ToString()).ToSourceKind(sourceKind);
 
-            var result = enumerable.AggregateRight((a, b) => string.Format("({0}+{1})", a, b));
+            var result = enumerable.AggregateRight((a, b) => $"({a}+{b})");
 
             Assert.That(result, Is.EqualTo("(1+(2+(3+(4+5))))"));
         }
@@ -78,7 +78,7 @@ namespace MoreLinq.Test
         public void AggregateRightSeed()
         {
             var result = Enumerable.Range(1, 4)
-                                   .AggregateRight("5", (a, b) => string.Format("({0}+{1})", a, b));
+                                   .AggregateRight("5", (a, b) => $"({a}+{b})");
 
             Assert.That(result, Is.EqualTo("(1+(2+(3+(4+5))))"));
         }
@@ -90,14 +90,14 @@ namespace MoreLinq.Test
         [TestCase(true)]
         public void AggregateRightResultorWithEmptySequence(object defaultValue)
         {
-            Assert.That(new int[0].AggregateRight(defaultValue, (a, b) => b, a => a == defaultValue), Is.EqualTo(true));
+            Assert.That(new int[0].AggregateRight(defaultValue, (_, b) => b, a => a == defaultValue), Is.EqualTo(true));
         }
 
         [Test]
         public void AggregateRightResultor()
         {
             var result = Enumerable.Range(1, 4)
-                                   .AggregateRight("5", (a, b) => string.Format("({0}+{1})", a, b), a => a.Length);
+                                   .AggregateRight("5", (a, b) => $"({a}+{b})", a => a.Length);
 
             Assert.That(result, Is.EqualTo("(1+(2+(3+(4+5))))".Length));
         }

--- a/MoreLinq.Test/ScanRightTest.cs
+++ b/MoreLinq.Test/ScanRightTest.cs
@@ -64,7 +64,7 @@ namespace MoreLinq.Test
             var result = Enumerable.Range(1, 5)
                                    .Select(x => x.ToString())
                                    .ToSourceKind(sourceKind)
-                                   .ScanRight((a, b) => string.Format("({0}+{1})", a, b));
+                                   .ScanRight((a, b) => $"({a}+{b})");
 
             var expectations = new[] { "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" };
 
@@ -101,7 +101,7 @@ namespace MoreLinq.Test
         public void ScanRightSeed()
         {
             var result = Enumerable.Range(1, 4)
-                                   .ScanRight("5", (a, b) => string.Format("({0}+{1})", a, b));
+                                   .ScanRight("5", (a, b) => $"({a}+{b})");
 
             var expectations = new[] { "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" };
 

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -34,7 +34,7 @@ namespace MoreLinq
         /// <returns>The final accumulator value.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// string result = Enumerable.Range(1, 5).Select(i => i.ToString()).AggregateRight((a, b) => string.Format("({0}/{1})", a, b));
+        /// string result = Enumerable.Range(1, 5).Select(i => i.ToString()).AggregateRight((a, b) => $"({a}/{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>"(1/(2/(3/(4/5))))"</c>.
         /// </example>
@@ -70,7 +70,7 @@ namespace MoreLinq
         /// <example>
         /// <code><![CDATA[
         /// var numbers = Enumerable.Range(1, 5);
-        /// string result = numbers.AggregateRight("6", (a, b) => string.Format("({0}/{1})", a, b));
+        /// string result = numbers.AggregateRight("6", (a, b) => $"({a}/{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>"(1/(2/(3/(4/(5/6)))))"</c>.
         /// </example>
@@ -106,7 +106,7 @@ namespace MoreLinq
         /// <example>
         /// <code><![CDATA[
         /// var numbers = Enumerable.Range(1, 5);
-        /// int result = numbers.AggregateRight("6", (a, b) => string.Format("({0}/{1})", a, b), str => str.Length);
+        /// int result = numbers.AggregateRight("6", (a, b) => $"({a}/{b})", str => str.Length);
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>21</c>.
         /// </example>

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -360,7 +360,7 @@ namespace MoreLinq.Extensions
         /// <returns>The final accumulator value.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// string result = Enumerable.Range(1, 5).Select(i => i.ToString()).AggregateRight((a, b) => string.Format("({0}/{1})", a, b));
+        /// string result = Enumerable.Range(1, 5).Select(i => i.ToString()).AggregateRight((a, b) => $"({a}/{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>"(1/(2/(3/(4/5))))"</c>.
         /// </example>
@@ -386,7 +386,7 @@ namespace MoreLinq.Extensions
         /// <example>
         /// <code><![CDATA[
         /// var numbers = Enumerable.Range(1, 5);
-        /// string result = numbers.AggregateRight("6", (a, b) => string.Format("({0}/{1})", a, b));
+        /// string result = numbers.AggregateRight("6", (a, b) => $"({a}/{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>"(1/(2/(3/(4/(5/6)))))"</c>.
         /// </example>
@@ -415,7 +415,7 @@ namespace MoreLinq.Extensions
         /// <example>
         /// <code><![CDATA[
         /// var numbers = Enumerable.Range(1, 5);
-        /// int result = numbers.AggregateRight("6", (a, b) => string.Format("({0}/{1})", a, b), str => str.Length);
+        /// int result = numbers.AggregateRight("6", (a, b) => $"({a}/{b})", str => str.Length);
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>21</c>.
         /// </example>
@@ -5022,7 +5022,7 @@ namespace MoreLinq.Extensions
         /// <returns>The scanned sequence.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// var result = Enumerable.Range(1, 4).ScanRight("5", (a, b) => string.Format("({0}/{1})", a, b));
+        /// var result = Enumerable.Range(1, 4).ScanRight("5", (a, b) => $"({a}+{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>[ "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" ]</c>.
         /// </example>

--- a/MoreLinq/ScanRight.cs
+++ b/MoreLinq/ScanRight.cs
@@ -70,7 +70,7 @@ namespace MoreLinq
         /// <returns>The scanned sequence.</returns>
         /// <example>
         /// <code><![CDATA[
-        /// var result = Enumerable.Range(1, 4).ScanRight("5", (a, b) => string.Format("({0}/{1})", a, b));
+        /// var result = Enumerable.Range(1, 4).ScanRight("5", (a, b) => $"({a}+{b})");
         /// ]]></code>
         /// The <c>result</c> variable will contain <c>[ "(1+(2+(3+(4+5))))", "(2+(3+(4+5)))", "(3+(4+5))", "(4+5)", "5" ]</c>.
         /// </example>


### PR DESCRIPTION
This PR replaces most `string.Format` invocations with string interpolation.