### PR TITLE
Rewrite switch in `Memoize` as expression

### DIFF
--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -47,17 +47,15 @@ namespace MoreLinq.Experimental
         /// (though never simultaneously) may iterate over the sequence.
         /// </remarks>
 
-        public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source)
-        {
-            switch (source)
+        public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source) =>
+            source switch
             {
-                case null: throw new ArgumentNullException(nameof(source));
-                case ICollection<T>        : // ...
-                case IReadOnlyCollection<T>: // ...
-                case MemoizedEnumerable<T> : return source;
-                default: return new MemoizedEnumerable<T>(source);
-            }
-        }
+                null => throw new ArgumentNullException(nameof(source)),
+                ICollection<T> => source,
+                IReadOnlyCollection<T> => source,
+                MemoizedEnumerable<T> => source,
+                _ => new MemoizedEnumerable<T>(source),
+            };
     }
 
     sealed class MemoizedEnumerable<T> : IEnumerable<T>, IDisposable


### PR DESCRIPTION
~This PR is for https://github.com/morelinq/MoreLINQ/issues/803.~ It updates to use the new switch expression for the operator.