### PR TITLE
Add NUnit.Analyzers, addressing warnings

### DIFF
--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -112,7 +112,7 @@ namespace MoreLinq.Test
         public void AssertCountWithMatchingCollectionCount()
         {
             var xs = new[] { 123, 456, 789 };
-            Assert.AreSame(xs, xs.AssertCount(3));
+            Assert.That(xs, Is.SameAs(xs.AssertCount(3)));
         }
 
         [TestCase(3, 2, "Sequence contains too many elements when exactly 2 were expected.")]
@@ -122,7 +122,7 @@ namespace MoreLinq.Test
             var xs = new int[sourceCount];
             using var enumerator = xs.AssertCount(count).GetEnumerator();
             var e = Assert.Throws<SequenceException>(() => enumerator.MoveNext());
-            Assert.AreEqual(e.Message, message);
+            Assert.That(e.Message, Is.EqualTo(message));
         }
 
         [Test]

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -57,7 +57,7 @@ namespace MoreLinq.Test
             var e =
                 Assert.Throws<ValueException>(() =>
                     new[] { 2, 4, 6, 7, 8, 9 }.Assert(n => n % 2 == 0, n => new ValueException(n)).Consume());
-            Assert.AreEqual(7, e.Value);
+            Assert.That(e.Value, Is.EqualTo(7));
         }
 
         class ValueException : Exception

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -88,7 +88,7 @@ namespace MoreLinq.Test
 
             var result = sequenceA.Cartesian(sequenceB, (a, b) => a + b);
 
-            Assert.AreEqual(expectedCount, result.Count() );
+            Assert.That(result.Count(), Is.EqualTo(expectedCount));
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace MoreLinq.Test
             var result = sequenceA.Cartesian(sequenceB, sequenceC, sequenceD, (a, b, c, d) => a + b + c + d);
 
             const int expectedCount = countA * countB * countC * countD;
-            Assert.AreEqual(expectedCount, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(expectedCount));
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace MoreLinq.Test
                             .ToArray();
 
             // verify that the expected number of results is correct
-            Assert.AreEqual(sequenceA.Count() * sequenceB.Count(), result.Count());
+            Assert.That(result.Count(), Is.EqualTo(sequenceA.Count() * sequenceB.Count()));
 
             // ensure that all "cells" were visited by the cartesian product
             foreach (var coord in result)
@@ -160,9 +160,9 @@ namespace MoreLinq.Test
             var resultB = Enumerable.Empty<int>().Cartesian(sequence, (a, b) => new { A = a, B = b });
             var resultC = Enumerable.Empty<int>().Cartesian(Enumerable.Empty<int>(), (a, b) => new { A = a, B = b });
 
-            Assert.AreEqual(0, resultA.Count());
-            Assert.AreEqual(0, resultB.Count());
-            Assert.AreEqual(0, resultC.Count());
+            Assert.That(resultA.Count(), Is.Zero);
+            Assert.That(resultB.Count(), Is.Zero);
+            Assert.That(resultC.Count(), Is.Zero);
         }
     }
 }

--- a/MoreLinq.Test/CompareCountTest.cs
+++ b/MoreLinq.Test/CompareCountTest.cs
@@ -57,8 +57,8 @@ namespace MoreLinq.Test
 
             using var seq = Enumerable.Range(0, sequenceCount).AsTestingSequence();
 
-            Assert.AreEqual(expectedCompareCount, collection.CompareCount(seq));
-            Assert.AreEqual(expectedMoveNextCallCount, seq.MoveNextCallCount);
+            Assert.That(collection.CompareCount(seq), Is.EqualTo(expectedCompareCount));
+            Assert.That(seq.MoveNextCallCount, Is.EqualTo(expectedMoveNextCallCount));
         }
 
         [TestCase(0, 0,  0, 1)]
@@ -74,8 +74,8 @@ namespace MoreLinq.Test
 
             using var seq = Enumerable.Range(0, sequenceCount).AsTestingSequence();
 
