### PR TITLE
Updated .NET Framework target to 4.6.2

### DIFF
--- a/MoreLinq.Test/CurrentThreadCultureScope.cs
+++ b/MoreLinq.Test/CurrentThreadCultureScope.cs
@@ -34,11 +34,7 @@ namespace MoreLinq.Test
 
         static void Install(CultureInfo value)
         {
-#if NET451
-            System.Threading.Thread.CurrentThread.CurrentCulture = value;
-#else
             CultureInfo.CurrentCulture = value;
-#endif
         }
     }
 }

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net451</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -48,11 +48,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Compile Remove="Async\*.cs" />
   </ItemGroup>
 
@@ -64,7 +64,7 @@
       <Compile Include="..\MoreLinq\Reactive\Subject.cs" Link="Subject.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -746,7 +746,7 @@ namespace MoreLinq.Experimental
 
         static class CompletedTask
         {
-            #if NET451 || NETSTANDARD1_0
+            #if NETSTANDARD1_0
 
             public static readonly Task Instance = CreateCompletedTask();
 

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -119,7 +119,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>3.3.2</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>net451;netstandard1.0;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard1.0;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <!-- Parallel build is disabled to avoid file locking issues during T4 code generation.
          See also: https://github.com/dotnet/msbuild/issues/2781 -->
     <BuildInParallel>false</BuildInParallel>
@@ -180,7 +180,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -191,7 +191,7 @@
     <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net451' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462' ">
     <DefineConstants>$(DefineConstants);NO_BUFFERS</DefineConstants>
   </PropertyGroup>
 
@@ -204,7 +204,7 @@
     <Compile Remove="Extensions.ToDataTable.g.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net451'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' Or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/test.cmd
+++ b/test.cmd
@@ -14,8 +14,8 @@ call build ^
   && call :test net6.0 Release ^
   && call :test netcoreapp3.1 Debug ^
   && call :test netcoreapp3.1 Release ^
-  && call :test net451 Debug ^
-  && call :test net451 Release ^
+  && call :test net462 Debug ^
+  && call :test net462 Release ^
   && call :report-cover
 goto :EOF
 
@@ -30,8 +30,8 @@ goto :EOF
 setlocal
 cd MoreLinq.Test
 echo Testing %1 (%2)...
-if %1==net451 (
-    bin\%2\net451\MoreLinq.Test.exe
+if %1==net462 (
+    bin\%2\net462\MoreLinq.Test.exe
     exit /b %ERRORLEVEL%
 )
 dotnet test --no-build -f %1 -c %2 --settings coverlet.runsettings || exit /b 1

--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,6 @@ if [[ -z `which mono 2>/dev/null` ]]; then
     echo>&2 against the Mono runtime will be skipped.
 else
     for c in $configs; do
-        mono MoreLinq.Test/bin/$c/net451/MoreLinq.Test.exe
+        mono MoreLinq.Test/bin/$c/net462/MoreLinq.Test.exe
     done
 fi


### PR DESCRIPTION
This PR closes #933.

Support for .NET Framework is retargeted from 4.5.1 that's no longer supported to the minimum supported version 4.6.1.
