### PR TITLE
Add null check for `Partition`

### DIFF
--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -79,6 +79,8 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
             return source.GroupBy(predicate).Partition(resultSelector);
         }
 


### PR DESCRIPTION
This introduces a null-check in order to fail-fast on a `null` `resultSelector` value.