### PR TITLE
Fix nullability of `Rank` comparer argument

### DIFF
--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4634,7 +4634,7 @@ namespace MoreLinq.Extensions
         /// <param name="comparer">A object that defines comparison semantics for the elements in the sequence</param>
         /// <returns>A sequence of position integers representing the ranks of the corresponding items in the sequence</returns>
 
-        public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource> comparer)
+        public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource>? comparer)
             => MoreEnumerable.Rank(source, comparer);
 
     }

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -43,7 +43,7 @@ namespace MoreLinq
         /// <param name="comparer">A object that defines comparison semantics for the elements in the sequence</param>
         /// <returns>A sequence of position integers representing the ranks of the corresponding items in the sequence</returns>
 
-        public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource> comparer)
+        public static IEnumerable<int> Rank<TSource>(this IEnumerable<TSource> source, IComparer<TSource>? comparer)
         {
             return source.RankBy(IdFn, comparer);
         }


### PR DESCRIPTION
This PR adds to #803. It fixes the nullability of `comparer` argument of one of `Rank` overloads.