### PR TITLE
Enable nullable context for remaining `*Zip*` tests

### DIFF
--- a/MoreLinq.Test/EquiZipTest.cs
+++ b/MoreLinq.Test/EquiZipTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/ZipShortestTest.cs
+++ b/MoreLinq.Test/ZipShortestTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;


### PR DESCRIPTION
This PR enables nullable context for tests for remaining `*Zip*` methods, namely `EquiZip` and `ZipShortest`. It adds to #803.

This was forked from unrelated changes in PR #900.
