### PR TITLE
Fix nullability of `ToDataTable` expressions argument

### DIFF
--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable enable
+
 namespace MoreLinq.Test
 {
     using System;
@@ -51,6 +53,8 @@ namespace MoreLinq.Test
                 ANullableDecimal = key / 3;
                 AString = "ABCDEFGHIKKLMNOPQRSTUVWXYSZ";
             }
+
+            public override string ToString() => nameof(TestObject);
         }
 
 
@@ -67,9 +71,9 @@ namespace MoreLinq.Test
         [Test]
         public void ToDataTableNullMemberExpressionMethod()
         {
-            Expression<Func<TestObject, object>> expression = null;
+            Expression<Func<TestObject, object?>>? expression = null;
 
-            Assert.That(() => _testObjects.ToDataTable(expression),
+            Assert.That(() => _testObjects.ToDataTable(expression!),
                         Throws.ArgumentException("expressions"));
         }
 
@@ -177,7 +181,7 @@ namespace MoreLinq.Test
                                   .Cast<DictionaryEntry>()
                                   .ToArray();
 
-            vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value.ToString() })
+            vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value!.ToString() })
                 .ToDataTable(dt, e => e.Name, e => e.Value);
 
             var rows = dt.Rows.Cast<DataRow>().ToArray();
@@ -201,10 +205,12 @@ namespace MoreLinq.Test
             var points = new[] { new Point(12, 34) }.ToDataTable();
 
             Assert.That(points.Columns.Count, Is.EqualTo(3));
-            DataColumn x, y, empty;
-            Assert.That(x = points.Columns["X"], Is.Not.Null);
-            Assert.That(y = points.Columns["Y"], Is.Not.Null);
-            Assert.That(empty = points.Columns["IsEmpty"], Is.Not.Null);
+            var x = points.Columns["X"];
+            var y = points.Columns["Y"];
+            var empty = points.Columns["IsEmpty"];
+            Assert.That(x, Is.Not.Null);
+            Assert.That(y, Is.Not.Null);
+            Assert.That(empty, Is.Not.Null);
             var row = points.Rows.Cast<DataRow>().Single();
             Assert.That(row[x], Is.EqualTo(12));
             Assert.That(row[y], Is.EqualTo(34));

--- a/MoreLinq/Extensions.ToDataTable.g.cs
+++ b/MoreLinq/Extensions.ToDataTable.g.cs
@@ -68,7 +68,7 @@ namespace MoreLinq.Extensions
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object>>[] expressions)
+        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object?>>[] expressions)
             => MoreEnumerable.ToDataTable(source, expressions);
         /// <summary>
         /// Appends elements in the sequence as rows of a given <see cref="DataTable"/> object.
@@ -101,7 +101,7 @@ namespace MoreLinq.Extensions
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
+        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object?>>[] expressions)
             where TTable : DataTable
             => MoreEnumerable.ToDataTable(source, table, expressions);
 

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
         public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table)
             where TTable : DataTable
         {
-            return ToDataTable(source, table, EmptyArray<Expression<Func<T, object>>>.Value);
+            return ToDataTable(source, table, EmptyArray<Expression<Func<T, object?>>>.Value);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object>>[] expressions)
+        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object?>>[] expressions)
         {
             return ToDataTable(source, new DataTable(), expressions);
         }
@@ -92,7 +92,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
+        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object?>>[] expressions)
             where TTable : DataTable
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -100,7 +100,7 @@ namespace MoreLinq
 
             // TODO disallow null for "expressions" in next major update
 
-            expressions ??= EmptyArray<Expression<Func<T, object>>>.Value;
+            expressions ??= EmptyArray<Expression<Func<T, object?>>>.Value;
 
             var members = PrepareMemberInfos(expressions).ToArray();
             members = BuildOrBindSchema(table, members);
@@ -130,7 +130,7 @@ namespace MoreLinq
             return table;
         }
 
-        static IEnumerable<MemberInfo> PrepareMemberInfos<T>(ICollection<Expression<Func<T, object>>> expressions)
+        static IEnumerable<MemberInfo> PrepareMemberInfos<T>(ICollection<Expression<Func<T, object?>>> expressions)
         {
             //
             // If no lambda expressions supplied then reflect them off the source element type.


### PR DESCRIPTION
This fixes the nullability of `ToDataTable` expressions argument, adding to #803. The actual and possibly boxed return type of each expression (`object`) is not really used; the actual type of the accessed property is. As a result, there is no requirement that the property type not be nullable and in fact can be limiting. This PR allows expressions to return `object?`.

Suppose the following record:

```c#
sealed record Person
{
    public required string FirstName { get; init; }
    public string? MiddleName { get; init; }
    public required string LastName { get; init; }
}
```

Before this PR, the following will issue a nullability warning ([CS8603](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#possible-null-assigned-to-a-nonnullable-reference)) at the line marked with the comment:

```c#
var people = new[]
{
    new Person { FirstName = "John", LastName = "Doe" }
};

var dt = people.ToDataTable(p => p.FirstName,
                            p => p.MiddleName, // CS8603 - Possible null reference return
                            p => p.LastName);
```

After this PR, the warning disappears.
