### PR TITLE
Add identity method to reduce JIT-ing

### DIFF
--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -50,7 +50,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
         {
-            return Batch(source, size, Identity<IEnumerable<TSource>>);
+            return Batch(source, size, IdFn<IEnumerable<TSource>>);
         }
 
         /// <summary>

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -50,7 +50,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
         {
-            return Batch(source, size, IdFn<IEnumerable<TSource>>);
+            return Batch(source, size, IdFn);
         }
 
         /// <summary>

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -50,7 +50,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(this IEnumerable<TSource> source, int size)
         {
-            return Batch(source, size, x => x);
+            return Batch(source, size, Identity<IEnumerable<TSource>>);
         }
 
         /// <summary>

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -87,7 +87,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return GroupAdjacent(source, keySelector, Identity<TSource>, comparer);
+            return GroupAdjacent(source, keySelector, IdFn, comparer);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace MoreLinq
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);
 
-            return GroupAdjacentImpl(source, keySelector, Identity<TSource>, ResultSelectorWrapper,
+            return GroupAdjacentImpl(source, keySelector, IdFn, ResultSelectorWrapper,
                                      EqualityComparer<TKey>.Default);
         }
 
@@ -253,7 +253,7 @@ namespace MoreLinq
 
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);
-            return GroupAdjacentImpl(source, keySelector, Identity<TSource>, ResultSelectorWrapper,
+            return GroupAdjacentImpl(source, keySelector, IdFn, ResultSelectorWrapper,
                                      comparer ?? EqualityComparer<TKey>.Default);
         }
 

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -87,7 +87,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return GroupAdjacent(source, keySelector, e => e, comparer);
+            return GroupAdjacent(source, keySelector, Identity<TSource>, comparer);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace MoreLinq
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);
 
-            return GroupAdjacentImpl(source, keySelector, i => i, ResultSelectorWrapper,
+            return GroupAdjacentImpl(source, keySelector, Identity<TSource>, ResultSelectorWrapper,
                                      EqualityComparer<TKey>.Default);
         }
 
@@ -253,7 +253,7 @@ namespace MoreLinq
 
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);
-            return GroupAdjacentImpl(source, keySelector, i => i, ResultSelectorWrapper,
+            return GroupAdjacentImpl(source, keySelector, Identity<TSource>, ResultSelectorWrapper,
                                      comparer ?? EqualityComparer<TKey>.Default);
         }
 

--- a/MoreLinq/IdFn.cs
+++ b/MoreLinq/IdFn.cs
@@ -17,8 +17,8 @@
 
 namespace MoreLinq
 {
-    public static partial class MoreEnumerable
+    static partial class MoreEnumerable
     {
-        private static T IdFn<T>(T x) => x;
+        static T IdFn<T>(T x) => x;
     }
 }

--- a/MoreLinq/IdFn.cs
+++ b/MoreLinq/IdFn.cs
@@ -19,11 +19,6 @@ namespace MoreLinq
 {
     public static partial class MoreEnumerable
     {
-        /// <summary>
-        /// Returns the identity function for a given type.
-        /// </summary>
-        /// <typeparam name="T">The type of identity function</typeparam>
-        /// <returns>A reference to the identity function</returns>
-        public static T Identity<T>(T x) => x;
+        private static T IdFn<T>(T x) => x;
     }
 }

--- a/MoreLinq/Identity.cs
+++ b/MoreLinq/Identity.cs
@@ -1,0 +1,29 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2022 Turning Code, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    public static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns the identity function for a given type.
+        /// </summary>
+        /// <typeparam name="T">The type of identity function</typeparam>
+        /// <returns>A reference to the identity function</returns>
+        public static T Identity<T>(T x) => x;
+    }
+}

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -70,7 +70,7 @@ namespace MoreLinq
             IEnumerable<T> second,
             IComparer<T>? comparer)
         {
-            return OrderedMerge(first, second, e => e, f => f, s => s, (a, _) => a, comparer);
+            return OrderedMerge(first, second, Identity<T>, Identity<T>, Identity<T>, (a, _) => a, comparer);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace MoreLinq
             IEnumerable<T> second,
             Func<T, TKey> keySelector)
         {
-            return OrderedMerge(first, second, keySelector, a => a, b => b, (a, _) => a, null);
+            return OrderedMerge(first, second, keySelector, Identity<T>, Identity<T>, (a, _) => a, null);
         }
 
         /// <summary>

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -70,7 +70,7 @@ namespace MoreLinq
             IEnumerable<T> second,
             IComparer<T>? comparer)
         {
-            return OrderedMerge(first, second, Identity<T>, Identity<T>, Identity<T>, (a, _) => a, comparer);
+            return OrderedMerge(first, second, IdFn, IdFn, IdFn, (a, _) => a, comparer);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace MoreLinq
             IEnumerable<T> second,
             Func<T, TKey> keySelector)
         {
-            return OrderedMerge(first, second, keySelector, Identity<T>, Identity<T>, (a, _) => a, null);
+            return OrderedMerge(first, second, keySelector, IdFn, IdFn, (a, _) => a, null);
         }
 
         /// <summary>

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -32,7 +32,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source)
         {
-            return source.RankBy(x => x);
+            return source.RankBy(Identity<TSource>);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource> comparer)
         {
-            return source.RankBy(x => x, comparer);
+            return source.RankBy(Identity<TSource>, comparer);
         }
 
         /// <summary>

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -32,7 +32,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source)
         {
-            return source.RankBy(Identity<TSource>);
+            return source.RankBy(IdFn);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource> comparer)
         {
-            return source.RankBy(Identity<TSource>, comparer);
+            return source.RankBy(IdFn, comparer);
         }
 
         /// <summary>

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -50,7 +50,7 @@ namespace MoreLinq
         public static IEnumerable<IEnumerable<TSource>> Split<TSource>(this IEnumerable<TSource> source,
             TSource separator, int count)
         {
-            return Split(source, separator, count, s => s);
+            return Split(source, separator, count, IdFn);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace MoreLinq
         public static IEnumerable<IEnumerable<TSource>> Split<TSource>(this IEnumerable<TSource> source,
             TSource separator, IEqualityComparer<TSource>? comparer, int count)
         {
-            return Split(source, separator, comparer, count, s => s);
+            return Split(source, separator, comparer, count, IdFn);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace MoreLinq
         public static IEnumerable<IEnumerable<TSource>> Split<TSource>(this IEnumerable<TSource> source,
             Func<TSource, bool> separatorFunc, int count)
         {
-            return Split(source, separatorFunc, count, s => s);
+            return Split(source, separatorFunc, count, IdFn);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, the C# compiler does not de-dupe methods, including identity methods, such as `x => x`. This means each instance of `x => x` is compiled as a separate method; and each method must be JIT to asm separately, and must be done so for each type separately.

Adding an `Identity` method improves JIT significantly:
* Fewer methods to JIT
* Since these methods are generic, they have to be JITted separately for each type; Identity<T> can share the JITted versions across multiple call sites

Until .net7.0 + tiered PGO, these methods will not get inlined because they are accessed via delegate. This means they also take additional space in memory due to the translated code.