-            Assert.AreEqual(expectedCompareCount, seq.CompareCount(collection));
-            Assert.AreEqual(expectedMoveNextCallCount, seq.MoveNextCallCount);
+            Assert.That(seq.CompareCount(collection), Is.EqualTo(expectedCompareCount));
+            Assert.That(seq.MoveNextCallCount, Is.EqualTo(expectedMoveNextCallCount));
         }
 
         [TestCase(0, 0,  0, 1)]
@@ -90,9 +90,9 @@ namespace MoreLinq.Test
             using var seq1 = Enumerable.Range(0, sequenceCount1).AsTestingSequence();
             using var seq2 = Enumerable.Range(0, sequenceCount2).AsTestingSequence();
 
-            Assert.AreEqual(expectedCompareCount, seq1.CompareCount(seq2));
-            Assert.AreEqual(expectedMoveNextCallCount, seq1.MoveNextCallCount);
-            Assert.AreEqual(expectedMoveNextCallCount, seq2.MoveNextCallCount);
+            Assert.That(seq1.CompareCount(seq2), Is.EqualTo(expectedCompareCount));
+            Assert.That(seq1.MoveNextCallCount, Is.EqualTo(expectedMoveNextCallCount));
+            Assert.That(seq2.MoveNextCallCount, Is.EqualTo(expectedMoveNextCallCount));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace MoreLinq.Test
             using var seq1 = TestingSequence.Of<int>();
             using var seq2 = TestingSequence.Of<int>();
 
-            Assert.AreEqual(0, seq1.CompareCount(seq2));
+            Assert.That(seq1.CompareCount(seq2), Is.Zero);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace MoreLinq.Test
 
             using var seq = TestingSequence.Of<int>();
 
-            Assert.AreEqual(0, seq.CompareCount(collection));
+            Assert.That(seq.CompareCount(collection), Is.Zero);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace MoreLinq.Test
 
             using var seq = TestingSequence.Of<int>();
 
-            Assert.AreEqual(0, collection.CompareCount(seq));
+            Assert.That(collection.CompareCount(seq), Is.Zero);
         }
 
         [Test]
@@ -135,8 +135,8 @@ namespace MoreLinq.Test
 
             var seq2 = Enumerable.Range(1, 3);
 
-            Assert.AreEqual( 1, seq1.CompareCount(seq2));
-            Assert.AreEqual(-1, seq2.CompareCount(seq1));
+            Assert.That(seq1.CompareCount(seq2), Is.EqualTo( 1));
+            Assert.That(seq2.CompareCount(seq1), Is.EqualTo(-1));
         }
 
         enum SequenceKind

--- a/MoreLinq.Test/ConsumeTest.cs
+++ b/MoreLinq.Test/ConsumeTest.cs
@@ -28,7 +28,7 @@ namespace MoreLinq.Test
             var counter = 0;
             var sequence = Enumerable.Range(0, 10).Pipe(_ => counter++);
             sequence.Consume();
-            Assert.AreEqual(10, counter);
+            Assert.That(counter, Is.EqualTo(10));
         }
     }
 }

--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -42,12 +42,12 @@ namespace MoreLinq.Test
         {
             var source = new[] { 1 }.ToSourceKind(sourceKind);
             // ReSharper disable PossibleMultipleEnumeration
-            Assert.AreSame(source.FallbackIfEmpty(12), source);
-            Assert.AreSame(source.FallbackIfEmpty(12, 23), source);
-            Assert.AreSame(source.FallbackIfEmpty(12, 23, 34), source);
-            Assert.AreSame(source.FallbackIfEmpty(12, 23, 34, 45), source);
-            Assert.AreSame(source.FallbackIfEmpty(12, 23, 34, 45, 56), source);
-            Assert.AreSame(source.FallbackIfEmpty(12, 23, 34, 45, 56, 67), source);
+            Assert.That(source.FallbackIfEmpty(12), Is.SameAs(source));
+            Assert.That(source.FallbackIfEmpty(12, 23), Is.SameAs(source));
+            Assert.That(source.FallbackIfEmpty(12, 23, 34), Is.SameAs(source));
+            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45), Is.SameAs(source));
+            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45, 56), Is.SameAs(source));
+            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45, 56, 67), Is.SameAs(source));
             // ReSharper restore PossibleMultipleEnumeration
         }
 
