### PR TITLE
Use tuples to perform swap in `Permutations`

### DIFF
--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -147,10 +147,7 @@ namespace MoreLinq
                 while (_permutation[j] > _permutation[k])
                     k--;
 
-                // interchange m_Permutation[j] and m_Permutation[k]
-                var oldValue = _permutation[k];
-                _permutation[k] = _permutation[j];
-                _permutation[j] = oldValue;
+                (_permutation[j], _permutation[k]) = (_permutation[k], _permutation[j]);
 
                 // move the tail of the permutation after the jth position in increasing order
                 var x = _permutation.Length - 1;
@@ -158,9 +155,7 @@ namespace MoreLinq
 
                 while (x > y)
                 {
-                    oldValue = _permutation[y];
-                    _permutation[y] = _permutation[x];
-                    _permutation[x] = oldValue;
+                    (_permutation[x], _permutation[y]) = (_permutation[y], _permutation[x]);
                     x--;
                     y++;
                 }


### PR DESCRIPTION
This PR refactors swaps in `Permutations` to use tuples, which reads simpler and more succinct.