### PR TITLE
Replace null-forgiving operator uses with debug assertions

### DIFF
--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -60,5 +60,13 @@ namespace MoreLinq.Test
             Assert.AreSame(source.FallbackIfEmpty(fallback), fallback);
             Assert.AreSame(source.FallbackIfEmpty(fallback.AsEnumerable()), fallback);
         }
+
+        [Test]
+        public void FallbackIfEmptyWithEmptyNullableSequence()
+        {
+            var source = Enumerable.Empty<int?>().Select(x => x);
+            var fallback = (int?)null;
+            source.FallbackIfEmpty(fallback).AssertSequenceEqual(fallback);
+        }
     }
 }

--- a/MoreLinq/Assume.cs
+++ b/MoreLinq/Assume.cs
@@ -1,0 +1,31 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2022 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System.Runtime.CompilerServices;
+
+    static class Assume
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T NotNull<T>(T? obj) where T : class
+        {
+            Debug.Assert(obj is not null);
+            return obj;
+        }
+    }
+}

--- a/MoreLinq/Debug.cs
+++ b/MoreLinq/Debug.cs
@@ -1,0 +1,31 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2022 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
+
+    static class Debug
+    {
+        [Conditional("DEBUG")]
+        public static void Assert([DoesNotReturnIf(false)] bool condition,
+                                  [CallerArgumentExpression(nameof(condition))] string? message = null) =>
+            System.Diagnostics.Debug.Assert(condition);
+    }
+}

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -23,7 +23,6 @@ namespace MoreLinq.Experimental
     using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Runtime.ExceptionServices;
     using System.Threading;
@@ -538,7 +537,8 @@ namespace MoreLinq.Experimental
 
                         if (kind == Notice.Error)
                         {
-                            error!.Throw();
+                            Debug.Assert(error is not null);
+                            error.Throw();
                         }
 
                         if (kind == Notice.End)

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -527,19 +527,15 @@ namespace MoreLinq.Experimental
                         catch (OperationCanceledException e) when (e.CancellationToken == consumerCancellationTokenSource.Token)
                         {
                             var (error1, error2) = lastCriticalErrors;
-                            Debug.Assert(error1 is not null);
                             throw new Exception("One or more critical errors have occurred.",
-                                error2 != null ? new AggregateException(error1, error2)
-                                               : new AggregateException(error1));
+                                error2 != null ? new AggregateException(Assume.NotNull(error1), error2)
+                                               : new AggregateException(Assume.NotNull(error1)));
                         }
 
                         var (kind, result, error) = notice.Current;
 
                         if (kind == Notice.Error)
-                        {
-                            Debug.Assert(error is not null);
-                            error.Throw();
-                        }
+                            Assume.NotNull(error).Throw();
 
                         if (kind == Notice.End)
                             break;

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -115,10 +115,7 @@ namespace MoreLinq.Experimental
                         if (index >= _cache.Count)
                         {
                             if (index == _errorIndex)
-                            {
-                                Debug.Assert(_error is not null);
-                                _error.Throw();
-                            }
+                                Assume.NotNull(_error).Throw();
 
                             if (_sourceEnumerator == null)
                                 break;

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -116,7 +116,8 @@ namespace MoreLinq.Experimental
                         {
                             if (index == _errorIndex)
                             {
-                                _error!.Throw();
+                                Debug.Assert(_error is not null);
+                                _error.Throw();
                             }
 
                             if (_sourceEnumerator == null)

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
 
     static partial class MoreEnumerable
     {
@@ -190,10 +189,26 @@ namespace MoreLinq
                 {
                     Debug.Assert(count is >= 1 and <= 4);
 
-                    yield return fallback1!;
-                    if (count > 1) yield return fallback2!;
-                    if (count > 2) yield return fallback3!;
-                    if (count > 3) yield return fallback4!;
+                    Debug.Assert(fallback1 is not null);
+                    yield return fallback1;
+
+                    if (count > 1)
+                    {
+                        Debug.Assert(fallback2 is not null);
+                        yield return fallback2;
+                    }
+
+                    if (count > 2)
+                    {
+                        Debug.Assert(fallback3 is not null);
+                        yield return fallback3;
+                    }
+
+                    if (count > 3)
+                    {
+                        Debug.Assert(fallback4 is not null);
+                        yield return fallback4;
+                    }
                 }
             }
         }

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -189,26 +189,10 @@ namespace MoreLinq
                 {
                     Debug.Assert(count is >= 1 and <= 4);
 
-                    Debug.Assert(fallback1 is not null);
-                    yield return fallback1;
-
-                    if (count > 1)
-                    {
-                        Debug.Assert(fallback2 is not null);
-                        yield return fallback2;
-                    }
-
-                    if (count > 2)
-                    {
-                        Debug.Assert(fallback3 is not null);
-                        yield return fallback3;
-                    }
-
-                    if (count > 3)
-                    {
-                        Debug.Assert(fallback4 is not null);
-                        yield return fallback4;
-                    }
+                    yield return fallback1!;
+                    if (count > 1) yield return fallback2!;
+                    if (count > 2) yield return fallback3!;
+                    if (count > 3) yield return fallback4!;
                 }
             }
         }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -67,59 +67,26 @@ namespace MoreLinq
             foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
                 elements[e.Key] = e.Value;
 
