### PR TITLE
Enable default compile items in test project

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -8,7 +8,6 @@
     <OutputType>Exe</OutputType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>false</IsPackable>
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject>MoreLinq.Test.Program</StartupObject>
@@ -57,32 +56,9 @@
   <ItemGroup>
       <None Remove="TestResult.xml" />
       <None Remove="TestResults\**" />
-      <Compile Include="*Test.cs" />
-      <Compile Include="Test*.cs" />
       <Compile Include="..\MoreLinq\Debug.cs" Link="Debug.cs" />
       <Compile Include="..\MoreLinq\Disposable.cs" Link="Disposable.cs" />
       <Compile Include="..\MoreLinq\Reactive\Subject.cs" Link="Subject.cs" />
-      <Compile Include="Throws.cs" />
-      <Compile Include="BreakingCollection.cs" />
-      <Compile Include="BreakingAction.cs" />
-      <Compile Include="BreakingFunc.cs" />
-      <Compile Include="BreakingList.cs" />
-      <Compile Include="BreakingReadOnlyCollection.cs" />
-      <Compile Include="BreakingReadOnlyList.cs" />
-      <Compile Include="BreakingSequence.cs" />
-      <Compile Include="Combinatorics.cs" />
-      <Compile Include="Comparable.cs" />
-      <Compile Include="CurrentThreadCultureScope.cs" />
-      <Compile Include="Enumerable.cs" />
-      <Compile Include="EqualityComparer.cs" />
-      <Compile Include="FuncModule.cs" />
-      <Compile Include="KeyValuePair.cs" />
-      <Compile Include="Program.cs" />
-      <Compile Include="ReadOnlyCollection.cs" />
-      <Compile Include="SampleData.cs" />
-      <Compile Include="Scope.cs" />
-      <Compile Include="SequenceReader.cs" />
-      <Compile Include="WatchableEnumerator.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -50,7 +50,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
-    <Compile Include="Async\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <Compile Remove="Async\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes [disabling of default compile items](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enabledefaultcompileitems), which was probably a dated hack from #261, to simplify the project file.

---
PS Credit to @viceroypenguin for [pointing this out](https://github.com/morelinq/MoreLINQ/pull/924/files#r1070623101).