@@ -57,8 +57,8 @@ namespace MoreLinq.Test
         {
             var source = new int[0].ToSourceKind(sourceKind);
             var fallback = new[] { 1 };
-            Assert.AreSame(source.FallbackIfEmpty(fallback), fallback);
-            Assert.AreSame(source.FallbackIfEmpty(fallback.AsEnumerable()), fallback);
+            Assert.That(source.FallbackIfEmpty(fallback), Is.SameAs(fallback));
+            Assert.That(source.FallbackIfEmpty(fallback.AsEnumerable()), Is.SameAs(fallback));
         }
 
         [Test]

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -48,7 +48,7 @@ namespace MoreLinq.Test
 
             var result = FullGroupJoin(overloadCase, listA, listB, x => x).ToDictionary(a => a.Key);
 
-            Assert.AreEqual(3, result.Keys.Count);
+            Assert.That(result.Keys.Count, Is.EqualTo(3));
 
             Assert.IsEmpty(result[1].Second);
             result[1].First.AssertSequenceEqual(1);
@@ -69,13 +69,13 @@ namespace MoreLinq.Test
 
             var result = FullGroupJoin(overloadCase, listA, listB, x => x).ToDictionary(a => a.Key);
 
-            Assert.AreEqual(2, result.Keys.Count);
+            Assert.That(result.Keys.Count, Is.EqualTo(2));
 
             Assert.IsEmpty(result[2].First);
-            Assert.AreEqual(2, result[2].Second.Single());
+            Assert.That(result[2].Second.Single(), Is.EqualTo(2));
 
             Assert.IsEmpty(result[3].First);
-            Assert.AreEqual(3, result[3].Second.Single());
+            Assert.That(result[3].Second.Single(), Is.EqualTo(3));
         }
 
         [TestCase(CustomResult)]
@@ -87,12 +87,12 @@ namespace MoreLinq.Test
 
             var result = FullGroupJoin(overloadCase, listA, listB, x => x).ToDictionary(a => a.Key);
 
-            Assert.AreEqual(2, result.Keys.Count);
+            Assert.That(result.Keys.Count, Is.EqualTo(2));
 
-            Assert.AreEqual(2, result[2].First.Single());
+            Assert.That(result[2].First.Single(), Is.EqualTo(2));
             Assert.IsEmpty(result[2].Second);
 
-            Assert.AreEqual(3, result[3].First.Single());
+            Assert.That(result[3].First.Single(), Is.EqualTo(3));
             Assert.IsEmpty(result[3].Second);
         }
 

--- a/MoreLinq.Test/GroupAdjacentTest.cs
+++ b/MoreLinq.Test/GroupAdjacentTest.cs
@@ -235,7 +235,7 @@ namespace MoreLinq.Test
         {
             var result = reader.Read();
             Assert.That(result, Is.Not.Null);
-            Assert.AreEqual(element, result);
+            Assert.That(result, Is.EqualTo(element));
         }
     }
 }

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -69,7 +69,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lag(lagBy, lagDefault, (_, lagVal) => lagVal);
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result.Take(lagBy), Is.EqualTo(Enumerable.Repeat(lagDefault, lagBy)));
         }
 
@@ -84,7 +84,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lag(lagBy, (_, lagVal) => lagVal);
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result.Take(lagBy), Is.EqualTo(Enumerable.Repeat(default(int), lagBy)));
         }
 
@@ -99,7 +99,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lag(count + 1, (a, _) => a);
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(sequence));
         }
 
@@ -114,7 +114,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lag(1, (a, b) => new { A = a, B = b });
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.IsTrue(result.All(x => x.B == (x.A - 1)));
         }
 
@@ -129,7 +129,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lag(2, (a, b) => new { A = a, B = b });
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.IsTrue(result.Skip(2).All(x => x.B == (x.A - 2)));
             Assert.IsTrue(result.Take(2).All(x => (x.A - x.B) == x.A));
         }

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -69,7 +69,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lead(leadBy, leadDefault, (_, leadVal) => leadVal);
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result.Skip(count - leadBy), Is.EqualTo(Enumerable.Repeat(leadDefault, leadBy)));
         }
 
