### PR TITLE
Enable nullable context for entire solution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>11</LangVersion>
+    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/MoreLinq.Test/AcquireTest.cs
+++ b/MoreLinq.Test/AcquireTest.cs
@@ -26,9 +26,9 @@ namespace MoreLinq.Test
         [Test]
         public void AcquireAll()
         {
-            Disposable a = null;
-            Disposable b = null;
-            Disposable c = null;
+            Disposable? a = null;
+            Disposable? b = null;
+            Disposable? c = null;
 
             var allocators = MoreEnumerable.From(() => a = new Disposable(),
                                                  () => b = new Disposable(),
@@ -48,9 +48,9 @@ namespace MoreLinq.Test
         [Test]
         public void AcquireSome()
         {
-            Disposable a = null;
-            Disposable b = null;
-            Disposable c = null;
+            Disposable? a = null;
+            Disposable? b = null;
+            Disposable? c = null;
 
             var allocators = MoreEnumerable.From(() => a = new Disposable(),
                                                  () => b = new Disposable(),

--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -65,10 +65,11 @@ namespace MoreLinq.Test
                 AccumulatorCount   = (m.Instantiation.GetParameters().Length - 2 /* source + resultSelector */) / 2 /* seed + accumulator */,
                 ResultSelectorType = rst,
                 Parameters =
-                    rst.GetMethod("Invoke")
-                       .GetParameters()
-                       .Select(p => Expression.Parameter(p.ParameterType))
-                       .ToArray(),
+                    rst.GetMethod("Invoke") is { } invoke
+                    ? invoke.GetParameters()
+                            .Select(p => Expression.Parameter(p.ParameterType))
+                            .ToArray()
+                    : throw new Exception("""Method "Invoke" not found."""),
             }
             into m
             let resultSelector =
@@ -96,7 +97,7 @@ namespace MoreLinq.Test
             select new TestCaseData(t.Method, t.Args).SetName(t.Name).Returns(t.Expectation);
 
         [TestCaseSource(nameof(AccumulatorsTestSource), new object[] { nameof(Accumulators), 10 })]
-        public object Accumulators(MethodInfo method, object[] args) =>
+        public object? Accumulators(MethodInfo method, object[] args) =>
             method.Invoke(null, args);
 
         [Test]

--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
         public void AppendWithNullTail()
         {
             var head = new[] { "first", "second" };
-            string tail = null;
+            string? tail = null;
             var whole = head.Append(tail);
             whole.AssertSequenceEqual("first", "second", null);
         }

--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -106,7 +106,7 @@ namespace MoreLinq.Test
         [Test]
         public void AssertCountWithCollectionIsLazy()
         {
-            new BreakingCollection<object>(5).AssertCount(0);
+            new BreakingCollection<int>(new int[5]).AssertCount(0);
         }
 
         [Test]

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -49,7 +49,7 @@ namespace MoreLinq.Test
         public void AssertSequenceWithInvalidElementsAndCustomErrorReturningNull()
         {
             var source = new[] { 2, 4, 6, 7, 8, 9 };
-            Assert.That(() => source.Assert(n => n % 2 == 0, _ => null).Consume(),
+            Assert.That(() => source.Assert(n => n % 2 == 0, _ => null!).Consume(),
                         Throws.InvalidOperationException);
         }
 

--- a/MoreLinq.Test/Async/AsyncEnumerable.cs
+++ b/MoreLinq.Test/Async/AsyncEnumerable.cs
@@ -141,7 +141,7 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource> ElementAtAsync<TSource>(this IAsyncEnumerable<TSource> source, int index) =>
             LinqEnumerable.ElementAtAsync(source, index);
 
-        public static ValueTask<TSource> ElementAtOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, int index) =>
+        public static ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, int index) =>
             LinqEnumerable.ElementAtOrDefaultAsync(source, index);
 
         public static IAsyncEnumerable<TResult> Empty<TResult>() =>
@@ -159,10 +159,10 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource> FirstAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.FirstAsync(source, predicate);
 
-        public static ValueTask<TSource> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
+        public static ValueTask<TSource?> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.FirstOrDefaultAsync(source);
 
-        public static ValueTask<TSource> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static ValueTask<TSource?> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.FirstOrDefaultAsync(source, predicate);
 
         public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IAsyncEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
@@ -213,10 +213,10 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource> LastAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.LastAsync(source, predicate);
 
-        public static ValueTask<TSource> LastOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
+        public static ValueTask<TSource?> LastOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.LastOrDefaultAsync(source);
 
-        public static ValueTask<TSource> LastOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static ValueTask<TSource?> LastOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.LastOrDefaultAsync(source, predicate);
 
         public static ValueTask<long> LongCountAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
@@ -411,10 +411,10 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource> SingleAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.SingleAsync(source, predicate);
 
-        public static ValueTask<TSource> SingleOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
+        public static ValueTask<TSource?> SingleOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.SingleOrDefaultAsync(source);
 
-        public static ValueTask<TSource> SingleOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static ValueTask<TSource?> SingleOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.SingleOrDefaultAsync(source, predicate);
 
         public static IAsyncEnumerable<TSource> Skip<TSource>(this IAsyncEnumerable<TSource> source, int count) =>
@@ -510,16 +510,20 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource[]> ToArrayAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.ToArrayAsync(source);
 
-        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+            where TKey: notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector);
 
-        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            where TKey: notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, comparer);
 
-        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
+            where TKey: notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, elementSelector);
 
