### PR TITLE
Remove redundant type spec on obvious new expressions

### DIFF
--- a/MoreLinq.Test/KeyValuePair.cs
+++ b/MoreLinq.Test/KeyValuePair.cs
@@ -21,7 +21,6 @@ namespace MoreLinq.Test
 
     static class KeyValuePair
     {
-        public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) =>
-            new KeyValuePair<TKey, TValue>(key, value);
+        public static KeyValuePair<TKey, TValue> Create<TKey, TValue>(TKey key, TValue value) => new(key, value);
     }
 }

--- a/MoreLinq.Test/ReturnTest.cs
+++ b/MoreLinq.Test/ReturnTest.cs
@@ -26,7 +26,7 @@ namespace MoreLinq.Test
     {
         static class SomeSingleton
         {
-            public static readonly object Item = new object();
+            public static readonly object Item = new();
             public static readonly IEnumerable<object> Sequence = MoreEnumerable.Return(Item);
             public static IList<object> List => (IList<object>)Sequence;
             public static ICollection<object> Collection => (ICollection<object>)Sequence;

--- a/MoreLinq.Test/SampleData.cs
+++ b/MoreLinq.Test/SampleData.cs
@@ -25,11 +25,15 @@ namespace MoreLinq.Test
     /// </summary>
     static class SampleData
     {
-        internal static readonly ReadOnlyCollection<string> Strings = new ReadOnlyCollection<string>(
-            new[] { "ax", "hello", "world", "aa", "ab", "ay", "az" });
+        internal static readonly ReadOnlyCollection<string> Strings = new(new[]
+        {
+            "ax", "hello", "world", "aa", "ab", "ay", "az"
+        });
 
-        internal static readonly ReadOnlyCollection<int> Values =
-            new ReadOnlyCollection<int>(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        internal static readonly ReadOnlyCollection<int> Values = new(new[]
+        {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        });
 
         internal static readonly Func<int, int, int> Plus = (a, b) => a + b;
         internal static readonly Func<int, int, int> Mul = (a, b) => a * b;

--- a/MoreLinq.Test/ShuffleTest.cs
+++ b/MoreLinq.Test/ShuffleTest.cs
@@ -23,7 +23,7 @@ namespace MoreLinq.Test
     [TestFixture]
     public class ShuffleTest
     {
-        static Random seed = new Random(12345);
+        static Random seed = new(12345);
 
         [Test]
         public void ShuffleIsLazy()

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -38,12 +38,7 @@ namespace MoreLinq.Test
             public decimal? ANullableDecimal { get; }
             public object Unreadable { set => throw new NotImplementedException(); }
 
-            public object this[int index]
-            {
-                get => new object();
-                set { }
-            }
-
+            public object this[int index] { get => new(); set { } }
 
             public TestObject(int key)
             {
@@ -192,8 +187,9 @@ namespace MoreLinq.Test
 
         struct Point
         {
+
 #pragma warning disable CA1805 // Do not initialize unnecessarily (avoids CS0649)
-            public static Point Empty = new Point();
+            public static Point Empty = new();
 #pragma warning restore CA1805 // Do not initialize unnecessarily
             public bool IsEmpty => X == 0 && Y == 0;
             public int X { get; }

--- a/MoreLinq.Test/TraverseTest.cs
+++ b/MoreLinq.Test/TraverseTest.cs
@@ -64,8 +64,7 @@ namespace MoreLinq.Test
 
         static class Tree
         {
-            public static Tree<T> New<T>(T value, params Tree<T>[] children) =>
-                new Tree<T>(value, children);
+            public static Tree<T> New<T>(T value, params Tree<T>[] children) => new(value, children);
         }
 
         [Test]

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -23,8 +23,7 @@ namespace MoreLinq.Test
 
     partial class TestExtensions
     {
-        public static WatchableEnumerator<T> AsWatchable<T>(this IEnumerator<T> source) =>
-            new WatchableEnumerator<T>(source);
+        public static WatchableEnumerator<T> AsWatchable<T>(this IEnumerator<T> source) => new(source);
     }
 
     sealed class WatchableEnumerator<T> : IEnumerator<T>

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -40,10 +40,9 @@ namespace MoreLinq.Experimental
         /// asynchronously.
         /// </summary>
 
-        public static readonly AwaitQueryOptions Default =
-            new AwaitQueryOptions(null /* = unbounded concurrency */,
-                                  TaskScheduler.Default,
-                                  preserveOrder: false);
+        public static readonly AwaitQueryOptions Default = new(null /* = unbounded concurrency */,
+                                                               TaskScheduler.Default,
+                                                               preserveOrder: false);
 
         /// <summary>
         /// Gets a positive (non-zero) integer that specifies the maximum
@@ -766,7 +765,7 @@ namespace MoreLinq.Experimental
 
         sealed class ConcurrencyGate
         {
-            public static readonly ConcurrencyGate Unbounded = new ConcurrencyGate();
+            public static readonly ConcurrencyGate Unbounded = new();
 
             readonly SemaphoreSlim? _semaphore;
 

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -301,7 +301,7 @@ namespace MoreLinq
         static class Grouping
         {
             public static Grouping<TKey, TElement> Create<TKey, TElement>(TKey key, IEnumerable<TElement> members) =>
-                new Grouping<TKey, TElement>(key, members);
+                new(key, members);
         }
 
         #if !NO_SERIALIZATION_ATTRIBUTES

--- a/MoreLinq/Return.cs
+++ b/MoreLinq/Return.cs
@@ -63,8 +63,7 @@ namespace MoreLinq
             public void Insert(int index, T item) => throw ReadOnlyException();
             public void RemoveAt(int index)       => throw ReadOnlyException();
 
-            static NotSupportedException ReadOnlyException() =>
-                new NotSupportedException("Single element list is immutable.");
+            static NotSupportedException ReadOnlyException() => new("Single element list is immutable.");
         }
     }
 }


### PR DESCRIPTION
This PR uses target-typed new expressions to avoid repeating the type in `new` expressions where it's very obvious.