### PR TITLE
Seal private enumerators

### DIFF
--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -29,7 +29,7 @@ namespace MoreLinq
         /// The private implementation class that produces permutations of a sequence.
         /// </summary>
 
-        class PermutationEnumerator<T> : IEnumerator<IList<T>>
+        sealed class PermutationEnumerator<T> : IEnumerator<IList<T>>
         {
             // NOTE: The algorithm used to generate permutations uses the fact that any set
             //       can be put into 1-to-1 correspondence with the set of ordinals number (0..n).

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -123,7 +123,7 @@ namespace MoreLinq
             /// predetermined size less than or equal to the original set size.
             /// </summary>
 
-            class SubsetEnumerator : IEnumerator<IList<T>>
+            sealed class SubsetEnumerator : IEnumerator<IList<T>>
             {
                 readonly IList<T> _set;   // the original set of elements
                 readonly T[] _subset;     // the current subset to return


### PR DESCRIPTION
This PR seals two private enumerators implementations since neither is designed for subclassing.