-        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            where TKey: notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, elementSelector, comparer);
 
         public static ValueTask<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source) =>

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -339,7 +339,7 @@ namespace MoreLinq.Test
         {
             var input = TestingSequence.Of(1, 2, 3, 4, 5, 6, 7, 8, 9);
             using var pool = new TestArrayPool<int>();
-            int[] bucketSelectorItems = null;
+            int[]? bucketSelectorItems = null;
 
             var result = input.Batch(4, pool, current => bucketSelectorItems = current.ToArray(), _ => 0);
 
@@ -356,18 +356,16 @@ namespace MoreLinq.Test
 
         sealed class TestArrayPool<T> : ArrayPool<T>, IDisposable
         {
-            T[] _pooledArray;
-            T[] _rentedArray;
+            T[]? _pooledArray;
+            T[]? _rentedArray;
 
             public override T[] Rent(int minimumLength)
             {
                 if (_pooledArray is null && _rentedArray is null)
                     _pooledArray = new T[minimumLength * 2];
 
-                if (_pooledArray is null)
-                    throw new InvalidOperationException("The pool is exhausted.");
-
-                (_pooledArray, _rentedArray) = (null, _pooledArray);
+                (_pooledArray, _rentedArray) =
+                    (null, _pooledArray ?? throw new InvalidOperationException("The pool is exhausted."));
 
                 return _rentedArray;
             }

--- a/MoreLinq.Test/BreakingCollection.cs
+++ b/MoreLinq.Test/BreakingCollection.cs
@@ -26,8 +26,6 @@ namespace MoreLinq.Test
 
         public BreakingCollection(params T[] values) : this ((IList<T>) values) {}
         public BreakingCollection(IList<T> list) => List = list;
-        public BreakingCollection(int count) :
-            this(Enumerable.Repeat(default(T), count).ToList()) {}
 
         public int Count => List.Count;
 

--- a/MoreLinq.Test/BreakingSequence.cs
+++ b/MoreLinq.Test/BreakingSequence.cs
@@ -27,7 +27,14 @@ namespace MoreLinq.Test
     /// </summary>
     class BreakingSequence<T> : IEnumerable<T>
     {
-        public IEnumerator<T> GetEnumerator() => throw new InvalidOperationException();
+        public IEnumerator<T> GetEnumerator() => throw new BreakException();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    sealed class BreakException : Exception
+    {
+        public BreakException() { }
+        public BreakException(string message) : base(message) { }
+        public BreakException(string message, Exception inner) : base(message, inner) { }
     }
 }

--- a/MoreLinq.Test/ChooseTest.cs
+++ b/MoreLinq.Test/ChooseTest.cs
@@ -67,7 +67,7 @@ namespace MoreLinq.Test
 
         static class Option<T>
         {
-            public static readonly (bool IsSome, T Value) None = (false, default);
+            public static readonly (bool IsSome, T Value) None = default;
         }
 
         [Test]

--- a/MoreLinq.Test/CompareCountTest.cs
+++ b/MoreLinq.Test/CompareCountTest.cs
@@ -53,7 +53,7 @@ namespace MoreLinq.Test
             int expectedCompareCount,
             int expectedMoveNextCallCount)
         {
-            var collection = new BreakingCollection<int>(collectionCount);
+            var collection = new BreakingCollection<int>(new int[collectionCount]);
 
             using var seq = Enumerable.Range(0, sequenceCount).AsTestingSequence();
 
@@ -70,7 +70,7 @@ namespace MoreLinq.Test
             int expectedCompareCount,
             int expectedMoveNextCallCount)
         {
-            var collection = new BreakingCollection<int>(collectionCount);
+            var collection = new BreakingCollection<int>(new int[collectionCount]);
 
             using var seq = Enumerable.Range(0, sequenceCount).AsTestingSequence();
 
@@ -107,7 +107,7 @@ namespace MoreLinq.Test
         [Test]
         public void CompareCountDisposesFirstEnumerator()
         {
-            var collection = new BreakingCollection<int>(0);
+            var collection = new BreakingCollection<int>();
 
             using var seq = TestingSequence.Of<int>();
 
@@ -117,7 +117,7 @@ namespace MoreLinq.Test
         [Test]
         public void CompareCountDisposesSecondEnumerator()
         {
-            var collection = new BreakingCollection<int>(0);
+            var collection = new BreakingCollection<int>();
 
             using var seq = TestingSequence.Of<int>();
 

--- a/MoreLinq.Test/Comparer.cs
+++ b/MoreLinq.Test/Comparer.cs
@@ -27,19 +27,19 @@ namespace MoreLinq.Test
         /// <see cref="Func{T,T,Int32}"/>.
         /// </summary>
 
-        public static IComparer<T> Create<T>(Func<T, T, int> compare) =>
+        public static IComparer<T> Create<T>(Func<T?, T?, int> compare) =>
             new DelegatingComparer<T>(compare);
 
         sealed class DelegatingComparer<T> : IComparer<T>
         {
-            readonly Func<T, T, int> _comparer;
+            readonly Func<T?, T?, int> _comparer;
 
-            public DelegatingComparer(Func<T, T, int> comparer)
+            public DelegatingComparer(Func<T?, T?, int> comparer)
             {
                 _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
             }
 
-            public int Compare(T x, T y) => _comparer(x, y);
+            public int Compare(T? x, T? y) => _comparer(x, y);
         }
     }
 }

--- a/MoreLinq.Test/CountByTest.cs
+++ b/MoreLinq.Test/CountByTest.cs
@@ -98,10 +98,10 @@ namespace MoreLinq.Test
             var result = ss.CountBy(s => s);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("foo", 2),
-                KeyValuePair.Create((string) null, 4),
-                KeyValuePair.Create("bar", 2),
-                KeyValuePair.Create("baz", 2));
+                KeyValuePair.Create((string?)"foo", 2),
+                KeyValuePair.Create((string?)null, 4),
+                KeyValuePair.Create((string?)"bar", 2),
+                KeyValuePair.Create((string?)"baz", 2));
         }
 
         [Test]
@@ -110,10 +110,10 @@ namespace MoreLinq.Test
             var result = new[] { "a", "B", null, "c", "A", null, "b", "A" }.CountBy(c => c, StringComparer.OrdinalIgnoreCase);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("a", 3),
-                KeyValuePair.Create("B", 2),
-                KeyValuePair.Create((string)null, 2),
-                KeyValuePair.Create("c", 1));
+                KeyValuePair.Create((string?)"a", 3),
+                KeyValuePair.Create((string?)"B", 2),
+                KeyValuePair.Create((string?)null, 2),
+                KeyValuePair.Create((string?)"c", 1));
         }
     }
 }

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -133,14 +133,14 @@ namespace MoreLinq.Test
         {
             public static ICollection<T>
                 Create<T>(ICollection<T> collection,
-                             Func<IEnumerator<T>, IEnumerator<T>> em = null)
+                             Func<IEnumerator<T>, IEnumerator<T>>? em = null)
             {
                 return new Collection<T>(collection, em);
             }
 
             public static IReadOnlyCollection<T>
                 CreateReadOnly<T>(ICollection<T> collection,
-                            Func<IEnumerator<T>, IEnumerator<T>> em = null)
+                            Func<IEnumerator<T>, IEnumerator<T>>? em = null)
             {
                 return new ReadOnlyCollection<T>(collection, em);
             }
@@ -154,7 +154,7 @@ namespace MoreLinq.Test
             {
                 readonly Func<IEnumerator<T>, IEnumerator<T>> _em;
 
-                protected Sequence(Func<IEnumerator<T>, IEnumerator<T>> em) =>
+                protected Sequence(Func<IEnumerator<T>, IEnumerator<T>>? em) =>
                     _em = em ?? (e => e);
 
                 public IEnumerator<T> GetEnumerator() =>
@@ -175,7 +175,7 @@ namespace MoreLinq.Test
                 readonly ICollection<T> _collection;
 
                 public Collection(ICollection<T> collection,
-                                  Func<IEnumerator<T>, IEnumerator<T>> em = null) :
+                                  Func<IEnumerator<T>, IEnumerator<T>>? em = null) :
                     base(em) =>
                     _collection = collection ?? throw new ArgumentNullException(nameof(collection));
 
