### PR TITLE
Fix `Memoize` Implementation

### DIFF
--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -154,10 +154,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestEmptyCartesianEvaluation()
         {
-            using var sequence = Enumerable.Range(0, 5).AsTestingSequence();
-
-            var resultA = sequence.Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
-            var resultB = Enumerable.Empty<int>().Cartesian(sequence, (a, b) => new { A = a, B = b });
+            var resultA = Enumerable.Range(0, 5).AsTestingSequence().Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
+            var resultB = Enumerable.Empty<int>().Cartesian(Enumerable.Range(0, 5).AsTestingSequence(), (a, b) => new { A = a, B = b });
             var resultC = Enumerable.Empty<int>().Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
 
             Assert.AreEqual(0, resultA.Count());

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -69,14 +69,11 @@ namespace MoreLinq.Test
             _disposed = false;
             enumerator.Disposed += delegate
             {
-                Assert.That(_disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
                 _disposed = true;
             };
-            var ended = false;
             enumerator.MoveNextCalled += (_, moved) =>
             {
-                Assert.That(ended, Is.False, "LINQ operators should not continue iterating a sequence that has terminated.");
-                ended = !moved;
+                Assert.That(_disposed, Is.False, "LINQ operators should not call MoveNext() on a disposed sequence.");
                 MoveNextCallCount++;
             };
             _sequence = null;

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -56,9 +56,9 @@ namespace MoreLinq.Experimental
             switch (source)
             {
                 case null: throw new ArgumentNullException(nameof(source));
-                case ICollection<T>: // ...
+                case ICollection<T>        : // ...
                 case IReadOnlyCollection<T>: // ...
-                case MemoizedEnumerable<T>: return source;
+                case MemoizedEnumerable<T> : return source;
                 default: return new MemoizedEnumerable<T>(source);
             }
         }


### PR DESCRIPTION
This PR does three things: 1) Correct issues in `Memoize` implementation; 2) Update tests for `Memoize` and `Cartesian` to reflect updated expectations; 3) Update `TestingSequence` with better expectations for how a testing sequence should be used.

Fixes #889 