@@ -84,7 +84,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lead(leadBy, (_, leadVal) => leadVal);
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result.Skip(count - leadBy), Is.EqualTo(Enumerable.Repeat(default(int), leadBy)));
         }
 
@@ -100,7 +100,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lead(count + 1, leadDefault, (val, leadVal) => new { A = val, B = leadVal });
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(sequence.Select(x => new { A = x, B = leadDefault })));
         }
 
@@ -115,7 +115,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lead(1, count + 1, (val, leadVal) => new { A = val, B = leadVal });
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.IsTrue(result.All(x => x.B == (x.A + 1)));
         }
 
@@ -131,7 +131,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.Lead(2, leadDefault, (val, leadVal) => new { A = val, B = leadVal });
 
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             Assert.IsTrue(result.Take(count - 2).All(x => x.B == (x.A + 2)));
             Assert.IsTrue(result.Skip(count - 2).All(x => x.B == leadDefault && x.A is count or count - 1));
         }

--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -34,15 +34,15 @@ namespace MoreLinq.Test
         [Test]
         public void MaxByReturnsMaxima()
         {
-            Assert.AreEqual(new[] { "hello", "world" },
-                            SampleData.Strings.MaxBy(x => x.Length));
+            Assert.That(SampleData.Strings.MaxBy(x => x.Length),
+                        Is.EqualTo(new[] { "hello", "world" }));
         }
 
         [Test]
         public void MaxByNullComparer()
         {
-            Assert.AreEqual(SampleData.Strings.MaxBy(x => x.Length),
-                            SampleData.Strings.MaxBy(x => x.Length, null));
+            Assert.That(SampleData.Strings.MaxBy(x => x.Length, null),
+                        Is.EqualTo(SampleData.Strings.MaxBy(x => x.Length)));
         }
 
         [Test]
@@ -54,13 +54,13 @@ namespace MoreLinq.Test
         [Test]
         public void MaxByWithNaturalComparer()
         {
-            Assert.AreEqual(new[] { "az" }, SampleData.Strings.MaxBy(x => x[1]));
+            Assert.That(SampleData.Strings.MaxBy(x => x[1]), Is.EqualTo(new[] { "az" }));
         }
 
         [Test]
         public void MaxByWithComparer()
         {
-            Assert.AreEqual(new[] { "aa" }, SampleData.Strings.MaxBy(x => x[1], Comparable<char>.DescendingOrderComparer));
+            Assert.That(SampleData.Strings.MaxBy(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "aa" }));
         }
 
         public class First

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -34,15 +34,15 @@ namespace MoreLinq.Test
         [Test]
         public void MinByReturnsMinima()
         {
-            Assert.AreEqual(new[] { "ax", "aa", "ab", "ay", "az" },
-                            SampleData.Strings.MinBy(x => x.Length));
+            Assert.That(SampleData.Strings.MinBy(x => x.Length),
+                        Is.EqualTo(new[] { "ax", "aa", "ab", "ay", "az" }));
         }
 
         [Test]
         public void MinByNullComparer()
         {
-            Assert.AreEqual(SampleData.Strings.MinBy(x => x.Length),
-                            SampleData.Strings.MinBy(x => x.Length, null));
+            Assert.That(SampleData.Strings.MinBy(x => x.Length, null),
+                        Is.EqualTo(SampleData.Strings.MinBy(x => x.Length)));
         }
 
         [Test]
@@ -54,13 +54,13 @@ namespace MoreLinq.Test
         [Test]
         public void MinByWithNaturalComparer()
         {
-            Assert.AreEqual(new[] { "aa" }, SampleData.Strings.MinBy(x => x[1]));
+            Assert.That(SampleData.Strings.MinBy(x => x[1]), Is.EqualTo(new[] { "aa" }));
         }
 
         [Test]
         public void MinByWithComparer()
         {
-            Assert.AreEqual(new[] { "az" }, SampleData.Strings.MinBy(x => x[1], Comparable<char>.DescendingOrderComparer));
+            Assert.That(SampleData.Strings.MinBy(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "az" }));
         }
 
         public class First

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -34,6 +34,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnitLite" Version="3.13.3" />
     <PackageReference Include="PolySharp" Version="1.7.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -89,7 +89,7 @@ namespace MoreLinq.Test
                                            };
 
             // should contain six permutations (as defined above)
