### PR TITLE
Update ReportGenerator tool to 5.1.11

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.6.4",
+      "version": "5.1.11",
       "commands": [
         "reportgenerator"
       ]


### PR DESCRIPTION
This PR updates the [ReportGenerator tool](https://www.nuget.org/packages/dotnet-reportgenerator-globaltool) to version [5.1.11](https://github.com/danielpalme/ReportGenerator/releases/tag/v5.1.11).