### PR TITLE
Additional tests for `TagFirstLast`

### DIFF
--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -23,6 +23,15 @@ namespace MoreLinq.Test
     public class TagFirstLastTest
     {
         [Test]
+        public void TagFirstLastEvaluatesSourceLazily()
+        {
+            var source = MoreEnumerable.From(() => 123, () => 456, () => throw new TestException());
+            source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
+                  .Take(1)
+                  .Consume();
+        }
+
+        [Test]
         public void TagFirstLastIsLazy()
         {
             new BreakingSequence<object>().TagFirstLast(BreakingFunc.Of<object, bool, bool, object>());

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -38,6 +38,14 @@ namespace MoreLinq.Test
         }
 
         [Test]
+        public void TagFirstLastWithSourceSequenceOfZero()
+        {
+            var source = new int[0];
+            var sut = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
+            Assert.That(sut, Is.Empty);
+        }
+
+        [Test]
         public void TagFirstLastWithSourceSequenceOfOne()
         {
             var source = new[] { 123 };

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -40,7 +40,7 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastWithSourceSequenceOfZero()
         {
-            var source = new int[0];
+            var source = Enumerable.Empty<int>();
             var sut = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
             Assert.That(sut, Is.Empty);
         }

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -23,9 +23,9 @@ namespace MoreLinq.Test
     public class TagFirstLastTest
     {
         [Test]
-        public void TagFirstLastEvaluatesSourceLazily()
+        public void TagFirstLastDoesOneLookAhead()
         {
-            var source = MoreEnumerable.From(() => 123, () => 456, () => throw new TestException());
+            var source = MoreEnumerable.From(() => 123, () => 456, BreakingFunc.Of<int>());
             source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast })
                   .Take(1)
                   .Consume();
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         public void TagFirstLastWithSourceSequenceOfZero()
         {
             var source = Enumerable.Empty<int>();
-            var sut = source.TagFirstLast((item, isFirst, isLast) => new { Item = item, IsFirst = isFirst, IsLast = isLast });
+            var sut = source.TagFirstLast(BreakingFunc.Of<int, bool, bool, int>());
             Assert.That(sut, Is.Empty);
         }
 


### PR DESCRIPTION
Add 

- TagFirstLastEvaluatesSourceLazily ensure that TagFirstLast doesn't evaluate the whole source uselessly.
- TagFirstLastWithSourceSequenceOfZero for 100% code coverage in #643 