### PR TITLE
Improve `TestingSequence` assertions

### DIFF
--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         {
             None,
             AllowMultipleEnumerations
-    }
+        }
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ namespace MoreLinq.Test
                 ended = !moved;
                 MoveNextCallCount++;
             };
-			
+
             enumerator.GetCurrentCalled += delegate
             {
                 Assert.That(_disposed, Is.False, "LINQ operators should not attempt to get the Current value on a disposed sequence.");

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         {
             None,
             AllowMultipleEnumerations
-        }
+    }
     }
 
     /// <summary>
@@ -86,15 +86,20 @@ namespace MoreLinq.Test
             _disposed = false;
             enumerator.Disposed += delegate
             {
-                Assert.That(_disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
                 _disposed = true;
             };
             var ended = false;
             enumerator.MoveNextCalled += (_, moved) =>
             {
-                Assert.That(ended, Is.False, "LINQ operators should not continue iterating a sequence that has terminated.");
+                Assert.That(_disposed, Is.False, "LINQ operators should not call MoveNext() on a disposed sequence.");
                 ended = !moved;
                 MoveNextCallCount++;
+            };
+			
+            enumerator.GetCurrentCalled += delegate
+            {
+                Assert.That(_disposed, Is.False, "LINQ operators should not attempt to get the Current value on a disposed sequence.");
+                Assert.That(ended, Is.False, "LINQ operators should not attempt to get the Current value on a completed sequence.");
             };
 
             if (!IsReiterationAllowed)

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -31,13 +31,30 @@ namespace MoreLinq.Test
         readonly IEnumerator<T> _source;
 
         public event EventHandler? Disposed;
+        public event EventHandler? GetCurrentCalled;
         public event EventHandler<bool>? MoveNextCalled;
 
         public WatchableEnumerator(IEnumerator<T> source) =>
             _source = source ?? throw new ArgumentNullException(nameof(source));
 
-        public T Current => _source.Current;
-        object? IEnumerator.Current => Current;
+        public T Current
+        {
+            get
+            {
+                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
+                return _source.Current;
+            }
+        }
+
+        object? IEnumerator.Current
+        {
+            get
+            {
+                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
+                return Current;
+            }
+        }
+
         public void Reset() => _source.Reset();
 
         public bool MoveNext()

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -46,14 +46,7 @@ namespace MoreLinq.Test
             }
         }
 
-        object? IEnumerator.Current
-        {
-            get
-            {
-                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
-                return Current;
-            }
-        }
+        object? IEnumerator.Current => this.Current;
 
         public void Reset() => _source.Reset();
 


### PR DESCRIPTION
This PR updates the assertions made in `TestingSequence`:
* Per the [specification](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose), it is not a failure to call `.Dispose()` multiple times. The `.Dispose()` method is expected to be idempotent, such that it is callable multiple times without throwing an exception. As such, we should not be afraid to take advantage of such behavior when it makes code easier.
* Per the [specification](https://learn.microsoft.com/en-us/dotnet/api/system.collections.ienumerator.movenext?view=net-7.0#remarks), it is not a failure to call `.MoveNext()` after receiving a `false` response. The enumerator is simply expected to continue to return `false` for each following call. As such, we should not be afraid to take advantage of such behavior when it makes code easier (see #905 for examples).
* While most `IEnumerator`s do not complain when calling `.MoveNext()` after disposal, it does indicate an error in our code to expect that `.MoveNext()` is a valid behavior after we have disposed the iterator. As such, we should fail directly.
* While most `IEnumerator`s return a default or the last value when calling `.Current` after `.MoveNext()` returns `false`, the spec does not make any promises on the usefulness of `.Current` in this situation. More importantly, we should be relying on `.MoveNext()` return value and not attempting to reference `.Current` in these cases. As such, we should fail directly.
* While most `IEnumerator`s do not complain when calling `.Current` after disposal, it does indicate an error in our code to expect that `.Current` is a valid behavior after we have disposed the iterator. As such, we should fail directly.