@@ -202,7 +202,7 @@ namespace MoreLinq.Test
                 readonly ICollection<T> _collection;
 
                 public ReadOnlyCollection(ICollection<T> collection,
-                                          Func<IEnumerator<T>, IEnumerator<T>> em = null) :
+                                          Func<IEnumerator<T>, IEnumerator<T>>? em = null) :
                     base(em) =>
                     _collection = collection ?? throw new ArgumentNullException(nameof(collection));
 

--- a/MoreLinq.Test/Enumerable.cs
+++ b/MoreLinq.Test/Enumerable.cs
@@ -126,7 +126,7 @@ namespace MoreLinq.Test
         public static int Count<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.Count(source);
 
-        public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source) =>
+        public static IEnumerable<TSource?> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.DefaultIfEmpty(source);
 
         public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue) =>
@@ -141,7 +141,7 @@ namespace MoreLinq.Test
         public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, int index) =>
             LinqEnumerable.ElementAt(source, index);
 
-        public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index) =>
+        public static TSource? ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index) =>
             LinqEnumerable.ElementAtOrDefault(source, index);
 
         public static IEnumerable<TResult> Empty<TResult>() =>
@@ -159,10 +159,10 @@ namespace MoreLinq.Test
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.First(source, predicate);
 
-        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
+        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.FirstOrDefault(source);
 
-        public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static TSource? FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.FirstOrDefault(source, predicate);
 
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
@@ -213,10 +213,10 @@ namespace MoreLinq.Test
         public static TSource Last<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.Last(source, predicate);
 
-        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source) =>
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.LastOrDefault(source);
 
-        public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static TSource? LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.LastOrDefault(source, predicate);
 
         public static long LongCount<TSource>(this IEnumerable<TSource> source) =>
@@ -249,13 +249,13 @@ namespace MoreLinq.Test
         public static float? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector) =>
             LinqEnumerable.Max(source, selector);
 
-        public static TResult Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
+        public static TResult? Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
             LinqEnumerable.Max(source, selector);
 
         public static double? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
             LinqEnumerable.Max(source, selector);
 
-        public static TSource Max<TSource>(this IEnumerable<TSource> source) =>
+        public static TSource? Max<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.Max(source);
 
         public static float Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector) =>
@@ -303,7 +303,7 @@ namespace MoreLinq.Test
         public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector) =>
             LinqEnumerable.Min(source, selector);
 
-        public static TResult Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
+        public static TResult? Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) =>
             LinqEnumerable.Min(source, selector);
 
         public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector) =>
@@ -321,7 +321,7 @@ namespace MoreLinq.Test
         public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector) =>
             LinqEnumerable.Min(source, selector);
 
-        public static TSource Min<TSource>(this IEnumerable<TSource> source) =>
+        public static TSource? Min<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.Min(source);
 
         public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector) =>
@@ -411,10 +411,10 @@ namespace MoreLinq.Test
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.Single(source, predicate);
 
-        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source) =>
+        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.SingleOrDefault(source);
 
-        public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
+        public static TSource? SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.SingleOrDefault(source, predicate);
 
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count) =>
@@ -510,16 +510,20 @@ namespace MoreLinq.Test
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source) =>
             LinqEnumerable.ToArray(source);
 
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+            where TKey : notnull =>
             LinqEnumerable.ToDictionary(source, keySelector);
 
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            where TKey : notnull =>
             LinqEnumerable.ToDictionary(source, keySelector, comparer);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
+            where TKey : notnull =>
             LinqEnumerable.ToDictionary(source, keySelector, elementSelector);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            where TKey : notnull =>
             LinqEnumerable.ToDictionary(source, keySelector, elementSelector, comparer);
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source) =>

--- a/MoreLinq.Test/EqualityComparer.cs
+++ b/MoreLinq.Test/EqualityComparer.cs
@@ -27,24 +27,24 @@ namespace MoreLinq.Test
         /// <see cref="Func{T,T,Boolean}"/>.
         /// </summary>
 
-        public static IEqualityComparer<T> Create<T>(Func<T, T, bool> comparer) =>
+        public static IEqualityComparer<T> Create<T>(Func<T?, T?, bool> comparer) =>
             new DelegatingComparer<T>(comparer);
 
         sealed class DelegatingComparer<T> : IEqualityComparer<T>
         {
-            readonly Func<T, T, bool> _comparer;
+            readonly Func<T?, T?, bool> _comparer;
             readonly Func<T, int> _hasher;
 
-            public DelegatingComparer(Func<T, T, bool> comparer)
+            public DelegatingComparer(Func<T?, T?, bool> comparer)
                 : this(comparer, x => x == null ? 0 : x.GetHashCode()) {}
 
-            DelegatingComparer(Func<T, T, bool> comparer, Func<T, int> hasher)
+            DelegatingComparer(Func<T?, T?, bool> comparer, Func<T, int> hasher)
             {
                 _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
                 _hasher = hasher ?? throw new ArgumentNullException(nameof(hasher));
             }
 
-            public bool Equals(T x, T y) => _comparer(x, y);
+            public bool Equals(T? x, T? y) => _comparer(x, y);
             public int GetHashCode(T obj) => _hasher(obj);
         }
     }

--- a/MoreLinq.Test/EquiZipTest.cs
+++ b/MoreLinq.Test/EquiZipTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
@@ -98,7 +96,7 @@ namespace MoreLinq.Test
             using var s1 = TestingSequence.Of(1, 2);
 
             Assert.That(() => s1.EquiZip(new BreakingSequence<int>(), Tuple.Create).Consume(),
-                        Throws.InvalidOperationException);
+                        Throws.BreakException);
         }
     }
 }

--- a/MoreLinq.Test/FlattenTest.cs
+++ b/MoreLinq.Test/FlattenTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System.Collections.Generic;

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/IndexByTest.cs
+++ b/MoreLinq.Test/IndexByTest.cs
@@ -81,18 +81,17 @@ namespace MoreLinq.Test
             var source = new[] { "foo", null, "bar", "baz", null, null, "baz", "bar", null, "foo" };
             var result = source.IndexBy(c => c);
 