-            switch (count)
+            return count switch
             {
-                case 1:
-                    Debug.Assert(folder1  is not null);
-                    return folder1(elements[0]);
-                case 2:
-                    Debug.Assert(folder2  is not null);
-                    return folder2(elements[0], elements[1]);
-                case 3:
-                    Debug.Assert(folder3  is not null);
-                    return folder3(elements[0], elements[1], elements[2]);
-                case 4:
-                    Debug.Assert(folder4  is not null);
-                    return folder4(elements[0], elements[1], elements[2], elements[3]);
-                case 5:
-                    Debug.Assert(folder5  is not null);
-                    return folder5(elements[0], elements[1], elements[2], elements[3], elements[4]);
-                case 6:
-                    Debug.Assert(folder6  is not null);
-                    return folder6(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
-                case 7:
-                    Debug.Assert(folder7  is not null);
-                    return folder7(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
-                case 8:
-                    Debug.Assert(folder8  is not null);
-                    return folder8(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
-                case 9:
-                    Debug.Assert(folder9  is not null);
-                    return folder9(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
-                case 10:
-                    Debug.Assert(folder10 is not null);
-                    return folder10(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
-                case 11:
-                    Debug.Assert(folder11 is not null);
-                    return folder11(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
-                case 12:
-                    Debug.Assert(folder12 is not null);
-                    return folder12(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
-                case 13:
-                    Debug.Assert(folder13 is not null);
-                    return folder13(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
-                case 14:
-                    Debug.Assert(folder14 is not null);
-                    return folder14(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
-                case 15:
-                    Debug.Assert(folder15 is not null);
-                    return folder15(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
-                case 16:
-                    Debug.Assert(folder16 is not null);
-                    return folder16(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
-                default:
-                    throw new NotSupportedException();
-            }
+                 1 => Assume.NotNull(folder1 )(elements[0]),
+                 2 => Assume.NotNull(folder2 )(elements[0], elements[1]),
+                 3 => Assume.NotNull(folder3 )(elements[0], elements[1], elements[2]),
+                 4 => Assume.NotNull(folder4 )(elements[0], elements[1], elements[2], elements[3]),
+                 5 => Assume.NotNull(folder5 )(elements[0], elements[1], elements[2], elements[3], elements[4]),
+                 6 => Assume.NotNull(folder6 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]),
+                 7 => Assume.NotNull(folder7 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]),
+                 8 => Assume.NotNull(folder8 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]),
+                 9 => Assume.NotNull(folder9 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]),
+                10 => Assume.NotNull(folder10)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]),
+                11 => Assume.NotNull(folder11)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]),
+                12 => Assume.NotNull(folder12)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]),
+                13 => Assume.NotNull(folder13)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]),
+                14 => Assume.NotNull(folder14)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]),
+                15 => Assume.NotNull(folder15)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]),
+                16 => Assume.NotNull(folder16)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]),
+                _ => throw new NotSupportedException()
+            };
         }
 
         static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -67,26 +67,59 @@ namespace MoreLinq
             foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
                 elements[e.Key] = e.Value;
 