-            Assert.AreEqual(expectedPermutations.Length, permutations.Count());
+            Assert.That(permutations.Count(), Is.EqualTo(expectedPermutations.Length));
             Assert.IsTrue(permutations.All(p => expectedPermutations.Contains(p, EqualityComparer.Create<IList<int>>((x, y) => x.SequenceEqual(y)))));
         }
 
@@ -132,7 +132,7 @@ namespace MoreLinq.Test
                                            };
 
             // should contain six permutations (as defined above)
-            Assert.AreEqual(expectedPermutations.Length, permutations.Count());
+            Assert.That(permutations.Count(), Is.EqualTo(expectedPermutations.Length));
             Assert.IsTrue(permutations.All(p => expectedPermutations.Contains(p, EqualityComparer.Create<IList<int>>((x, y) => x.SequenceEqual(y)))));
         }
 
@@ -159,7 +159,7 @@ namespace MoreLinq.Test
             {
                 var permutedSet = set.Permutations();
                 var permutationCount = permutedSet.Count();
-                Assert.AreEqual(Combinatorics.Factorial(set.Count()), permutationCount);
+                Assert.That(permutationCount, Is.EqualTo(Combinatorics.Factorial(set.Count())));
             }
         }
 
@@ -192,7 +192,7 @@ namespace MoreLinq.Test
                 for (var j = 1; j < listPermutations.Count; j++)
                 {
                     if (j == i) continue;
-                    Assert.AreNotSame(listPermutations[i], listPermutations[j]);
+                    Assert.That(listPermutations[i], Is.Not.SameAs(listPermutations[j]));
                 }
             }
         }

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Empty<int>();
             var result = sequence.RandomSubset(0); // we can only get subsets <= sequence.Count()
 
-            Assert.AreEqual(0, result.Count());
+            Assert.That(result.Count(), Is.Zero);
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace MoreLinq.Test
             var resultB = sequence.RandomSubset(count, new Random(12345));
 
             // ensure random subset is always a complete reordering of original sequence
-            Assert.AreEqual(count, resultA.Distinct().Count());
-            Assert.AreEqual(count, resultB.Distinct().Count());
+            Assert.That(resultA.Distinct().Count(), Is.EqualTo(count));
+            Assert.That(resultB.Distinct().Count(), Is.EqualTo(count));
         }
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace MoreLinq.Test
             var resultB = sequence.RandomSubset(subsetSize, new Random(12345));
 
             // ensure random subset is always a distinct subset of original sequence
-            Assert.AreEqual(subsetSize, resultA.Distinct().Count());
-            Assert.AreEqual(subsetSize, resultB.Distinct().Count());
+            Assert.That(resultA.Distinct().Count(), Is.EqualTo(subsetSize));
+            Assert.That(resultB.Distinct().Count(), Is.EqualTo(subsetSize));
         }
 
         /// <summary>

--- a/MoreLinq.Test/RandomTest.cs
+++ b/MoreLinq.Test/RandomTest.cs
@@ -68,8 +68,8 @@ namespace MoreLinq.Test
             var resultB = MoreEnumerable.RandomDouble(new Random()).Take(RandomTrials);
 
             // NOTE: Unclear what should actually be verified here... some additional thought needed.
-            Assert.AreEqual(RandomTrials, resultA.Count());
-            Assert.AreEqual(RandomTrials, resultB.Count());
+            Assert.That(resultA.Count(), Is.EqualTo(RandomTrials));
+            Assert.That(resultB.Count(), Is.EqualTo(RandomTrials));
             Assert.IsTrue(resultA.All(x => x is >= 0.0 and < 1.0));
             Assert.IsTrue(resultB.All(x => x is >= 0.0 and < 1.0));
         }
@@ -84,8 +84,8 @@ namespace MoreLinq.Test
             var resultA = MoreEnumerable.Random(max).Take(RandomTrials);
             var resultB = MoreEnumerable.Random(new Random(), max).Take(RandomTrials);
 
