### PR TITLE
Sync `Lookup` + `Grouping` from .NET 7 sources

### DIFF
--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -244,9 +244,9 @@ namespace MoreLinq
 
         bool ICollection<TElement>.IsReadOnly => true;
 
-        void ICollection<TElement>.Add(TElement item) => ThrowHelper.ThrowNotSupportedException();
+        void ICollection<TElement>.Add(TElement item) => ThrowModificationNotSupportedException();
 
-        void ICollection<TElement>.Clear() => ThrowHelper.ThrowNotSupportedException();
+        void ICollection<TElement>.Clear() => ThrowModificationNotSupportedException();
 
         bool ICollection<TElement>.Contains(TElement item) => Array.IndexOf(_elements, item, 0, _count) >= 0;
 
@@ -255,15 +255,15 @@ namespace MoreLinq
 
         bool ICollection<TElement>.Remove(TElement item)
         {
-            ThrowHelper.ThrowNotSupportedException();
+            ThrowModificationNotSupportedException();
             return false;
         }
 
         int IList<TElement>.IndexOf(TElement item) => Array.IndexOf(_elements, item, 0, _count);
 
-        void IList<TElement>.Insert(int index, TElement item) => ThrowHelper.ThrowNotSupportedException();
+        void IList<TElement>.Insert(int index, TElement item) => ThrowModificationNotSupportedException();
 
-        void IList<TElement>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
+        void IList<TElement>.RemoveAt(int index) => ThrowModificationNotSupportedException();
 
         TElement IList<TElement>.this[int index]
         {
@@ -271,13 +271,10 @@ namespace MoreLinq
                    ? throw new ArgumentOutOfRangeException(nameof(index))
                    : _elements[index];
 
-            set => ThrowHelper.ThrowNotSupportedException();
+            set => ThrowModificationNotSupportedException();
         }
 
-        static class ThrowHelper
-        {
-            [DoesNotReturn]
-            internal static void ThrowNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");
-        }
+        [DoesNotReturn]
+        static void ThrowModificationNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");
     }
 }

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -244,26 +244,12 @@ namespace MoreLinq
 
         bool ICollection<TElement>.IsReadOnly => true;
 
-        void ICollection<TElement>.Add(TElement item) => ThrowModificationNotSupportedException();
-
-        void ICollection<TElement>.Clear() => ThrowModificationNotSupportedException();
-
         bool ICollection<TElement>.Contains(TElement item) => Array.IndexOf(_elements, item, 0, _count) >= 0;
 
         void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex) =>
             Array.Copy(_elements, 0, array, arrayIndex, _count);
 
-        bool ICollection<TElement>.Remove(TElement item)
-        {
-            ThrowModificationNotSupportedException();
-            return false;
-        }
-
         int IList<TElement>.IndexOf(TElement item) => Array.IndexOf(_elements, item, 0, _count);
-
-        void IList<TElement>.Insert(int index, TElement item) => ThrowModificationNotSupportedException();
-
-        void IList<TElement>.RemoveAt(int index) => ThrowModificationNotSupportedException();
 
         TElement IList<TElement>.this[int index]
         {
@@ -273,6 +259,12 @@ namespace MoreLinq
 
             set => ThrowModificationNotSupportedException();
         }
+
+        void ICollection<TElement>.Add(TElement item) => ThrowModificationNotSupportedException();
+        void ICollection<TElement>.Clear() => ThrowModificationNotSupportedException();
+        bool ICollection<TElement>.Remove(TElement item) { ThrowModificationNotSupportedException(); return false; }
+        void IList<TElement>.Insert(int index, TElement item) => ThrowModificationNotSupportedException();
+        void IList<TElement>.RemoveAt(int index) => ThrowModificationNotSupportedException();
 
         [DoesNotReturn]
         static void ThrowModificationNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -24,257 +24,283 @@
 // SOFTWARE.
 #endregion
 
-#nullable disable
+#if !NET6_0_OR_GREATER
+#nullable enable annotations
+#pragma warning disable 8602 // Dereference of a possibly null reference.
+#pragma warning disable 8603 // Possible null reference return.
+#endif
 
 namespace MoreLinq
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
 
     /// <summary>
     /// A <see cref="ILookup{TKey, TElement}"/> implementation that preserves insertion order
     /// </summary>
