### PR TITLE
Consolidate error formatting between `AssertCount` and `Fold`

### DIFF
--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -53,13 +53,17 @@ namespace MoreLinq.Test
                         Throws.TypeOf<SequenceException>());
         }
 
-        [TestCase(4, "Sequence contains too few elements when exactly 4 were expected.")]
-        [TestCase(2, "Sequence contains too many elements when exactly 2 were expected.")]
-        public void AssertCountDefaultExceptionMessageVariesWithCase(int count, string expectedMessage)
+        [TestCase("", 1, "Sequence contains too few elements when exactly 1 was expected.")]
+        [TestCase("foo,bar,baz", 1, "Sequence contains too many elements when exactly 1 was expected.")]
+        [TestCase("foo,bar,baz", 4, "Sequence contains too few elements when exactly 4 were expected.")]
+        [TestCase("foo,bar,baz", 2, "Sequence contains too many elements when exactly 2 were expected.")]
+        public void AssertCountDefaultExceptionMessageVariesWithCase(string str, int count, string expectedMessage)
         {
-            var tokens = "foo,bar,baz".GenerateSplits(',');
+            var tokens = str.GenerateSplits(',')
+                            .Where(t => t.Length > 0)
+                            .AssertCount(count);
 
-            Assert.That(() => tokens.AssertCount(count).Consume(),
+            Assert.That(() => tokens.Consume(),
                         Throws.TypeOf<SequenceException>().With.Message.EqualTo(expectedMessage));
         }
 

--- a/MoreLinq.Test/FoldTest.cs
+++ b/MoreLinq.Test/FoldTest.cs
@@ -27,21 +27,24 @@ namespace MoreLinq.Test
         public void FoldWithTooFewItems()
         {
             Assert.That(() => Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int, int, int>()),
-                        Throws.TypeOf<InvalidOperationException>());
+                        Throws.TypeOf<InvalidOperationException>()
+                              .And.Message.EqualTo("Sequence contains too few elements when exactly 4 were expected."));
         }
 
         [Test]
         public void FoldWithEmptySequence()
         {
             Assert.That(() => Enumerable.Empty<int>().Fold(BreakingFunc.Of<int, int>()),
-                        Throws.TypeOf<InvalidOperationException>());
+                        Throws.TypeOf<InvalidOperationException>()
+                              .And.Message.EqualTo("Sequence contains too few elements when exactly 1 was expected."));
         }
 
         [Test]
         public void FoldWithTooManyItems()
         {
             Assert.That(() => Enumerable.Range(1, 3).Fold(BreakingFunc.Of<int, int, int>()),
-                        Throws.TypeOf<InvalidOperationException>());
+                        Throws.TypeOf<InvalidOperationException>()
+                              .And.Message.EqualTo("Sequence contains too many elements when exactly 2 were expected."));
         }
 
         [Test]

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -71,13 +71,11 @@ namespace MoreLinq
             int count, Func<int, int, Exception> errorSelector) =>
             AssertCountImpl(source, count, errorSelector);
 
-        static Exception OnAssertCountFailure(int cmp, int count)
-        {
-            var message = cmp < 0
-                        ? "Sequence contains too few elements when exactly {0} were expected."
-                        : "Sequence contains too many elements when exactly {0} were expected.";
-            return new SequenceException(string.Format(message, count.ToString("N0")));
-        }
+        static Exception OnAssertCountFailure(int cmp, int count) =>
+            new SequenceException(FormatSequenceLengthErrorMessage(cmp, count));
+
+        internal static string FormatSequenceLengthErrorMessage(int cmp, int count) =>
+            $"Sequence contains too {(cmp < 0 ? "few" : "many")} elements when exactly {count:N0} {(count == 1 ? "was" : "were")} expected.";
 
         #endif
 

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -91,12 +91,7 @@ namespace MoreLinq
 
         static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
 
-        static Exception OnFolderSourceSizeError(int cmp, int count)
-        {
-            var message = cmp < 0
-                        ? "Sequence contains too few elements when exactly {0} {1} expected."
-                        : "Sequence contains too many elements when exactly {0} {1} expected.";
-            return new InvalidOperationException(string.Format(message, count.ToString("N0"), count == 1 ? "was" : "were"));
-        }
+        static Exception OnFolderSourceSizeError(int cmp, int count) =>
+            new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count));
     }
 }


### PR DESCRIPTION
The formatting of the error message was duplicated between `AssertCount` and `Fold`. This PR consolidates that duplication by using a common formatting method.