-            Assert.AreEqual(RandomTrials, resultA.Count());
-            Assert.AreEqual(RandomTrials, resultB.Count());
+            Assert.That(resultA.Count(), Is.EqualTo(RandomTrials));
+            Assert.That(resultB.Count(), Is.EqualTo(RandomTrials));
             Assert.IsTrue(resultA.All(x => x < max));
             Assert.IsTrue(resultB.All(x => x < max));
         }
@@ -101,8 +101,8 @@ namespace MoreLinq.Test
             var resultA = MoreEnumerable.Random(min, max).Take(RandomTrials);
             var resultB = MoreEnumerable.Random(new Random(), min, max).Take(RandomTrials);
 
-            Assert.AreEqual(RandomTrials, resultA.Count());
-            Assert.AreEqual(RandomTrials, resultB.Count());
+            Assert.That(resultA.Count(), Is.EqualTo(RandomTrials));
+            Assert.That(resultB.Count(), Is.EqualTo(RandomTrials));
             Assert.IsTrue(resultA.All(x => x is >= min and < max));
             Assert.IsTrue(resultB.All(x => x is >= min and < max));
         }

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -76,7 +76,7 @@ namespace MoreLinq.Test
             var result = sequence.AsTestingSequence().Rank().ToArray();
             var expectedResult = Enumerable.Range(1, count);
 
-            Assert.AreEqual(count, result.Length);
+            Assert.That(result.Length, Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(expectedResult));
         }
 
@@ -92,7 +92,7 @@ namespace MoreLinq.Test
             var result = sequence.AsTestingSequence().Rank().ToArray();
             var expectedResult = Enumerable.Range(1, count).Reverse();
 
-            Assert.AreEqual(count, result.Length);
+            Assert.That(result.Length, Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(expectedResult));
         }
 
@@ -106,7 +106,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Repeat(1234, count);
             var result = sequence.AsTestingSequence().Rank().ToArray();
 
-            Assert.AreEqual(count, result.Length);
+            Assert.That(result.Length, Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(Enumerable.Repeat(1, count)));
         }
 
@@ -122,7 +122,7 @@ namespace MoreLinq.Test
                 .Concat(Enumerable.Range(0, count));
             var result = sequence.AsTestingSequence().Rank();
 
-            Assert.AreEqual(count, result.Distinct().Count());
+            Assert.That(result.Distinct().Count(), Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(sequence.Reverse().Select(x => x + 1)));
         }
 
@@ -136,7 +136,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(1, count);
             var result = sequence.AsTestingSequence().Rank();
 
-            Assert.AreEqual(1, result.OrderBy(x => x).First());
+            Assert.That(result.OrderBy(x => x).First(), Is.EqualTo(1));
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace MoreLinq.Test
                                };
             var result = sequence.AsTestingSequence().RankBy(x => x.Age).ToArray();
 
-            Assert.AreEqual(sequence.Length, result.Length);
+            Assert.That(result.Length, Is.EqualTo(sequence.Length));
             Assert.That(result, Is.EqualTo(sequence.Select(x => x.ExpectedRank)));
         }
 

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -55,7 +55,7 @@ namespace MoreLinq.Test
         [Test]
         public void SeededScanEmpty()
         {
-            Assert.AreEqual(-1, new int[0].Scan(-1, SampleData.Plus).Single());
+            Assert.That(new int[0].Scan(-1, SampleData.Plus).Single(), Is.EqualTo(-1));
         }
 
         [Test]

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -77,7 +77,7 @@ namespace MoreLinq.Test
                 for (var i = 0; i < 2; i++)
                 {
                     Assert.IsTrue(segment.Any());
-                    Assert.AreEqual(value, segment.Single());
+                    Assert.That(segment.Single(), Is.EqualTo(value));
                 }
             }
         }
@@ -127,10 +127,10 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Repeat(1, count);
             var result = sequence.Segment((_, i) => i % segmentSize == 0);
 
-            Assert.AreEqual(count / segmentSize, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count / segmentSize));
             foreach (var segment in result)
             {
-                Assert.AreEqual(segmentSize, segment.Count());
+                Assert.That(segment.Count(), Is.EqualTo(segmentSize));
             }
         }
 