-            const string @null = null; // type inference happiness
             result.AssertSequenceEqual(
-                KeyValuePair.Create(0, "foo"),
-                KeyValuePair.Create(0, @null),
-                KeyValuePair.Create(0, "bar"),
-                KeyValuePair.Create(0, "baz"),
-                KeyValuePair.Create(1, @null),
-                KeyValuePair.Create(2, @null),
-                KeyValuePair.Create(1, "baz"),
-                KeyValuePair.Create(1, "bar"),
-                KeyValuePair.Create(3, @null),
-                KeyValuePair.Create(1, "foo"));
+                KeyValuePair.Create(0, (string?)"foo"),
+                KeyValuePair.Create(0, (string?)null),
+                KeyValuePair.Create(0, (string?)"bar"),
+                KeyValuePair.Create(0, (string?)"baz"),
+                KeyValuePair.Create(1, (string?)null),
+                KeyValuePair.Create(2, (string?)null),
+                KeyValuePair.Create(1, (string?)"baz"),
+                KeyValuePair.Create(1, (string?)"bar"),
+                KeyValuePair.Create(3, (string?)null),
+                KeyValuePair.Create(1, (string?)"foo"));
         }
 
         [Test]

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
 
             // Expected and thrown by BreakingSequence
             Assert.That(() => sequenceA.Interleave(sequenceB).Consume(),
-                        Throws.InvalidOperationException);
+                        Throws.BreakException);
         }
 
         /// <summary>

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -343,13 +343,13 @@ namespace MoreLinq.Test
             {
                 readonly IEnumerator<T> _sequence;
 
-                public event EventHandler Disposed;
+                public event EventHandler? Disposed;
 
                 public DisposeTestingSequenceEnumerator(IEnumerator<T> sequence) =>
                     _sequence = sequence;
 
                 public T Current => _sequence.Current;
-                object IEnumerator.Current => Current;
+                object? IEnumerator.Current => Current;
                 public void Reset() => _sequence.Reset();
                 public bool MoveNext() => _sequence.MoveNext();
 

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -56,6 +56,7 @@
       <None Remove="TestResults\**" />
       <Compile Include="*Test.cs" />
       <Compile Include="Test*.cs" />
+      <Compile Include="..\MoreLinq\Debug.cs" Link="Debug.cs" />
       <Compile Include="..\MoreLinq\Disposable.cs" Link="Disposable.cs" />
       <Compile Include="..\MoreLinq\Reactive\Subject.cs" Link="Subject.cs" />
       <Compile Include="Throws.cs" />

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -15,6 +15,8 @@
 // limitations under the License.
 #endregion
 
+#nullable disable
+
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -15,19 +15,17 @@
 // limitations under the License.
 #endregion
 
-#nullable disable
-
 namespace MoreLinq.Test
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using NUnit.Framework.Interfaces;
+    using StackTrace = System.Diagnostics.StackTrace;
 
     [TestFixture]
     public class NullArgumentTest
@@ -43,7 +41,7 @@ namespace MoreLinq.Test
         static IEnumerable<ITestCaseData> GetNotNullTestCases() =>
             GetTestCases(canBeNull: false, testCaseFactory: (method, args, paramName) => () =>
             {
-                Exception e = null;
+                Exception? e = null;
 
                 try
                 {
@@ -55,24 +53,29 @@ namespace MoreLinq.Test
                 }
 
                 Assert.That(e, Is.Not.Null, $"No exception was thrown when {nameof(ArgumentNullException)} was expected.");
-                Assert.That(e, Is.InstanceOf<ArgumentNullException>());
-                var ane = (ArgumentNullException) e;
-                Assert.That(ane.ParamName, Is.EqualTo(paramName));
-                var stackTrace = new StackTrace(ane, false);
+                Assert.That(e, Is.InstanceOf<ArgumentNullException>().With.Property(nameof(ArgumentNullException.ParamName)).EqualTo(paramName));
+                Debug.Assert(e is not null);
+                var stackTrace = new StackTrace(e, false);
                 var stackFrame = stackTrace.GetFrames().First();
-                var actualType = stackFrame.GetMethod().DeclaringType;
+#if NETCOREAPP3_1
+                // Under .NET Core 3.1, "StackTrace.GetFrames()" was defined to return an array
+                // of nullable frame elements. See:
+                // https://github.com/dotnet/corefx/blob/v3.1.32/src/Common/src/CoreLib/System/Diagnostics/StackTrace.cs#L162
+                Debug.Assert(stackFrame is not null);
+#endif
+                var actualType = stackFrame.GetMethod()?.DeclaringType;
                 Assert.That(actualType, Is.SameAs(typeof(MoreEnumerable)));
             });
 
         static IEnumerable<ITestCaseData> GetCanBeNullTestCases() =>
             GetTestCases(canBeNull: true, testCaseFactory: (method, args, _) => () => method.Invoke(null, args));
 
-        static IEnumerable<ITestCaseData> GetTestCases(bool canBeNull, Func<MethodInfo, object[], string, Action> testCaseFactory) =>
+        static IEnumerable<ITestCaseData> GetTestCases(bool canBeNull, Func<MethodInfo, object?[], string, Action> testCaseFactory) =>
             from m in typeof (MoreEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             from t in CreateTestCases(m, canBeNull, testCaseFactory)
             select t;
 
-        static IEnumerable<ITestCaseData> CreateTestCases(MethodInfo methodDefinition, bool canBeNull, Func<MethodInfo, object[], string, Action> testCaseFactory)
+        static IEnumerable<ITestCaseData> CreateTestCases(MethodInfo methodDefinition, bool canBeNull, Func<MethodInfo, object?[], string, Action> testCaseFactory)
         {
             var method = InstantiateMethod(methodDefinition);
             var parameters = method.GetParameters().ToList();
@@ -80,7 +83,7 @@ namespace MoreLinq.Test
             return from param in parameters
                 where IsReferenceType(param) && CanBeNull(param) == canBeNull
                 let arguments = parameters.Select(p => p == param ? null : CreateInstance(p.ParameterType)).ToArray()
-                let testCase = testCaseFactory(method, arguments, param.Name)
+                let testCase = testCaseFactory(method, arguments, param.Name ?? throw new NullReferenceException())
                 let testName = GetTestName(methodDefinition, param)
                 select (ITestCaseData) new TestCaseData(testCase).SetName(testName);
         }
@@ -141,15 +144,25 @@ namespace MoreLinq.Test
             if (type == typeof (string)) return "";
             if (type == typeof(TaskScheduler)) return TaskScheduler.Default;
             if (type == typeof(IEnumerable<int>)) return new[] { 1, 2, 3 }; // Provide non-empty sequence for MinBy/MaxBy.
-            if (type.IsArray) return Array.CreateInstance(type.GetElementType(), 0);
-            if (type.GetTypeInfo().IsValueType || HasDefaultConstructor(type)) return Activator.CreateInstance(type);
             if (typeof(Delegate).IsAssignableFrom(type)) return CreateDelegateInstance(type);
 
-            var typeInfo = type.GetTypeInfo();
+            if (type.IsArray)
+            {
+                var elementType = type.GetElementType();
+                Debug.Assert(elementType is not null);
+                return Array.CreateInstance(elementType, 0);
+            }
 
-            return typeInfo.IsGenericType
-                    ? CreateGenericInterfaceInstance(typeInfo)
-                    : EmptyEnumerable.Instance;
+            if (type.GetTypeInfo().IsValueType || HasDefaultConstructor(type))
+            {
+                var instance = Activator.CreateInstance(type);
+                Debug.Assert(instance is not null);
+                return instance;
+            }
+
+            return type.GetTypeInfo() is { IsGenericType: true } typeInfo
+                 ? CreateGenericInterfaceInstance(typeInfo)
+                 : EmptyEnumerable.Instance;
         }
 
         static bool HasDefaultConstructor(Type type) =>
@@ -158,6 +171,7 @@ namespace MoreLinq.Test
         static Delegate CreateDelegateInstance(Type type)
         {
             var invoke = type.GetMethod("Invoke");
+            Debug.Assert(invoke is not null);
             var parameters = invoke.GetParameters().Select(p => Expression.Parameter(p.ParameterType, p.Name));
             var body = Expression.Default(invoke.ReturnType); // requires >= .NET 4.0
             var lambda = Expression.Lambda(type, body, parameters);
@@ -169,8 +183,10 @@ namespace MoreLinq.Test
             Debug.Assert(type.IsGenericType && type.IsInterface);
             var name = type.Name.Substring(1); // Delete first character, i.e. the 'I' in IEnumerable
             var definition = typeof (GenericArgs).GetTypeInfo().GetNestedType(name);
-            var instantiation = definition.MakeGenericType(type.GetGenericArguments());
-            return Activator.CreateInstance(instantiation);
+            Debug.Assert(definition is not null);
+            var instance = Activator.CreateInstance(definition.MakeGenericType(type.GetGenericArguments()));
+            Debug.Assert(instance is not null);
+            return instance;
         }
 
         static class EmptyEnumerable
@@ -193,45 +209,45 @@ namespace MoreLinq.Test
         // ReSharper disable UnusedMember.Local, UnusedAutoPropertyAccessor.Local
         static class GenericArgs
         {
-            class Enumerator<T> : IEnumerator<T>
+            class Enumerator<T> : IEnumerator<T?>
             {
                 public bool MoveNext() => false;
-                public T Current { get; private set; }
-                object IEnumerator.Current => Current;
+                public T? Current { get; private set; }
+                object? IEnumerator.Current => Current;
                 public void Reset() { }
                 public void Dispose() { }
             }
 
-            public class Enumerable<T> : IEnumerable<T>
+            public class Enumerable<T> : IEnumerable<T?>
             {
-                public IEnumerator<T> GetEnumerator() => new Enumerator<T>();
+                public IEnumerator<T?> GetEnumerator() => new Enumerator<T?>();
                 IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             }
 
-            public class OrderedEnumerable<T> : Enumerable<T>, System.Linq.IOrderedEnumerable<T>
+            public class OrderedEnumerable<T> : Enumerable<T>, System.Linq.IOrderedEnumerable<T?>
             {
-                public System.Linq.IOrderedEnumerable<T> CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey> comparer, bool descending)
+                public System.Linq.IOrderedEnumerable<T?> CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)
                 {
                     if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
                     return this;
                 }
             }
 
