### PR TITLE
Fix exception thrown by current buffer index implementation

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -308,6 +308,20 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void BatchCurrentListIndexerWithBadIndexThrowsArgumentOutOfRangeException()
+        {
+            using var input = TestingSequence.Of(1, 2, 3, 4, 5, 6, 7, 8, 9);
+            using var pool = new TestArrayPool<int>();
+
+            var result = input.Batch(4, pool, current => current, current => (ICurrentBuffer<int>)current);
+
+            using var reader = result.Read();
+            var current = reader.Read();
+
+            Assert.That(() => current[100], Throws.ArgumentOutOfRangeException("index"));
+        }
+
+        [Test]
         public void BatchCallsBucketSelectorBeforeIteratingSource()
         {
             var iterations = 0;

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -268,9 +268,8 @@ namespace MoreLinq.Experimental
 
             public override T this[int index]
             {
-                get => index >= 0 && index < Count ? _array[index] : throw new IndexOutOfRangeException();
+                get => index >= 0 && index < Count ? _array[index] : throw new ArgumentOutOfRangeException(nameof(index));
                 set => throw new NotSupportedException();
-
             }
 
             public void Dispose()


### PR DESCRIPTION
This PR fixes the `ICurrentBuffer<>` indexer implementation, used in `Batch`, to throw `IndexOutOfRangeException` instead of `ArgumentOutOfRangeException`. This is to respect the contract of `IList<T>[index]`, which should [throw `ArgumentOutOfRangeException` for an index index](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ilist-1.item?view=net-7.0#exceptions).

This is a follow-up to [a review comment](https://github.com/morelinq/MoreLINQ/pull/924#discussion_r1070624671) by @viceroypenguin on PR #924.