@@ -145,7 +145,7 @@ namespace MoreLinq.Test
                                      .SelectMany(x => Enumerable.Repeat(x, repCount));
             var result = sequence.Segment((curr, prev, _) => curr != prev);
 
-            Assert.AreEqual(sequence.Distinct().Count(), result.Count());
+            Assert.That(result.Count(), Is.EqualTo(sequence.Distinct().Count()));
             Assert.IsTrue(result.All(s => s.Count() == repCount));
         }
 

--- a/MoreLinq.Test/SequenceTest.cs
+++ b/MoreLinq.Test/SequenceTest.cs
@@ -124,7 +124,7 @@ namespace MoreLinq.Test
         {
             var result = MoreEnumerable.Sequence(start, stop, step);
 
-            Assert.AreEqual(result.Count(), count);
+            Assert.That(result.Count(), Is.EqualTo(count));
         }
 
         [TestCase(           5,           10)]

--- a/MoreLinq.Test/SliceTest.cs
+++ b/MoreLinq.Test/SliceTest.cs
@@ -142,7 +142,7 @@ namespace MoreLinq.Test
 
             var result = sequence.Slice(sliceStart, sliceCount);
 
-            Assert.AreEqual(sliceCount, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(sliceCount));
             CollectionAssert.AreEqual(Enumerable.Range(5, sliceCount), result);
         }
     }

--- a/MoreLinq.Test/SubsetTest.cs
+++ b/MoreLinq.Test/SubsetTest.cs
@@ -107,7 +107,7 @@ namespace MoreLinq.Test
 
             var expectedCount = Math.Pow(2, count);
 
-            Assert.AreEqual(expectedCount, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(expectedCount));
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace MoreLinq.Test
             // number of subsets of a given size is defined by the binomial coefficient: c! / ((c-s)!*s!)
             var expectedSubsetCount = Combinatorics.Binomial(count, subsetSize);
 
-            Assert.AreEqual(expectedSubsetCount, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(expectedSubsetCount));
         }
 
         /// <summary>

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -130,27 +130,27 @@ namespace MoreLinq.Test
 
             // Assert properties first, then fields, then in declaration order
 
-            Assert.AreEqual("AString", dt.Columns[0].Caption);
-            Assert.AreEqual(typeof(string), dt.Columns[0].DataType);
+            Assert.That(dt.Columns[0].Caption, Is.EqualTo("AString"));
+            Assert.That(dt.Columns[0].DataType, Is.EqualTo(typeof(string)));
 
-            Assert.AreEqual("ANullableDecimal", dt.Columns[1].Caption);
-            Assert.AreEqual(typeof(decimal), dt.Columns[1].DataType);
+            Assert.That(dt.Columns[1].Caption, Is.EqualTo("ANullableDecimal"));
+            Assert.That(dt.Columns[1].DataType, Is.EqualTo(typeof(decimal)));
 
-            Assert.AreEqual("KeyField", dt.Columns[2].Caption);
-            Assert.AreEqual(typeof(int), dt.Columns[2].DataType);
+            Assert.That(dt.Columns[2].Caption, Is.EqualTo("KeyField"));
+            Assert.That(dt.Columns[2].DataType, Is.EqualTo(typeof(int)));
 
-            Assert.AreEqual("ANullableGuidField", dt.Columns[3].Caption);
-            Assert.AreEqual(typeof(Guid), dt.Columns[3].DataType);
+            Assert.That(dt.Columns[3].Caption, Is.EqualTo("ANullableGuidField"));
+            Assert.That(dt.Columns[3].DataType, Is.EqualTo(typeof(Guid)));
             Assert.IsTrue(dt.Columns[3].AllowDBNull);
 
-            Assert.AreEqual(4, dt.Columns.Count);
+            Assert.That(dt.Columns.Count, Is.EqualTo(4));
         }
 
         [Test]
         public void ToDataTableContainsAllElements()
         {
             var dt = _testObjects.ToDataTable();
-            Assert.AreEqual(_testObjects.Count, dt.Rows.Count);
+            Assert.That(dt.Rows.Count, Is.EqualTo(_testObjects.Count));
         }
 
         [Test]
