### PR TITLE
Enable nullable context in `Flatten` tests

### DIFF
--- a/MoreLinq.Test/FlattenTest.cs
+++ b/MoreLinq.Test/FlattenTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;
@@ -395,7 +397,7 @@ namespace MoreLinq.Test
             var result = new[] { source }.Flatten(obj => obj switch
             {
                 int => null,
-                Tree<int> tree => new object[] { tree.Left, tree.Value, tree.Right },
+                Tree<int> tree => new object?[] { tree.Left, tree.Value, tree.Right },
                 IEnumerable inner => inner,
                 _ => Enumerable.Empty<object>()
             });
@@ -407,23 +409,23 @@ namespace MoreLinq.Test
 
         class Series
         {
-            public string Name;
-            public Attribute[] Attributes;
+            public required string Name;
+            public required Attribute[] Attributes;
         }
 
         class Attribute
         {
-            public int[] Values;
+            public required int[] Values;
         }
 
         class Tree<T>
         {
             public readonly T Value;
-            public readonly Tree<T> Left;
-            public readonly Tree<T> Right;
+            public readonly Tree<T>? Left;
+            public readonly Tree<T>? Right;
 
             public Tree(T value) : this(null, value, null) {}
-            public Tree(Tree<T> left, T value, Tree<T> right)
+            public Tree(Tree<T>? left, T value, Tree<T>? right)
             {
                 Left = left;
                 Value = value;

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -35,6 +35,7 @@
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="PolySharp" Version="1.7.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />


### PR DESCRIPTION
This PR enables the nullable context in the unit tests for `Flatten`.

This is a follow-up to PR #847 that adds to #803.