### PR TITLE
Replace `MayBeNull` with `?` in `IExtremaEnumerable` members

### DIFF
--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1907,8 +1907,7 @@ namespace MoreLinq.Extensions
         /// otherwise, the first element in source.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T FirstOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? FirstOrDefault<T>(this IExtremaEnumerable<T> source)
             => MoreEnumerable.FirstOrDefault(source);
 
     }
@@ -3114,8 +3113,7 @@ namespace MoreLinq.Extensions
         /// otherwise, the last element in source.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T LastOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? LastOrDefault<T>(this IExtremaEnumerable<T> source)
             => MoreEnumerable.LastOrDefault(source);
 
     }
@@ -5178,8 +5176,7 @@ namespace MoreLinq.Extensions
         /// <typeparamref name="T"/> if the sequence contains no elements.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T SingleOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? SingleOrDefault<T>(this IExtremaEnumerable<T> source)
             => MoreEnumerable.SingleOrDefault(source);
 
     }

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -20,7 +20,6 @@ namespace MoreLinq
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
 
     /// <summary>
@@ -88,8 +87,7 @@ namespace MoreLinq
         /// otherwise, the first element in source.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T FirstOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? FirstOrDefault<T>(this IExtremaEnumerable<T> source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.Take(1).AsEnumerable().FirstOrDefault();
@@ -125,8 +123,7 @@ namespace MoreLinq
         /// otherwise, the last element in source.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T LastOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? LastOrDefault<T>(this IExtremaEnumerable<T> source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.TakeLast(1).AsEnumerable().LastOrDefault();
@@ -164,8 +161,7 @@ namespace MoreLinq
         /// <typeparamref name="T"/> if the sequence contains no elements.
         /// </returns>
 
-        [return: MaybeNull]
-        public static T SingleOrDefault<T>(this IExtremaEnumerable<T> source)
+        public static T? SingleOrDefault<T>(this IExtremaEnumerable<T> source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             return source.Take(2).AsEnumerable().SingleOrDefault();


### PR DESCRIPTION
This PR replaces `MayBeNull` annotations with `?` in `IExtremaEnumerable<>` members.