### PR TITLE
`ScanBy`: Update docs

### DIFF
--- a/MoreLinq.Test/ScanByTest.cs
+++ b/MoreLinq.Test/ScanByTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;
@@ -48,10 +50,10 @@ namespace MoreLinq.Test
             };
 
             var result =
-                    source.ScanBy(
-                        item => item.First(),
-                        key => (Element: default(string), Key: key, State: key - 1),
-                        (state, key, item) => (item, char.ToUpperInvariant(key), state.State + 1));
+                source.ScanBy(
+                    item => item.First(),
+                    key => (Element: string.Empty, Key: key, State: key - 1),
+                    (state, key, item) => (item, char.ToUpperInvariant(key), state.State + 1));
 
             result.AssertSequenceEqual(
                KeyValuePair.Create('a', ("ana",     'A', 97)),
@@ -103,31 +105,31 @@ namespace MoreLinq.Test
             var result = source.ScanBy(c => c, _ => -1, (i, _, _) => i + 1);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("foo"       , 0),
-                KeyValuePair.Create((string)null, 0),
-                KeyValuePair.Create("bar"       , 0),
-                KeyValuePair.Create("baz"       , 0),
-                KeyValuePair.Create((string)null, 1),
-                KeyValuePair.Create((string)null, 2),
-                KeyValuePair.Create("baz"       , 1),
-                KeyValuePair.Create("bar"       , 1),
-                KeyValuePair.Create((string)null, 3),
-                KeyValuePair.Create("foo"       , 1));
+                KeyValuePair.Create<string?, int>("foo", 0),
+                KeyValuePair.Create<string?, int>(null , 0),
+                KeyValuePair.Create<string?, int>("bar", 0),
+                KeyValuePair.Create<string?, int>("baz", 0),
+                KeyValuePair.Create<string?, int>(null , 1),
+                KeyValuePair.Create<string?, int>(null , 2),
+                KeyValuePair.Create<string?, int>("baz", 1),
+                KeyValuePair.Create<string?, int>("bar", 1),
+                KeyValuePair.Create<string?, int>(null , 3),
+                KeyValuePair.Create<string?, int>("foo", 1));
         }
 
         [Test]
         public void ScanByWithNullSeed()
         {
-            var nil = (object)null;
+            var nil = (object?)null;
             var source = new[] { "foo", null, "bar", null, "baz" };
             var result = source.ScanBy(c => c, _ => nil, (_, _, _) => nil);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("foo"       , nil),
-                KeyValuePair.Create((string)null, nil),
-                KeyValuePair.Create("bar"       , nil),
-                KeyValuePair.Create((string)null, nil),
-                KeyValuePair.Create("baz"       , nil));
+                KeyValuePair.Create<string?, object?>("foo", nil),
+                KeyValuePair.Create<string?, object?>(null , nil),
+                KeyValuePair.Create<string?, object?>("bar", nil),
+                KeyValuePair.Create<string?, object?>(null , nil),
+                KeyValuePair.Create<string?, object?>("baz", nil));
         }
 
         [Test]

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4917,8 +4917,8 @@ namespace MoreLinq.Extensions
     public static partial class ScanByExtension
     {
         /// <summary>
-        /// Applies an accumulator function over sequence element keys,
-        /// returning the keys along with intermediate accumulator states.
+        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
+        /// accumulator states.
         /// </summary>
         /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -4927,17 +4927,18 @@ namespace MoreLinq.Extensions
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is
-        /// invoked once per key encountered.</param>
+        /// A function to determine the initial value for the accumulator that is invoked once per key
+        /// encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
+        /// name="accumulator"/> is <see langword="null"/>.
+        /// </exception>
+
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -4946,9 +4947,8 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.ScanBy(source, keySelector, seedSelector, accumulator);
 
         /// <summary>
-        /// Applies an accumulator function over sequence element keys,
-        /// returning the keys along with intermediate accumulator states. An
-        /// additional parameter specifies the comparer to use to compare keys.
+        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
+        /// accumulator states. An additional parameter specifies the comparer to use to compare keys.
         /// </summary>
         /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -4957,20 +4957,20 @@ namespace MoreLinq.Extensions
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is
-        /// invoked once per key encountered.</param>
+        /// A function to determine the initial value for the accumulator that is invoked once per key
+        /// encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
-        /// <param name="comparer">The equality comparer to use to determine
-        /// whether or not keys are equal. If <c>null</c>, the default equality
-        /// comparer for <typeparamref name="TSource"/> is used.</param>
+        /// <param name="comparer">The equality comparer to use to determine whether or not keys are equal. If <see
+        /// langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
+        /// name="accumulator"/> is <see langword="null"/>.
+        /// </exception>
+
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4917,26 +4917,28 @@ namespace MoreLinq.Extensions
     public static partial class ScanByExtension
     {
         /// <summary>
-        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
-        /// accumulator states.
+        /// Applies an accumulator function over sequence element keys,
+        /// returning the keys along with intermediate accumulator states.
         /// </summary>
-        /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
+        /// <typeparam name="TSource">Type of the elements of the source
+        /// sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TState">Type of the state.</typeparam>
         /// <param name="source">The source sequence.</param>
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is invoked once per key
-        /// encountered.</param>
+        /// A function to determine the initial value for the accumulator that
+        /// is invoked once per key encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
-        /// name="accumulator"/> is <see langword="null"/>.
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref
+        /// name="seedSelector"/>, or <paramref name="accumulator"/> is <see
+        /// langword="null"/>.
         /// </exception>
 
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
@@ -4947,28 +4949,32 @@ namespace MoreLinq.Extensions
             => MoreEnumerable.ScanBy(source, keySelector, seedSelector, accumulator);
 
         /// <summary>
-        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
-        /// accumulator states. An additional parameter specifies the comparer to use to compare keys.
+        /// Applies an accumulator function over sequence element keys,
+        /// returning the keys along with intermediate accumulator states. An
+        /// additional parameter specifies the comparer to use to compare keys.
         /// </summary>
-        /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
+        /// <typeparam name="TSource">Type of the elements of the source
+        /// sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TState">Type of the state.</typeparam>
         /// <param name="source">The source sequence.</param>
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is invoked once per key
-        /// encountered.</param>
+        /// A function to determine the initial value for the accumulator that
+        /// is invoked once per key encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
-        /// <param name="comparer">The equality comparer to use to determine whether or not keys are equal. If <see
-        /// langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.</param>
+        /// <param name="comparer">The equality comparer to use to determine
+        /// whether or not keys are equal. If <see langword="null"/>, <see
+        /// cref="EqualityComparer{T}.Default"/> is used.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
-        /// name="accumulator"/> is <see langword="null"/>.
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref
+        /// name="seedSelector"/>, or <paramref name="accumulator"/> is <see
+        /// langword="null"/>.
         /// </exception>
 
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4934,7 +4934,10 @@ namespace MoreLinq.Extensions
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -4964,7 +4967,10 @@ namespace MoreLinq.Extensions
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -23,26 +23,28 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
-        /// accumulator states.
+        /// Applies an accumulator function over sequence element keys,
+        /// returning the keys along with intermediate accumulator states.
         /// </summary>
-        /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
+        /// <typeparam name="TSource">Type of the elements of the source
+        /// sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TState">Type of the state.</typeparam>
         /// <param name="source">The source sequence.</param>
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is invoked once per key
-        /// encountered.</param>
+        /// A function to determine the initial value for the accumulator that
+        /// is invoked once per key encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
-        /// name="accumulator"/> is <see langword="null"/>.
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref
+        /// name="seedSelector"/>, or <paramref name="accumulator"/> is <see
+        /// langword="null"/>.
         /// </exception>
 
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
@@ -55,28 +57,32 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
-        /// accumulator states. An additional parameter specifies the comparer to use to compare keys.
+        /// Applies an accumulator function over sequence element keys,
+        /// returning the keys along with intermediate accumulator states. An
+        /// additional parameter specifies the comparer to use to compare keys.
         /// </summary>
-        /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
+        /// <typeparam name="TSource">Type of the elements of the source
+        /// sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TState">Type of the state.</typeparam>
         /// <param name="source">The source sequence.</param>
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is invoked once per key
-        /// encountered.</param>
+        /// A function to determine the initial value for the accumulator that
+        /// is invoked once per key encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
-        /// <param name="comparer">The equality comparer to use to determine whether or not keys are equal. If <see
-        /// langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.</param>
+        /// <param name="comparer">The equality comparer to use to determine
+        /// whether or not keys are equal. If <see langword="null"/>, <see
+        /// cref="EqualityComparer{T}.Default"/> is used.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
-        /// name="accumulator"/> is <see langword="null"/>.
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref
+        /// name="seedSelector"/>, or <paramref name="accumulator"/> is <see
+        /// langword="null"/>.
         /// </exception>
 
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
@@ -90,8 +96,6 @@ namespace MoreLinq
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
             if (seedSelector == null) throw new ArgumentNullException(nameof(seedSelector));
             if (accumulator == null) throw new ArgumentNullException(nameof(accumulator));
-
-            comparer ??= EqualityComparer<TKey>.Default;
 
             return _(comparer ?? EqualityComparer<TKey>.Default);
 

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -40,14 +40,17 @@ namespace MoreLinq
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TKey, TState> seedSelector,
             Func<TState, TKey, TSource, TState> accumulator)
         {
-            return source.ScanBy(keySelector, seedSelector, accumulator, null);
+            return source.ScanBy(keySelector, seedSelector, accumulator, comparer: null);
         }
 
         /// <summary>
@@ -72,7 +75,10 @@ namespace MoreLinq
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -85,9 +91,16 @@ namespace MoreLinq
             if (seedSelector == null) throw new ArgumentNullException(nameof(seedSelector));
             if (accumulator == null) throw new ArgumentNullException(nameof(accumulator));
 
-            return _(comparer ?? EqualityComparer<TKey>.Default);
+            comparer ??= EqualityComparer<TKey>.Default;
 
-            IEnumerable<KeyValuePair<TKey, TState>> _(IEqualityComparer<TKey> comparer)
+            return _(source, keySelector, seedSelector, accumulator, comparer);
+
+            static IEnumerable<KeyValuePair<TKey, TState>> _(
+                IEnumerable<TSource> source,
+                Func<TSource, TKey> keySelector,
+                Func<TKey, TState> seedSelector,
+                Func<TState, TKey, TSource, TState> accumulator,
+                IEqualityComparer<TKey> comparer)
             {
                 var stateByKey = new Collections.Dictionary<TKey, TState>(comparer);
 

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -23,8 +23,8 @@ namespace MoreLinq
     static partial class MoreEnumerable
     {
         /// <summary>
-        /// Applies an accumulator function over sequence element keys,
-        /// returning the keys along with intermediate accumulator states.
+        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
+        /// accumulator states.
         /// </summary>
         /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -33,17 +33,18 @@ namespace MoreLinq
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is
-        /// invoked once per key encountered.</param>
+        /// A function to determine the initial value for the accumulator that is invoked once per key
+        /// encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
+        /// name="accumulator"/> is <see langword="null"/>.
+        /// </exception>
+
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -54,9 +55,8 @@ namespace MoreLinq
         }
 
         /// <summary>
-        /// Applies an accumulator function over sequence element keys,
-        /// returning the keys along with intermediate accumulator states. An
-        /// additional parameter specifies the comparer to use to compare keys.
+        /// Applies an accumulator function over sequence element keys, returning the keys along with intermediate
+        /// accumulator states. An additional parameter specifies the comparer to use to compare keys.
         /// </summary>
         /// <typeparam name="TSource">Type of the elements of the source sequence.</typeparam>
         /// <typeparam name="TKey">The type of the key.</typeparam>
@@ -65,20 +65,20 @@ namespace MoreLinq
         /// <param name="keySelector">
         /// A function that returns the key given an element.</param>
         /// <param name="seedSelector">
-        /// A function to determine the initial value for the accumulator that is
-        /// invoked once per key encountered.</param>
+        /// A function to determine the initial value for the accumulator that is invoked once per key
+        /// encountered.</param>
         /// <param name="accumulator">
         /// An accumulator function invoked for each element.</param>
-        /// <param name="comparer">The equality comparer to use to determine
-        /// whether or not keys are equal. If <c>null</c>, the default equality
-        /// comparer for <typeparamref name="TSource"/> is used.</param>
+        /// <param name="comparer">The equality comparer to use to determine whether or not keys are equal. If <see
+        /// langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.</param>
         /// <returns>
         /// A sequence of keys paired with intermediate accumulator states.
         /// </returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="seedSelector"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="accumulator"/> is null</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="source"/>, <paramref name="keySelector"/>, <paramref name="seedSelector"/>, or <paramref
+        /// name="accumulator"/> is <see langword="null"/>.
+        /// </exception>
+
         public static IEnumerable<KeyValuePair<TKey, TState>> ScanBy<TSource, TKey, TState>(
             this IEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
@@ -93,14 +93,9 @@ namespace MoreLinq
 
             comparer ??= EqualityComparer<TKey>.Default;
 
-            return _(source, keySelector, seedSelector, accumulator, comparer);
+            return _(comparer ?? EqualityComparer<TKey>.Default);
 
-            static IEnumerable<KeyValuePair<TKey, TState>> _(
-                IEnumerable<TSource> source,
-                Func<TSource, TKey> keySelector,
-                Func<TKey, TState> seedSelector,
-                Func<TState, TKey, TSource, TState> accumulator,
-                IEqualityComparer<TKey> comparer)
+            IEnumerable<KeyValuePair<TKey, TState>> _(IEqualityComparer<TKey> comparer)
             {
                 var stateByKey = new Collections.Dictionary<TKey, TState>(comparer);
 


### PR DESCRIPTION
This PR adds to https://github.com/morelinq/MoreLINQ/issues/803. It updates documentation. `ScanBy` does not need other changes to address nullability documentation. 