### PR TITLE
Simplify `ZipShortest` implementation

### DIFF
--- a/MoreLinq.Test/ZipShortestTest.cs
+++ b/MoreLinq.Test/ZipShortestTest.cs
@@ -74,6 +74,19 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        [TestCase(1), TestCase(2), TestCase(3), TestCase(4)]
+        public void ZipShortestEndsAtShortestSequence(int shortSequence)
+        {
+            var seq1 = Enumerable.Range(1, shortSequence == 1 ? 2 : 3);
+            var seq2 = Enumerable.Range(1, shortSequence == 2 ? 2 : 3);
+            var seq3 = Enumerable.Range(1, shortSequence == 3 ? 2 : 3);
+            var seq4 = Enumerable.Range(1, shortSequence == 4 ? 2 : 3);
+
+            var seq = seq1.ZipShortest(seq2, seq3, seq4, (a, _, _, _) => a);
+            seq.AssertSequenceEqual(1, 2);
+        }
+
+        [Test]
         public void MoveNextIsNotCalledUnnecessarilyWhenFirstIsShorter()
         {
             using var s1 = TestingSequence.Of(1, 2);


### PR DESCRIPTION
The various Zip* methods currently share implementation in `.ZipImpl()`. However, the code is simpler for each one when they are written separately; that is, in this case, the variances are more than the commonality. As such, we should allow each method to be implemented separately.

This PR updates the implementation of `ZipShortest` to be done separately from `.ZipImpl()`. 