### PR TITLE
PartialSort: #nullable enable on tests

### DIFF
--- a/MoreLinq.Test/PartialSortByTest.cs
+++ b/MoreLinq.Test/PartialSortByTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;


### PR DESCRIPTION
This PR is for #803. There are no nullability changes required for `.PartialSort()`