-            public class AwaitQuery<T> : Enumerable<T>,
-                                         Experimental.IAwaitQuery<T>
+            public class AwaitQuery<T> : Enumerable<T?>,
+                                         Experimental.IAwaitQuery<T?>
             {
                 public Experimental.AwaitQueryOptions Options => Experimental.AwaitQueryOptions.Default;
-                public Experimental.IAwaitQuery<T> WithOptions(Experimental.AwaitQueryOptions options) => this;
+                public Experimental.IAwaitQuery<T?> WithOptions(Experimental.AwaitQueryOptions options) => this;
             }
 
             public class Comparer<T> : IComparer<T>
             {
-                public int Compare(T x, T y) => -1;
+                public int Compare(T? x, T? y) => -1;
             }
 
             public class EqualityComparer<T> : IEqualityComparer<T>
             {
-                public bool Equals(T x, T y) => false;
+                public bool Equals(T? x, T? y) => false;
                 public int GetHashCode(T obj) => 0;
             }
         }

--- a/MoreLinq.Test/OrderByTest.cs
+++ b/MoreLinq.Test/OrderByTest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     /// <summary>
@@ -45,6 +46,16 @@ namespace MoreLinq.Test
             Assert.That(resultDes1, Is.EqualTo(resultDes2));
         }
 
+        static readonly IComparer<string> NumericStringComparer =
+            Comparer.Create((string? a, string? b) =>
+                (a, b) switch
+                {
+                    (null, null) => 0,
+                    (null, _) => -1,
+                    (_, null) => 1,
+                    var (sa, sb) => int.Parse(sa).CompareTo(int.Parse(sb))
+                });
+
         /// <summary>
         /// Verify that OrderBy preserves the comparer
         /// </summary>
@@ -55,7 +66,7 @@ namespace MoreLinq.Test
             var sequenceAscending = sequence.Select(x => x.ToString());
             var sequenceDescending = sequenceAscending.Reverse();
 
-            var comparer = Comparer.Create<string>((a, b) => int.Parse(a).CompareTo(int.Parse(b)));
+            var comparer = NumericStringComparer;
 
             var resultAsc1 = sequenceAscending.OrderBy(x => x, comparer, OrderByDirection.Descending);
             var resultAsc2 = sequenceAscending.OrderByDescending(x => x, comparer);
@@ -119,7 +130,7 @@ namespace MoreLinq.Test
                                    new {A = "2", B = "1"},
                                };
 
-            var comparer = Comparer.Create<string>((a, b) => int.Parse(a).CompareTo(int.Parse(b)));
+            var comparer = NumericStringComparer;
 
             var resultA1 = sequence.OrderBy(x => x.A, comparer, OrderByDirection.Ascending)
                                      .ThenBy(y => y.B, comparer, OrderByDirection.Ascending);

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;

--- a/MoreLinq.Test/PartialSortByTest.cs
+++ b/MoreLinq.Test/PartialSortByTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/PartitionTest.cs
+++ b/MoreLinq.Test/PartitionTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -90,7 +90,7 @@ namespace MoreLinq.Test
 
             // should contain six permutations (as defined above)
             Assert.That(permutations.Count(), Is.EqualTo(expectedPermutations.Length));
-            Assert.That(permutations.All(p => expectedPermutations.Contains(p, EqualityComparer.Create<IList<int>>((x, y) => x.SequenceEqual(y)))), Is.True);
+            Assert.That(permutations.All(p => expectedPermutations.Contains(p, SequenceEqualityComparer<int>.Instance)), Is.True);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace MoreLinq.Test
 
             // should contain six permutations (as defined above)
             Assert.That(permutations.Count(), Is.EqualTo(expectedPermutations.Length));
