### PR TITLE
Address to-do about consolidating testing sequence implementations

### DIFF
--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -25,12 +25,23 @@ namespace MoreLinq.Test
     static class TestingSequence
     {
         internal static TestingSequence<T> Of<T>(params T[] elements) =>
-            new TestingSequence<T>(elements);
+            Of(Options.None, elements);
 
-        internal static TestingSequence<T> AsTestingSequence<T>(this IEnumerable<T> source) =>
+        internal static TestingSequence<T> Of<T>(Options options, params T[] elements) =>
+            elements.AsTestingSequence(options);
+
+        internal static TestingSequence<T> AsTestingSequence<T>(this IEnumerable<T> source,
+                                                                Options options = Options.None) =>
             source != null
-            ? new TestingSequence<T>(source)
+            ? new TestingSequence<T>(source) { IsReiterationAllowed = options.HasFlag(Options.AllowMultipleEnumerations) }
             : throw new ArgumentNullException(nameof(source));
+
+        [Flags]
+        public enum Options
+        {
+            None,
+            AllowMultipleEnumerations
+        }
     }
 
     /// <summary>
@@ -46,6 +57,8 @@ namespace MoreLinq.Test
         internal TestingSequence(IEnumerable<T> sequence) =>
             _sequence = sequence;
 
+        public bool IsDisposed => _disposed ?? false;
+        public bool IsReiterationAllowed { get; init; }
         public int MoveNextCallCount { get; private set; }
 
         void IDisposable.Dispose() =>
@@ -64,7 +77,9 @@ namespace MoreLinq.Test
 
         public IEnumerator<T> GetEnumerator()
         {
-            Assert.That(_sequence, Is.Not.Null, "LINQ operators should not enumerate a sequence more than once.");
+            if (!IsReiterationAllowed)
+                Assert.That(_sequence, Is.Not.Null, "LINQ operators should not enumerate a sequence more than once.");
+
             Debug.Assert(_sequence is not null);
 
             var enumerator = _sequence.GetEnumerator().AsWatchable();
@@ -81,7 +96,10 @@ namespace MoreLinq.Test
                 ended = !moved;
                 MoveNextCallCount++;
             };
-            _sequence = null;
+
+            if (!IsReiterationAllowed)
+                _sequence = null;
+
             return enumerator;
         }
 


### PR DESCRIPTION
This PR addresses a to-do comment by removing `DisposalTrackingSequence` in `MemoizeTest` and using `TestingSequence` instead. This required enhancing `TestingSequence` with an option to allow re-iteration of a sequence as well as exposing a property to assert if the enumerator was disposed.