-    /// <typeparam name="TKey">The type of the keys in the <see cref="Lookup{TKey, TElement}"/></typeparam>
-    /// <typeparam name="TElement">The type of the elements in the <see cref="IEnumerable{T}"/> sequences that make up the values in the <see cref="Lookup{TKey, TElement}"/></typeparam>
     /// <remarks>
-    /// This implementation preserves insertion order of keys and elements within each <see cref="IEnumerable{T}"/>
-    /// Copied over from CoreFX on 2015-10-27
-    /// https://github.com/dotnet/corefx/blob/6f1c2a86fb8fa1bdaee7c6e70a684d27842d804c/src/System.Linq/src/System/Linq/Enumerable.cs#L3230-L3403
-    /// Modified to remove internal interfaces
+    /// This implementation preserves insertion order of keys and elements within each <see
+    /// cref="IEnumerable{T}"/>. Copied and modified from
+    /// <c><a href="https://github.com/dotnet/runtime/blob/v7.0.0/src/libraries/System.Linq/src/System/Linq/Lookup.cs">Lookup.cs</a></c>
     /// </remarks>
-    internal class Lookup<TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, ILookup<TKey, TElement>
+
+    [DebuggerDisplay("Count = {Count}")]
+    sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>
     {
-        private IEqualityComparer<TKey> _comparer;
+        private readonly IEqualityComparer<TKey> _comparer;
         private Grouping<TKey, TElement>[] _groupings;
-        private Grouping<TKey, TElement> _lastGrouping;
+        private Grouping<TKey, TElement>? _lastGrouping;
         private int _count;
 
-        internal static Lookup<TKey, TElement> Create<TSource>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        internal static Lookup<TKey, TElement> Create<TSource>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            if (elementSelector == null) throw new ArgumentNullException(nameof(elementSelector));
+            Debug.Assert(source != null);
+            Debug.Assert(keySelector != null);
+            Debug.Assert(elementSelector != null);
+
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
-            foreach (TSource item in source) {
-                lookup.GetGrouping(keySelector(item), true).Add(elementSelector(item));
+            foreach (TSource item in source)
+            {
+                lookup.GetGrouping(keySelector(item), create: true)!.Add(elementSelector(item));
             }
+
             return lookup;
         }
 
-        internal static Lookup<TKey, TElement> CreateForJoin(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        internal static Lookup<TKey, TElement> Create(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(keySelector != null);
+
+            Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
+            foreach (TElement item in source)
+            {
+                lookup.GetGrouping(keySelector(item), create: true)!.Add(item);
+            }
+
+            return lookup;
+        }
+
+        internal static Lookup<TKey, TElement> CreateForJoin(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IEqualityComparer<TKey>? comparer)
         {
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
-            foreach (TElement item in source) {
+            foreach (TElement item in source)
+            {
                 TKey key = keySelector(item);
-                if (key != null) lookup.GetGrouping(key, true).Add(item);
+                if (key != null)
+                {
+                    lookup.GetGrouping(key, create: true)!.Add(item);
+                }
             }
+
             return lookup;
         }
 
-        private Lookup(IEqualityComparer<TKey> comparer)
+        private Lookup(IEqualityComparer<TKey>? comparer)
         {
-            if (comparer == null) comparer = EqualityComparer<TKey>.Default;
-            _comparer = comparer;
+            _comparer = comparer ?? EqualityComparer<TKey>.Default;
             _groupings = new Grouping<TKey, TElement>[7];
         }
 
-        public int Count
-        {
-            get { return _count; }
-        }
+        public int Count => _count;
 
         public IEnumerable<TElement> this[TKey key]
         {
             get
             {
-                Grouping<TKey, TElement> grouping = GetGrouping(key, false);
-                if (grouping != null) return grouping;
-                return Enumerable.Empty<TElement>();
+                Grouping<TKey, TElement>? grouping = GetGrouping(key, create: false);
+                return grouping ?? Enumerable.Empty<TElement>();
             }
         }
 
-        public bool Contains(TKey key)
-        {
-            return _count > 0 && GetGrouping(key, false) != null;
-        }
+        public bool Contains(TKey key) => GetGrouping(key, create: false) != null;
 
         public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator()
         {
-            Grouping<TKey, TElement> g = _lastGrouping;
-            if (g != null) {
-                do {
-                    g = g.next;
+            Grouping<TKey, TElement>? g = _lastGrouping;
+            if (g != null)
+            {
+                do
+                {
+                    g = g._next;
+
+                    Debug.Assert(g != null);
                     yield return g;
-                } while (g != _lastGrouping);
+                }
+                while (g != _lastGrouping);
             }
         }
 
-        public IEnumerable<TResult> ApplyResultSelector<TResult>(Func<TKey, IEnumerable<TElement>, TResult> resultSelector)
-        {
-            Grouping<TKey, TElement> g = _lastGrouping;
-            if (g != null) {
-                do {
-                    g = g.next;
-                    if (g.count != g.elements.Length) { Array.Resize(ref g.elements, g.count); }
-                    yield return resultSelector(g.key, g.elements);
-                } while (g != _lastGrouping);
-            }
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        internal int InternalGetHashCode(TKey key)
+        private int InternalGetHashCode(TKey key)
         {
             // Handle comparer implementations that throw when passed null
             return (key == null) ? 0 : _comparer.GetHashCode(key) & 0x7FFFFFFF;
         }
 
-        internal Grouping<TKey, TElement> GetGrouping(TKey key, bool create)
+        internal Grouping<TKey, TElement>? GetGrouping(TKey key, bool create)
         {
             int hashCode = InternalGetHashCode(key);
-            for (Grouping<TKey, TElement> g = _groupings[hashCode % _groupings.Length]; g != null; g = g.hashNext)
-                if (g.hashCode == hashCode && _comparer.Equals(g.key, key)) return g;
-            if (create) {
-                if (_count == _groupings.Length) Resize();
+            for (Grouping<TKey, TElement>? g = _groupings[hashCode % _groupings.Length]; g != null; g = g._hashNext)
+            {
+                if (g._hashCode == hashCode && _comparer.Equals(g._key, key))
+                {
+                    return g;
+                }
+            }
+
+            if (create)
+            {
+                if (_count == _groupings.Length)
+                {
+                    Resize();
+                }
+
                 int index = hashCode % _groupings.Length;
-                Grouping<TKey, TElement> g = new Grouping<TKey, TElement>();
-                g.key = key;
-                g.hashCode = hashCode;
-                g.elements = new TElement[1];
-                g.hashNext = _groupings[index];
+                Grouping<TKey, TElement> g = new Grouping<TKey, TElement>(key, hashCode);
+                g._hashNext = _groupings[index];
                 _groupings[index] = g;
-                if (_lastGrouping == null) {
-                    g.next = g;
+                if (_lastGrouping == null)
+                {
+                    g._next = g;
                 }
-                else {
-                    g.next = _lastGrouping.next;
-                    _lastGrouping.next = g;
+                else
+                {
+                    g._next = _lastGrouping._next;
+                    _lastGrouping._next = g;
                 }
+
                 _lastGrouping = g;
                 _count++;
                 return g;
             }
+
             return null;
         }
 
         private void Resize()
         {
-            int newSize = checked(_count * 2 + 1);
+            int newSize = checked((_count * 2) + 1);
             Grouping<TKey, TElement>[] newGroupings = new Grouping<TKey, TElement>[newSize];
-            Grouping<TKey, TElement> g = _lastGrouping;
-            do {
-                g = g.next;
-                int index = g.hashCode % newSize;
-                g.hashNext = newGroupings[index];
+            Grouping<TKey, TElement> g = _lastGrouping!;
+            do
+            {
+                g = g._next!;
+                int index = g._hashCode % newSize;
+                g._hashNext = newGroupings[index];
                 newGroupings[index] = g;
-            } while (g != _lastGrouping);
+            }
+            while (g != _lastGrouping);
+
             _groupings = newGroupings;
         }
     }
 
-    internal class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
-    {
-        internal TKey key;
-        internal int hashCode;
-        internal TElement[] elements;
-        internal int count;
-        internal Grouping<TKey, TElement> hashNext;
-        internal Grouping<TKey, TElement> next;
+    // Modified from:
+    // https://github.com/dotnet/runtime/blob/v7.0.0/src/libraries/System.Linq/src/System/Linq/Grouping.cs#L48-L141
 
-        internal Grouping()
+    [DebuggerDisplay("Key = {Key}")]
+    sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
+    {
+        internal readonly TKey _key;
+        internal readonly int _hashCode;
+        internal TElement[] _elements;
+        internal int _count;
+        internal Grouping<TKey, TElement>? _hashNext;
+        internal Grouping<TKey, TElement>? _next;
+
+        internal Grouping(TKey key, int hashCode)
         {
+            _key = key;
+            _hashCode = hashCode;
+            _elements = new TElement[1];
         }
 
         internal void Add(TElement element)
         {
-            if (elements.Length == count) Array.Resize(ref elements, checked(count * 2));
-            elements[count] = element;
-            count++;
+            if (_elements.Length == _count)
+            {
+                Array.Resize(ref _elements, checked(_count * 2));
+            }
+
+            _elements[_count] = element;
+            _count++;
+        }
+
+        internal void Trim()
+        {
+            if (_elements.Length != _count)
+            {
+                Array.Resize(ref _elements, _count);
+            }
         }
 
         public IEnumerator<TElement> GetEnumerator()
         {
-            for (int i = 0; i < count; i++) yield return elements[i];
+            for (int i = 0; i < _count; i++)
+            {
+                yield return _elements[i];
+            }
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         // DDB195907: implement IGrouping<>.Key implicitly
         // so that WPF binding works on this property.
-        public TKey Key
-        {
-            get { return key; }
-        }
+        public TKey Key => _key;
 
-        int ICollection<TElement>.Count
-        {
-            get { return count; }
-        }
+        int ICollection<TElement>.Count => _count;
 
-        bool ICollection<TElement>.IsReadOnly
-        {
-            get { return true; }
-        }
+        bool ICollection<TElement>.IsReadOnly => true;
 
-        void ICollection<TElement>.Add(TElement item)
-        {
-            throw new NotSupportedException("Lookup is immutable");
-        }
+        void ICollection<TElement>.Add(TElement item) => ThrowHelper.ThrowNotSupportedException();
 
-        void ICollection<TElement>.Clear()
-        {
-            throw new NotSupportedException("Lookup is immutable");
-        }
+        void ICollection<TElement>.Clear() => ThrowHelper.ThrowNotSupportedException();
 
-        bool ICollection<TElement>.Contains(TElement item)
-        {
-            return Array.IndexOf(elements, item, 0, count) >= 0;
-        }
+        bool ICollection<TElement>.Contains(TElement item) => Array.IndexOf(_elements, item, 0, _count) >= 0;
 
-        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
-        {
-            Array.Copy(elements, 0, array, arrayIndex, count);
-        }
+        void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex) =>
+            Array.Copy(_elements, 0, array, arrayIndex, _count);
 
         bool ICollection<TElement>.Remove(TElement item)
         {
-            throw new NotSupportedException("Lookup is immutable");
+            ThrowHelper.ThrowNotSupportedException();
+            return false;
         }
 
-        int IList<TElement>.IndexOf(TElement item)
-        {
-            return Array.IndexOf(elements, item, 0, count);
-        }
+        int IList<TElement>.IndexOf(TElement item) => Array.IndexOf(_elements, item, 0, _count);
 
-        void IList<TElement>.Insert(int index, TElement item)
-        {
-            throw new NotSupportedException("Lookup is immutable");
-        }
+        void IList<TElement>.Insert(int index, TElement item) => ThrowHelper.ThrowNotSupportedException();
 
-        void IList<TElement>.RemoveAt(int index)
-        {
-            throw new NotSupportedException("Lookup is immutable");
-        }
+        void IList<TElement>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
 
         TElement IList<TElement>.this[int index]
         {
             get
             {
-                if (index < 0 || index >= count) throw new ArgumentOutOfRangeException(nameof(index));
-                return elements[index];
+                if (index < 0 || index >= _count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return _elements[index];
             }
+
             set
             {
-                throw new NotSupportedException("Lookup is immutable");
+                ThrowHelper.ThrowNotSupportedException();
             }
+        }
+
+        static class ThrowHelper
+        {
+            [DoesNotReturn]
+            internal static void ThrowNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");
         }
     }
 }


### PR DESCRIPTION
This PR updates the implementations of [`Lookup`](https://github.com/dotnet/runtime/blob/v7.0.0/src/libraries/System.Linq/src/System/Linq/Lookup.cs) and [`Grouping`](https://github.com/dotnet/runtime/blob/v7.0.0/src/libraries/System.Linq/src/System/Linq/Grouping.cs#L48-L141) from .NET 7 sources. It allows the code to participate to be subjected to nullability checks from .NET 6 onwards.