-            Assert.That(permutations.All(p => expectedPermutations.Contains(p, EqualityComparer.Create<IList<int>>((x, y) => x.SequenceEqual(y)))), Is.True);
+            Assert.That(permutations.All(p => expectedPermutations.Contains(p, SequenceEqualityComparer<int>.Instance)), Is.True);
         }
 
         /// <summary>
@@ -195,6 +195,12 @@ namespace MoreLinq.Test
                     Assert.That(listPermutations[i], Is.Not.SameAs(listPermutations[j]));
                 }
             }
+        }
+
+        static class SequenceEqualityComparer<T>
+        {
+            public static readonly IEqualityComparer<IEnumerable<T>> Instance =
+                EqualityComparer.Create<IEnumerable<T>>((x, y) => x is { } sx && y is { } sy && sx.SequenceEqual(sy));
         }
     }
 }

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
         public void PrependWithNullHead()
         {
             string[] tail = { "second", "third" };
-            string head = null;
+            string? head = null;
             var whole = tail.Prepend(head);
             whole.AssertSequenceEqual(null, "second", "third");
         }

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/ReturnTest.cs
+++ b/MoreLinq.Test/ReturnTest.cs
@@ -34,8 +34,8 @@ namespace MoreLinq.Test
 
         static class NullSingleton
         {
-            public static readonly IEnumerable<object> Sequence = MoreEnumerable.Return<object>(null);
-            public static IList<object> List => (IList<object>)Sequence;
+            public static readonly IEnumerable<object?> Sequence = MoreEnumerable.Return<object?>(null);
+            public static IList<object?> List => (IList<object?>)Sequence;
         }
 
         [Test]
@@ -77,13 +77,13 @@ namespace MoreLinq.Test
         [Test]
         public void TestIndexOfDoesNotThrowWhenTheItemProvidedIsNull()
         {
-            Assert.That(() => NullSingleton.List.IndexOf(new object()), Throws.Nothing);
+            Assert.That(() => SomeSingleton.List.IndexOf(new object()), Throws.Nothing);
         }
 
         [Test]
         public void TestIndexOfDoesNotThrowWhenTheItemContainedIsNull()
         {
-            Assert.That(() => SomeSingleton.List.IndexOf(null), Throws.Nothing);
+            Assert.That(() => NullSingleton.List.IndexOf(null), Throws.Nothing);
         }
 
         [Test]

--- a/MoreLinq.Test/ScanByTest.cs
+++ b/MoreLinq.Test/ScanByTest.cs
@@ -50,7 +50,7 @@ namespace MoreLinq.Test
             var result =
                     source.ScanBy(
                         item => item.First(),
-                        key => (Element: default(string), Key: key, State: key - 1),
+                        key => (Element: string.Empty, Key: key, State: key - 1),
                         (state, key, item) => (item, char.ToUpperInvariant(key), state.State + 1));
 
             result.AssertSequenceEqual(
@@ -103,31 +103,31 @@ namespace MoreLinq.Test
             var result = source.ScanBy(c => c, _ => -1, (i, _, _) => i + 1);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("foo"       , 0),
-                KeyValuePair.Create((string)null, 0),
-                KeyValuePair.Create("bar"       , 0),
-                KeyValuePair.Create("baz"       , 0),
-                KeyValuePair.Create((string)null, 1),
-                KeyValuePair.Create((string)null, 2),
-                KeyValuePair.Create("baz"       , 1),
-                KeyValuePair.Create("bar"       , 1),
-                KeyValuePair.Create((string)null, 3),
-                KeyValuePair.Create("foo"       , 1));
+                KeyValuePair.Create((string?)"foo", 0),
+                KeyValuePair.Create((string?)null , 0),
+                KeyValuePair.Create((string?)"bar", 0),
+                KeyValuePair.Create((string?)"baz", 0),
+                KeyValuePair.Create((string?)null , 1),
+                KeyValuePair.Create((string?)null , 2),
+                KeyValuePair.Create((string?)"baz", 1),
+                KeyValuePair.Create((string?)"bar", 1),
+                KeyValuePair.Create((string?)null , 3),
+                KeyValuePair.Create((string?)"foo", 1));
         }
 
         [Test]
         public void ScanByWithNullSeed()
         {
-            var nil = (object)null;
+            var nil = (object?)null;
             var source = new[] { "foo", null, "bar", null, "baz" };
             var result = source.ScanBy(c => c, _ => nil, (_, _, _) => nil);
 
             result.AssertSequenceEqual(
-                KeyValuePair.Create("foo"       , nil),
-                KeyValuePair.Create((string)null, nil),
-                KeyValuePair.Create("bar"       , nil),
-                KeyValuePair.Create((string)null, nil),
-                KeyValuePair.Create("baz"       , nil));
+                KeyValuePair.Create((string?)"foo", nil),
+                KeyValuePair.Create((string?)null , nil),
+                KeyValuePair.Create((string?)"bar", nil),
+                KeyValuePair.Create((string?)null , nil),
+                KeyValuePair.Create((string?)"baz", nil));
         }
 
         [Test]

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -47,7 +47,7 @@ namespace MoreLinq.Test
         {
             var sequence = Enumerable.Range(1, 3).Concat(new BreakingSequence<int>()).Scan(SampleData.Plus);
             var gold = new[] {1, 3, 6};
-            Assert.That(sequence.Consume, Throws.InvalidOperationException);
+            Assert.That(sequence.Consume, Throws.BreakException);
             sequence.Take(3).AssertSequenceEqual(gold);
         }
 
@@ -68,7 +68,7 @@ namespace MoreLinq.Test
         [Test]
         public void SeededScanIsLazy()
         {
-            new BreakingSequence<object>().Scan(null, BreakingFunc.Of<object, object, object>());
+            new BreakingSequence<object>().Scan(null, BreakingFunc.Of<object?, object, object>());
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace MoreLinq.Test
         {
             var sequence = Enumerable.Range(1, 3).Concat(new BreakingSequence<int>()).Scan(0, SampleData.Plus);
             var gold = new[] { 0, 1, 3, 6 };
-            Assert.That(sequence.Consume, Throws.InvalidOperationException);
+            Assert.That(sequence.Consume, Throws.BreakException);
             sequence.Take(4).AssertSequenceEqual(gold);
         }
 

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -51,7 +51,7 @@ namespace MoreLinq.Test
             // Expected and thrown by BreakingSequence
             Assert.That(() => sequenceA.SortedMerge(OrderByDirection.Ascending, new BreakingSequence<int>())
                                        .Consume(),
-                        Throws.InvalidOperationException);
+                        Throws.BreakException);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace MoreLinq.Test
         {
             var sequenceA = Enumerable.Range(1, 3);
             var sequenceB = Enumerable.Range(4, 3);
-            var result = sequenceA.SortedMerge(OrderByDirection.Ascending, (IComparer<int>)null, sequenceB);
+            var result = sequenceA.SortedMerge(OrderByDirection.Ascending, (IComparer<int>?)null, sequenceB);
 
             Assert.That(result, Is.EqualTo(sequenceA.Concat(sequenceB)));
         }

