### PR TITLE
Fix nullability annotation in `Subject`

### DIFF
--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -116,12 +116,12 @@ namespace MoreLinq.Reactive
         }
 
         public void OnError(Exception error) =>
-            OnFinality(ref _error, error, (observer, err) => observer.OnError(err!));
+            OnFinality(ref _error, error, (observer, err) => observer.OnError(err));
 
         public void OnCompleted() =>
             OnFinality(ref _completed, true, (observer, _) => observer.OnCompleted());
 
-        void OnFinality<TState>(ref TState state, TState value, Action<IObserver<T>, TState> action)
+        void OnFinality<TState>(ref TState? state, TState value, Action<IObserver<T>, TState> action)
         {
             if (IsMuted)
                 return;


### PR DESCRIPTION
This PR fixes the nullability annotation in the private helper method of `Subject` so a null-forgiving operator is not needed at the call site.