@@ -158,10 +158,10 @@ namespace MoreLinq.Test
         {
             var dt = _testObjects.ToDataTable(t => t.AString);
 
-            Assert.AreEqual("AString", dt.Columns[0].Caption);
-            Assert.AreEqual(typeof(string), dt.Columns[0].DataType);
+            Assert.That(dt.Columns[0].Caption, Is.EqualTo("AString"));
+            Assert.That(dt.Columns[0].DataType, Is.EqualTo(typeof(string)));
 
-            Assert.AreEqual(1, dt.Columns.Count);
+            Assert.That(dt.Columns.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -201,15 +201,15 @@ namespace MoreLinq.Test
         {
             var points = new[] { new Point(12, 34) }.ToDataTable();
 
-            Assert.AreEqual(3, points.Columns.Count);
+            Assert.That(points.Columns.Count, Is.EqualTo(3));
             DataColumn x, y, empty;
             Assert.NotNull(x = points.Columns["X"]);
             Assert.NotNull(y = points.Columns["Y"]);
             Assert.NotNull(empty = points.Columns["IsEmpty"]);
             var row = points.Rows.Cast<DataRow>().Single();
-            Assert.AreEqual(12, row[x]);
-            Assert.AreEqual(34, row[y]);
-            Assert.AreEqual(false, row[empty]);
+            Assert.That(row[x], Is.EqualTo(12));
+            Assert.That(row[y], Is.EqualTo(34));
+            Assert.That(row[empty], Is.False);
         }
     }
 }

--- a/MoreLinq.Test/TransposeTest.cs
+++ b/MoreLinq.Test/TransposeTest.cs
@@ -215,7 +215,7 @@ namespace MoreLinq.Test
             var resultList = result.ToList();
             var expectationList = expectation.ToList();
 
-            Assert.AreEqual(expectationList.Count, resultList.Count);
+            Assert.That(resultList.Count, Is.EqualTo(expectationList.Count));
 
             expectationList.Zip(resultList, ValueTuple.Create)
                            .ForEach(t => t.Item1.AssertSequenceEqual(t.Item2));

--- a/MoreLinq.Test/WindowTest.cs
+++ b/MoreLinq.Test/WindowTest.cs
@@ -116,11 +116,11 @@ namespace MoreLinq.Test
             var result = sequence.Window(1);
 
             // number of windows should be equal to the source sequence length
-            Assert.AreEqual(count, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count));
             // each window should contain single item consistent of element at that offset
             var index = -1;
             foreach (var window in result)
-                Assert.AreEqual(sequence.ElementAt(++index), window.Single());
+                Assert.That(window.Single(), Is.EqualTo(sequence.ElementAt(++index)));
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace MoreLinq.Test
             var result = sequence.Window(windowSize);
 
             // ensure that the number of windows is correct
-            Assert.AreEqual(count - windowSize + 1, result.Count());
+            Assert.That(result.Count(), Is.EqualTo(count - windowSize + 1));
             // ensure each window contains the correct set of items
             var index = -1;
             foreach (var window in result)


### PR DESCRIPTION
This PR addresses #909. It adds the **NUnit.Analyzers** package to the tests project and addresses the following warnings/errors:

- [NUnit2015]: Consider using `Assert.That(actual, Is.SameAs(expected))` instead of `Assert.AreSame(expected, actual)`
- [NUnit2005]: Consider using `Assert.That(actual, Is.EqualTo(expected))` instead of `Assert.AreEqual(expected, actual)`
- [NUnit2031]: Consider using `Assert.That(actual, Is.Not.SameAs(expected))` instead of `Assert.AreNotSame(expected, actual)`

[NUnit2015]: https://github.com/nunit/nunit.analyzers/blob/3.5.0/documentation/NUnit2015.md
[NUnit2005]: https://github.com/nunit/nunit.analyzers/blob/3.5.0/documentation/NUnit2005.md
[NUnit2031]: https://github.com/nunit/nunit.analyzers/blob/3.5.0/documentation/NUnit2031.md