--- a/MoreLinq.Test/SubjectTest.cs
+++ b/MoreLinq.Test/SubjectTest.cs
@@ -25,9 +25,9 @@ namespace MoreLinq.Test
     public class SubjectTest
     {
         static IDisposable Subscribe<T>(IObservable<T> subject,
-                                        Action<T> onNext = null,
-                                        Action<Exception> onError = null,
-                                        Action onCompleted = null) =>
+                                        Action<T>? onNext = null,
+                                        Action<Exception>? onError = null,
+                                        Action? onCompleted = null) =>
             subject.Subscribe(onNext ?? BreakingAction.Of<T>(),
                               onError ?? BreakingAction.Of<Exception>(),
                               onCompleted ?? BreakingAction.WithoutArguments);
@@ -36,7 +36,7 @@ namespace MoreLinq.Test
         public void SubscribeWithNullObserverThrows()
         {
             var subject = new Subject<int>();
-            Assert.That(() => subject.Subscribe(null),
+            Assert.That(() => subject.Subscribe(null!),
                         Throws.ArgumentNullException("observer"));
         }
 
@@ -60,8 +60,8 @@ namespace MoreLinq.Test
         [Test]
         public void OnErrorObservations()
         {
-            Exception error1 = null;
-            Exception error2 = null;
+            Exception? error1 = null;
+            Exception? error2 = null;
 
             var subject = new Subject<int>();
 
@@ -139,7 +139,7 @@ namespace MoreLinq.Test
         [Test]
         public void SubscriptionPostError()
         {
-            Exception observedError = null;
+            Exception? observedError = null;
             var subject = new Subject<int>();
             var error = new TestException();
             subject.OnError(error);
@@ -215,8 +215,12 @@ namespace MoreLinq.Test
         public void SafeToDisposeDuringOnNext()
         {
             var subject = new Subject<int>();
-            IDisposable subscription = null;
-            var action = new Action(() => subscription.Dispose());
+            IDisposable? subscription = null;
+            var action = new Action(() =>
+            {
+                Debug.Assert(subscription is not null);
+                subscription.Dispose();
+            });
             subscription = subject.Subscribe(_ => action());
             subject.OnNext(42);
             action = BreakingAction.WithoutArguments;

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
     sealed class TestingSequence<T> : IEnumerable<T>, IDisposable
     {
         bool? _disposed;
-        IEnumerable<T> _sequence;
+        IEnumerable<T>? _sequence;
 
         internal TestingSequence(IEnumerable<T> sequence) =>
             _sequence = sequence;
@@ -65,6 +65,8 @@ namespace MoreLinq.Test
         public IEnumerator<T> GetEnumerator()
         {
             Assert.That(_sequence, Is.Not.Null, "LINQ operators should not enumerate a sequence more than once.");
+            Debug.Assert(_sequence is not null);
+
             var enumerator = _sequence.GetEnumerator().AsWatchable();
             _disposed = false;
             enumerator.Disposed += delegate

--- a/MoreLinq.Test/Throws.cs
+++ b/MoreLinq.Test/Throws.cs
@@ -24,7 +24,8 @@ namespace MoreLinq.Test
     {
         public static ThrowsNothingConstraint Nothing => NUnit.Framework.Throws.Nothing;
         public static ExactTypeConstraint InvalidOperationException => NUnit.Framework.Throws.InvalidOperationException;
-        public static ExactTypeConstraint ObjectDisposedException => NUnit.Framework.Throws.TypeOf<ObjectDisposedException>();
+        public static ExactTypeConstraint ObjectDisposedException => TypeOf<ObjectDisposedException>();
+        public static ExactTypeConstraint BreakException => TypeOf<BreakException>();
 
         public static InstanceOfTypeConstraint InstanceOf<T>()
             where T : Exception =>
@@ -41,7 +42,7 @@ namespace MoreLinq.Test
             NUnit.Framework.Throws.ArgumentNullException.With.ParamName().EqualTo(expectedParamName);
 
         public static ExactTypeConstraint ArgumentOutOfRangeException() =>
-            NUnit.Framework.Throws.TypeOf<ArgumentOutOfRangeException>();
+            TypeOf<ArgumentOutOfRangeException>();
 
         public static EqualConstraint ArgumentOutOfRangeException(string expectedParamName) =>
             ArgumentOutOfRangeException().With.ParamName().EqualTo(expectedParamName);

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -51,6 +51,8 @@ namespace MoreLinq.Test
                 ANullableDecimal = key / 3;
                 AString = "ABCDEFGHIKKLMNOPQRSTUVWXYSZ";
             }
+
+            public override string ToString() => nameof(TestObject);
         }
 
 
@@ -67,9 +69,9 @@ namespace MoreLinq.Test
         [Test]
         public void ToDataTableNullMemberExpressionMethod()
         {
-            Expression<Func<TestObject, object>> expression = null;
+            Expression<Func<TestObject, object?>>? expression = null;
 
-            Assert.That(() => _testObjects.ToDataTable(expression),
+            Assert.That(() => _testObjects.ToDataTable(expression!),
                         Throws.ArgumentException("expressions"));
         }
 
@@ -177,7 +179,7 @@ namespace MoreLinq.Test
                                   .Cast<DictionaryEntry>()
                                   .ToArray();
 
-            vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value.ToString() })
+            vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value!.ToString() })
                 .ToDataTable(dt, e => e.Name, e => e.Value);
 
             var rows = dt.Rows.Cast<DataRow>().ToArray();
@@ -201,10 +203,12 @@ namespace MoreLinq.Test
             var points = new[] { new Point(12, 34) }.ToDataTable();
 
             Assert.That(points.Columns.Count, Is.EqualTo(3));
-            DataColumn x, y, empty;
-            Assert.That(x = points.Columns["X"], Is.Not.Null);
-            Assert.That(y = points.Columns["Y"], Is.Not.Null);
-            Assert.That(empty = points.Columns["IsEmpty"], Is.Not.Null);
+            var x = points.Columns["X"];
+            var y = points.Columns["Y"];
+            var empty = points.Columns["IsEmpty"];
+            Assert.That(x, Is.Not.Null);
+            Assert.That(y, Is.Not.Null);
+            Assert.That(empty, Is.Not.Null);
             var row = points.Rows.Cast<DataRow>().Single();
             Assert.That(row[x], Is.EqualTo(12));
             Assert.That(row[y], Is.EqualTo(34));

--- a/MoreLinq.Test/ToDelimitedStringTest.cs
+++ b/MoreLinq.Test/ToDelimitedStringTest.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         [Test]
         public void ToDelimitedStringWithNonEmptySequenceContainingNulls()
         {
-            var result = new object[] { 1, null, "foo", true }.ToDelimitedString(",");
+            var result = new object?[] { 1, null, "foo", true }.ToDelimitedString(",");
             Assert.That(result, Is.EqualTo("1,,foo,True"));
         }
 
@@ -40,7 +40,7 @@ namespace MoreLinq.Test
         public void ToDelimitedStringWithNonEmptySequenceContainingNullsAtStart()
         {
             // See: https://github.com/morelinq/MoreLINQ/issues/43
-            var result = new object[] { null, null, "foo" }.ToDelimitedString(",");
+            var result = new object?[] { null, null, "foo" }.ToDelimitedString(",");
             Assert.That(result, Is.EqualTo(",,foo"));
         }
     }

--- a/MoreLinq.Test/TraceTest.cs
+++ b/MoreLinq.Test/TraceTest.cs
@@ -84,7 +84,6 @@ namespace MoreLinq.Test
 
             IEnumerator<string> _(TextReader reader)
             {
-                Debug.Assert(reader != null);
                 while (reader.ReadLine() is { } line)
                     yield return line;
             }

--- a/MoreLinq.Test/TransposeTest.cs
+++ b/MoreLinq.Test/TransposeTest.cs
@@ -36,7 +36,7 @@ namespace MoreLinq.Test
             using var seq1 = TestingSequence.Of(10, 11);
             using var seq2 = TestingSequence.Of<int>();
             using var seq3 = TestingSequence.Of(30, 31, 32);
-            using var matrix = TestingSequence.Of(seq1, seq2, seq3, null);
+            using var matrix = TestingSequence.Of<IEnumerable<int>>(seq1, seq2, seq3, null!);
 
             Assert.That(() => matrix.Transpose().FirstOrDefault(),
                         Throws.TypeOf<NullReferenceException>());

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -31,14 +31,14 @@ namespace MoreLinq.Test
     {
         readonly IEnumerator<T> _source;
 
-        public event EventHandler Disposed;
-        public event EventHandler<bool> MoveNextCalled;
+        public event EventHandler? Disposed;
+        public event EventHandler<bool>? MoveNextCalled;
 
         public WatchableEnumerator(IEnumerator<T> source) =>
             _source = source ?? throw new ArgumentNullException(nameof(source));
 
         public T Current => _source.Current;
-        object IEnumerator.Current => Current;
+        object? IEnumerator.Current => Current;
         public void Reset() => _source.Reset();
 
         public bool MoveNext()

--- a/MoreLinq.Test/ZipLongestTest.cs
+++ b/MoreLinq.Test/ZipLongestTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;
@@ -81,7 +79,7 @@ namespace MoreLinq.Test
             using var s1 = TestingSequence.Of(1, 2);
 
             Assert.That(() => s1.ZipLongest(new BreakingSequence<int>(), Tuple.Create).Consume(),
-                        Throws.InvalidOperationException);
+                        Throws.BreakException);
         }
     }
 }

