### PR TITLE
Mark local function static where possible

### DIFF
--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -43,7 +43,7 @@ namespace MoreLinq.Test
 
             flowArray.AssertSequenceEqual(flowBuffer);
 
-            IEnumerable<object> InnerForEach(IEnumerable<int> source)
+            static IEnumerable<object> InnerForEach(IEnumerable<int> source)
             {
                 var firstVisitAtInnerLoopDone = false;
 

--- a/MoreLinq.Test/TraceTest.cs
+++ b/MoreLinq.Test/TraceTest.cs
@@ -82,7 +82,7 @@ namespace MoreLinq.Test
             while (e.MoveNext())
                 yield return e.Current;
 
-            IEnumerator<string> _(TextReader reader)
+            static IEnumerator<string> _(TextReader reader)
             {
                 while (reader.ReadLine() is { } line)
                     yield return line;

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -159,7 +159,7 @@ namespace MoreLinq
                 throw new ArgumentException("One of the supplied expressions is not allowed.", nameof(expressions), e);
             }
 
-            MemberInfo GetAccessedMember(LambdaExpression lambda)
+            static MemberInfo GetAccessedMember(LambdaExpression lambda)
             {
                 var body = lambda.Body;
 


### PR DESCRIPTION
This PR marks local functions as `static`, those that don't access variables from their enclosing scope.