### PR TITLE
Fix off-by-one index validation bug in `ToArrayByIndex`

### DIFF
--- a/MoreLinq.Test/ToArrayByIndexTest.cs
+++ b/MoreLinq.Test/ToArrayByIndexTest.cs
@@ -83,7 +83,7 @@ namespace MoreLinq.Test
             Assert.That(() => input.ToArrayByIndex(length, _ => badIndex),
                         Throws.TypeOf<IndexOutOfRangeException>());
 
-            Assert.That(() => input.ToArrayByIndex(10, _ => -1, BreakingFunc.Of<int, object>()),
+            Assert.That(() => input.ToArrayByIndex(length, _ => badIndex, BreakingFunc.Of<int, object>()),
                         Throws.TypeOf<IndexOutOfRangeException>());
         }
 

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -249,7 +249,7 @@ namespace MoreLinq
             {
                 var i = indexSelector(e);
 
-                if (i < 0 || i > array.Length)
+                if (i < 0 || i >= array.Length)
                 {
 #pragma warning disable CA2201 // Do not raise reserved exception types
                     throw new IndexOutOfRangeException();


### PR DESCRIPTION
This PR fixes the bug identified in issue #931.