--- a/MoreLinq.Test/ZipShortestTest.cs
+++ b/MoreLinq.Test/ZipShortestTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using NUnit.Framework;
@@ -111,7 +109,7 @@ namespace MoreLinq.Test
             using var s1 = TestingSequence.Of(1, 2);
 
             Assert.That(() => s1.ZipShortest(new BreakingSequence<int>(), Tuple.Create).Consume(),
-                        Throws.InvalidOperationException);
+                        Throws.BreakException);
         }
     }
 }

--- a/MoreLinq/Extensions.ToDataTable.g.cs
+++ b/MoreLinq/Extensions.ToDataTable.g.cs
@@ -68,7 +68,7 @@ namespace MoreLinq.Extensions
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object>>[] expressions)
+        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object?>>[] expressions)
             => MoreEnumerable.ToDataTable(source, expressions);
         /// <summary>
         /// Appends elements in the sequence as rows of a given <see cref="DataTable"/> object.
@@ -101,7 +101,7 @@ namespace MoreLinq.Extensions
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
+        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object?>>[] expressions)
             where TTable : DataTable
             => MoreEnumerable.ToDataTable(source, table, expressions);
 

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -120,7 +120,6 @@
     <VersionPrefix>3.3.2</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
     <TargetFrameworks>net451;netstandard1.0;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <!-- Parallel build is disabled to avoid file locking issues during T4 code generation.
          See also: https://github.com/dotnet/msbuild/issues/2781 -->
     <BuildInParallel>false</BuildInParallel>

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Reactive
 {
     using System;

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -41,7 +41,7 @@ namespace MoreLinq
         public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table)
             where TTable : DataTable
         {
-            return ToDataTable(source, table, EmptyArray<Expression<Func<T, object>>>.Value);
+            return ToDataTable(source, table, EmptyArray<Expression<Func<T, object?>>>.Value);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object>>[] expressions)
+        public static DataTable ToDataTable<T>(this IEnumerable<T> source, params Expression<Func<T, object?>>[] expressions)
         {
             return ToDataTable(source, new DataTable(), expressions);
         }
@@ -92,7 +92,7 @@ namespace MoreLinq
         /// </returns>
         /// <remarks>This operator uses immediate execution.</remarks>
 
-        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object>>[] expressions)
+        public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object?>>[] expressions)
             where TTable : DataTable
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -100,7 +100,7 @@ namespace MoreLinq
 
             // TODO disallow null for "expressions" in next major update
 
-            expressions ??= EmptyArray<Expression<Func<T, object>>>.Value;
+            expressions ??= EmptyArray<Expression<Func<T, object?>>>.Value;
 
             var members = PrepareMemberInfos(expressions).ToArray();
             members = BuildOrBindSchema(table, members);
@@ -130,7 +130,7 @@ namespace MoreLinq
             return table;
         }
 
-        static IEnumerable<MemberInfo> PrepareMemberInfos<T>(ICollection<Expression<Func<T, object>>> expressions)
+        static IEnumerable<MemberInfo> PrepareMemberInfos<T>(ICollection<Expression<Func<T, object?>>> expressions)
         {
             //
             // If no lambda expressions supplied then reflect them off the source element type.

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />


### PR DESCRIPTION
This PR enables the nullable context for the entire solution by addressing all warnings that appeared in test projects. It remove individual `#nullable enable` directives in files. The nullable context is now enabled on all projects via `Directory.Build.props`.

This PR also revises `SequenceReader<>` to be sealed (YAGNI) and simpler in implementation, and as a result, making it easier to address nullability warnings. A `BreakException` is introduced that is thrown by `SequenceReader<>` to avoid it being masked by `InvalidOperationException` that's also common in methods under test.

Pending:

- [x] `NullArgumentTest`