-            return count switch
+            switch (count)
             {
-                 1 => folder1 !(elements[0]),
-                 2 => folder2 !(elements[0], elements[1]),
-                 3 => folder3 !(elements[0], elements[1], elements[2]),
-                 4 => folder4 !(elements[0], elements[1], elements[2], elements[3]),
-                 5 => folder5 !(elements[0], elements[1], elements[2], elements[3], elements[4]),
-                 6 => folder6 !(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]),
-                 7 => folder7 !(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]),
-                 8 => folder8 !(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]),
-                 9 => folder9 !(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]),
-                10 => folder10!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]),
-                11 => folder11!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]),
-                12 => folder12!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]),
-                13 => folder13!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]),
-                14 => folder14!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]),
-                15 => folder15!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]),
-                16 => folder16!(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]),
-                _ => throw new NotSupportedException()
-            };
+                case 1:
+                    Debug.Assert(folder1  is not null);
+                    return folder1(elements[0]);
+                case 2:
+                    Debug.Assert(folder2  is not null);
+                    return folder2(elements[0], elements[1]);
+                case 3:
+                    Debug.Assert(folder3  is not null);
+                    return folder3(elements[0], elements[1], elements[2]);
+                case 4:
+                    Debug.Assert(folder4  is not null);
+                    return folder4(elements[0], elements[1], elements[2], elements[3]);
+                case 5:
+                    Debug.Assert(folder5  is not null);
+                    return folder5(elements[0], elements[1], elements[2], elements[3], elements[4]);
+                case 6:
+                    Debug.Assert(folder6  is not null);
+                    return folder6(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
+                case 7:
+                    Debug.Assert(folder7  is not null);
+                    return folder7(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
+                case 8:
+                    Debug.Assert(folder8  is not null);
+                    return folder8(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
+                case 9:
+                    Debug.Assert(folder9  is not null);
+                    return folder9(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
+                case 10:
+                    Debug.Assert(folder10 is not null);
+                    return folder10(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
+                case 11:
+                    Debug.Assert(folder11 is not null);
+                    return folder11(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
+                case 12:
+                    Debug.Assert(folder12 is not null);
+                    return folder12(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
+                case 13:
+                    Debug.Assert(folder13 is not null);
+                    return folder13(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
+                case 14:
+                    Debug.Assert(folder14 is not null);
+                    return folder14(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
+                case 15:
+                    Debug.Assert(folder15 is not null);
+                    return folder15(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
+                case 16:
+                    Debug.Assert(folder16 is not null);
+                    return folder16(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
+                default:
+                    throw new NotSupportedException();
+            }
         }
 
         static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -60,8 +60,7 @@ namespace MoreLinq
 
             foreach (var item in source)
             {
-                var grouping = lookup.GetGrouping(keySelector(item), create: true);
-                Debug.Assert(grouping is not null);
+                var grouping = Assume.NotNull(lookup.GetGrouping(keySelector(item), create: true));
                 grouping.Add(elementSelector(item));
             }
 
@@ -77,8 +76,7 @@ namespace MoreLinq
 
             foreach (var item in source)
             {
-                var grouping = lookup.GetGrouping(keySelector(item), create: true);
-                Debug.Assert(grouping is not null);
+                var grouping = Assume.NotNull(lookup.GetGrouping(keySelector(item), create: true));
                 grouping.Add(item);
             }
 
@@ -93,8 +91,7 @@ namespace MoreLinq
             {
                 if (keySelector(item) is { } key)
                 {
-                    var grouping = lookup.GetGrouping(key, create: true);
-                    Debug.Assert(grouping is not null);
+                    var grouping = Assume.NotNull(lookup.GetGrouping(key, create: true));
                     grouping.Add(item);
                 }
             }
@@ -128,9 +125,7 @@ namespace MoreLinq
             {
                 do
                 {
-                    g = g._next;
-
-                    Debug.Assert(g is not null);
+                    g = Assume.NotNull(g._next);
                     yield return g;
                 }
                 while (g != _lastGrouping);
@@ -185,12 +180,10 @@ namespace MoreLinq
         {
             var newSize = checked((_count * 2) + 1);
             var newGroupings = new Grouping<TKey, TElement>[newSize];
-            var g = _lastGrouping;
-            Debug.Assert(g is not null);
+            var g = Assume.NotNull(_lastGrouping);
             do
             {
-                g = g._next;
-                Debug.Assert(g is not null);
+                g = Assume.NotNull(g._next);
                 var index = g._hashCode % newSize;
                 g._hashNext = newGroupings[index];
                 newGroupings[index] = g;

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -24,12 +24,6 @@
 // SOFTWARE.
 #endregion
 
-#if !NET6_0_OR_GREATER
-#nullable enable annotations
-#pragma warning disable 8602 // Dereference of a possibly null reference.
-#pragma warning disable 8603 // Possible null reference return.
-#endif
-
 namespace MoreLinq
 {
     using System;
@@ -65,7 +59,11 @@ namespace MoreLinq
             var lookup = new Lookup<TKey, TElement>(comparer);
 
             foreach (var item in source)
-                lookup.GetGrouping(keySelector(item), create: true)!.Add(elementSelector(item));
+            {
+                var grouping = lookup.GetGrouping(keySelector(item), create: true);
+                Debug.Assert(grouping is not null);
+                grouping.Add(elementSelector(item));
+            }
 
             return lookup;
         }
@@ -78,7 +76,11 @@ namespace MoreLinq
             var lookup = new Lookup<TKey, TElement>(comparer);
 
             foreach (var item in source)
-                lookup.GetGrouping(keySelector(item), create: true)!.Add(item);
+            {
+                var grouping = lookup.GetGrouping(keySelector(item), create: true);
+                Debug.Assert(grouping is not null);
+                grouping.Add(item);
+            }
 
             return lookup;
         }
@@ -90,7 +92,11 @@ namespace MoreLinq
             foreach (var item in source)
             {
                 if (keySelector(item) is { } key)
-                    lookup.GetGrouping(key, create: true)!.Add(item);
+                {
+                    var grouping = lookup.GetGrouping(key, create: true);
+                    Debug.Assert(grouping is not null);
+                    grouping.Add(item);
+                }
             }
 
             return lookup;
@@ -179,10 +185,12 @@ namespace MoreLinq
         {
             var newSize = checked((_count * 2) + 1);
             var newGroupings = new Grouping<TKey, TElement>[newSize];
-            var g = _lastGrouping!;
+            var g = _lastGrouping;
+            Debug.Assert(g is not null);
             do
             {
-                g = g._next!;
+                g = g._next;
+                Debug.Assert(g is not null);
                 var index = g._hashCode % newSize;
                 g._hashNext = newGroupings[index];
                 newGroupings[index] = g;

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
 
     static partial class MoreEnumerable
     {

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -242,7 +242,8 @@ namespace MoreLinq
             {
                 if (keys != null)
                 {
-                    var key = keySelector!(item);
+                    Debug.Assert(keySelector is not null);
+                    var key = keySelector(item);
                     if (Insert(keys, key, keyComparer) is {} i)
                     {
                         if (top.Count == count)

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -242,8 +242,7 @@ namespace MoreLinq
             {
                 if (keys != null)
                 {
-                    Debug.Assert(keySelector is not null);
-                    var key = keySelector(item);
+                    var key = Assume.NotNull(keySelector)(item);
                     if (Insert(keys, key, keyComparer) is {} i)
                     {
                         if (top.Count == count)

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
 
     static partial class MoreEnumerable

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -116,12 +116,12 @@ namespace MoreLinq.Reactive
         }
 
         public void OnError(Exception error) =>
-            OnFinality(ref _error, error, (observer, err) => observer.OnError(err!));
+            OnFinality(ref _error, error, (observer, err) => observer.OnError(err));
 
         public void OnCompleted() =>
             OnFinality(ref _completed, true, (observer, _) => observer.OnCompleted());
 
-        void OnFinality<TState>(ref TState state, TState value, Action<IObserver<T>, TState> action)
+        void OnFinality<TState>(ref TState? state, TState value, Action<IObserver<T>, TState> action)
         {
             if (IsMuted)
                 return;

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -116,12 +116,12 @@ namespace MoreLinq.Reactive
         }
 
         public void OnError(Exception error) =>
-            OnFinality(ref _error, error, (observer, err) => observer.OnError(err));
+            OnFinality(ref _error, error, (observer, err) => observer.OnError(err!));
 
         public void OnCompleted() =>
             OnFinality(ref _completed, true, (observer, _) => observer.OnCompleted());
 
-        void OnFinality<TState>(ref TState? state, TState value, Action<IObserver<T>, TState> action)
+        void OnFinality<TState>(ref TState state, TState value, Action<IObserver<T>, TState> action)
         {
             if (IsMuted)
                 return;


### PR DESCRIPTION
This PR introduces `Debug.Assert` that's defined similarly to [`System.Diagnostics.Debug.Assert`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.debug.assert?view=net-7.0#system-diagnostics-debug-assert(system-boolean-system-string)) to help eliminate the bulk uses of the null-forgiving operator (`!`). The assertion more explicitly states the illegal case, and if triggered, will also relay the offending condition in the message. It also eliminates needing to suppress [CS8602](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-dereference-of-null) and [CS8603](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference) in target earlier than .NET 6.

This PR also adds `Assume.NotNull`, that's a `Debug.Assert` in disguise, but which specifically asserts the not-null-reference case. The idea is to make these cases easily searchable in code.
