### PR TITLE
Fix test scripts to test on .NET 7 runtime

### DIFF
--- a/test.cmd
+++ b/test.cmd
@@ -8,6 +8,8 @@ goto :EOF
 setlocal
 call build ^
   && call :clean ^
+  && call :test net7.0 Debug ^
+  && call :test net7.0 Release ^
   && call :test net6.0 Debug ^
   && call :test net6.0 Release ^
   && call :test netcoreapp3.1 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in netcoreapp3.1 net6.0; do
+for f in netcoreapp3.1 net6.0 net7.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"


### PR DESCRIPTION
This PR fixes test scripts to also execute unit tests on the .NET 7 runtime. It's a follow-up fix to PR #871.