### PR TITLE
Improve and Validate `TestingSequence` assertions

### DIFF
--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -246,7 +246,7 @@ namespace MoreLinq.Test
             var error = new TestException("This is a test exception.");
 
             using var xs = MoreEnumerable.From(() => 123, () => throw error)
-                                         .AsTestingSequence(TestingSequence.Options.AllowMultipleEnumerations);
+                                         .AsTestingSequence(numEnumerations: 2);
             var memoized = xs.Memoize();
             using ((IDisposable)memoized)
             using (var r1 = memoized.Read())
@@ -274,7 +274,7 @@ namespace MoreLinq.Test
             using var xs = MoreEnumerable.From(() => 0 == i++
                                                    ? throw error // throw at start for first iteration only
                                                    : 42)
-                                         .AsTestingSequence(TestingSequence.Options.AllowMultipleEnumerations);
+                                         .AsTestingSequence(numEnumerations: 2);
             var memoized = xs.Memoize();
             using ((IDisposable)memoized)
             using (var r1 = memoized.Read())

--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -246,7 +246,7 @@ namespace MoreLinq.Test
             var error = new TestException("This is a test exception.");
 
             using var xs = MoreEnumerable.From(() => 123, () => throw error)
-                                         .AsTestingSequence(numEnumerations: 2);
+                                         .AsTestingSequence(maxEnumerations: 2);
             var memoized = xs.Memoize();
             using ((IDisposable)memoized)
             using (var r1 = memoized.Read())
@@ -274,7 +274,7 @@ namespace MoreLinq.Test
             using var xs = MoreEnumerable.From(() => 0 == i++
                                                    ? throw error // throw at start for first iteration only
                                                    : 42)
-                                         .AsTestingSequence(numEnumerations: 2);
+                                         .AsTestingSequence(maxEnumerations: 2);
             var memoized = xs.Memoize();
             using ((IDisposable)memoized)
             using (var r1 = memoized.Read())

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -135,6 +135,28 @@ namespace MoreLinq.Test
     public class TestingSequenceTest
     {
         [Test]
+        public void TestingSequencePublicPropertiesTest()
+        {
+            using var sequence = Of(1, 2, 3, 4);
+            Assert.That(sequence.IsDisposed, Is.False);
+            Assert.That(sequence.MoveNextCallCount, Is.EqualTo(0));
+
+            var iter = sequence.GetEnumerator();
+            Assert.That(sequence.IsDisposed, Is.False);
+            Assert.That(sequence.MoveNextCallCount, Is.EqualTo(0));
+
+            for (var i = 1; i <= 4; i++)
+            {
+                _ = iter.MoveNext();
+                Assert.That(sequence.IsDisposed, Is.False);
+                Assert.That(sequence.MoveNextCallCount, Is.EqualTo(i));
+            }
+
+            iter.Dispose();
+            Assert.That(sequence.IsDisposed, Is.True);
+        }
+
+        [Test]
         public void TestingSequenceShouldValidateDisposal()
         {
             static IEnumerable<int> InvalidUsage(IEnumerable<int> enumerable)

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         {
             None,
             AllowMultipleEnumerations
-    }
+        }
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ namespace MoreLinq.Test
                 ended = !moved;
                 MoveNextCallCount++;
             };
-			
+
             enumerator.GetCurrentCalled += delegate
             {
                 Assert.That(_disposed, Is.False, "LINQ operators should not attempt to get the Current value on a disposed sequence.");

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -186,8 +186,6 @@ namespace MoreLinq.Test
                     yield return 2;
                 using (enumerable.GetEnumerator())
                     yield return 3;
-
-                yield break;
             }
 
             static void Act()
@@ -250,8 +248,6 @@ namespace MoreLinq.Test
                 while (enumerator.MoveNext())
                     yield return enumerator.Current;
                 _ = enumerator.MoveNext();
-
-                yield break;
             }
 
             static void Act()
@@ -271,8 +267,6 @@ namespace MoreLinq.Test
                 var enumerator = enumerable.GetEnumerator();
                 enumerator.Dispose();
                 yield return enumerator.Current;
-
-                yield break;
             }
 
             static void Act()
@@ -293,8 +287,6 @@ namespace MoreLinq.Test
                 while (enumerator.MoveNext())
                     yield return enumerator.Current;
                 yield return enumerator.Current;
-
-                yield break;
             }
 
             static void Act()

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -211,7 +211,7 @@ namespace MoreLinq.Test
         {
             static IEnumerable<int> InvalidUsage(IEnumerable<int> enumerable)
             {
-                using var enumerator = enumerable.GetEnumerator();
+                var enumerator = enumerable.GetEnumerator();
                 enumerator.Dispose();
                 enumerator.MoveNext();
 
@@ -260,7 +260,7 @@ namespace MoreLinq.Test
         {
             static IEnumerable<int> InvalidUsage(IEnumerable<int> enumerable)
             {
-                using var enumerator = enumerable.GetEnumerator();
+                var enumerator = enumerable.GetEnumerator();
                 enumerator.Dispose();
                 yield return enumerator.Current;
 

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -20,6 +20,7 @@ namespace MoreLinq.Test
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Text.RegularExpressions;
     using NUnit.Framework;
     using static TestingSequence;
 
@@ -149,10 +150,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(ExpectedDisposal));
+            AssertTestingSequenceException(Act, ExpectedDisposal);
         }
 
         [Test]
@@ -176,10 +174,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(TooManyEnumerations));
+            AssertTestingSequenceException(Act, TooManyEnumerations);
         }
 
         [Test]
@@ -200,10 +195,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(TooManyDisposals));
+            AssertTestingSequenceException(Act, TooManyDisposals);
         }
 
         [Test]
@@ -224,10 +216,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(MoveNextPostDisposal));
+            AssertTestingSequenceException(Act, MoveNextPostDisposal);
         }
 
         [Test]
@@ -249,10 +238,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(MoveNextPostEnumeration));
+            AssertTestingSequenceException(Act, MoveNextPostEnumeration);
         }
 
         [Test]
@@ -273,10 +259,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(CurrentPostDisposal));
+            AssertTestingSequenceException(Act, CurrentPostDisposal);
         }
 
         [Test]
@@ -298,10 +281,7 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(CurrentPostEnumeration));
+            AssertTestingSequenceException(Act, CurrentPostEnumeration);
         }
 
         [Test]
@@ -321,10 +301,10 @@ namespace MoreLinq.Test
                 InvalidUsage(xs).Consume();
             }
 
-            Assert.That(
-                Act,
-                Throws.InstanceOf<AssertionException>()
-                    .With.Message.Contains(SimultaneousEnumerations));
+            AssertTestingSequenceException(Act, SimultaneousEnumerations);
         }
+
+        static void AssertTestingSequenceException(TestDelegate code, string message) =>
+            Assert.That(code, Throws.InstanceOf<AssertionException>().With.Message.Matches(@"^\s*" + Regex.Escape(message)));
     }
 }

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -160,11 +160,11 @@ namespace MoreLinq.Test
         {
             static IEnumerable<int> InvalidUsage(IEnumerable<int> enumerable)
             {
-                using (var _ = enumerable.GetEnumerator())
+                using (enumerable.GetEnumerator())
                     yield return 1;
-                using (var _ = enumerable.GetEnumerator())
+                using (enumerable.GetEnumerator())
                     yield return 2;
-                using (var _ = enumerable.GetEnumerator())
+                using (enumerable.GetEnumerator())
                     yield return 3;
 
                 yield break;

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         {
             None,
             AllowMultipleEnumerations
-        }
+    }
     }
 
     /// <summary>
@@ -86,15 +86,20 @@ namespace MoreLinq.Test
             _disposed = false;
             enumerator.Disposed += delegate
             {
-                Assert.That(_disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
                 _disposed = true;
             };
             var ended = false;
             enumerator.MoveNextCalled += (_, moved) =>
             {
-                Assert.That(ended, Is.False, "LINQ operators should not continue iterating a sequence that has terminated.");
+                Assert.That(_disposed, Is.False, "LINQ operators should not call MoveNext() on a disposed sequence.");
                 ended = !moved;
                 MoveNextCallCount++;
+            };
+			
+            enumerator.GetCurrentCalled += delegate
+            {
+                Assert.That(_disposed, Is.False, "LINQ operators should not attempt to get the Current value on a disposed sequence.");
+                Assert.That(ended, Is.False, "LINQ operators should not attempt to get the Current value on a completed sequence.");
             };
 
             if (!IsReiterationAllowed)

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -205,7 +205,7 @@ namespace MoreLinq.Test
             {
                 var enumerator = enumerable.GetEnumerator();
                 enumerator.Dispose();
-                enumerator.MoveNext();
+                _ = enumerator.MoveNext();
 
                 yield break;
             }
@@ -227,7 +227,7 @@ namespace MoreLinq.Test
                 using var enumerator = enumerable.GetEnumerator();
                 while (enumerator.MoveNext())
                     yield return enumerator.Current;
-                enumerator.MoveNext();
+                _ = enumerator.MoveNext();
 
                 yield break;
             }

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -31,13 +31,30 @@ namespace MoreLinq.Test
         readonly IEnumerator<T> _source;
 
         public event EventHandler? Disposed;
+        public event EventHandler? GetCurrentCalled;
         public event EventHandler<bool>? MoveNextCalled;
 
         public WatchableEnumerator(IEnumerator<T> source) =>
             _source = source ?? throw new ArgumentNullException(nameof(source));
 
-        public T Current => _source.Current;
-        object? IEnumerator.Current => Current;
+        public T Current
+        {
+            get
+            {
+                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
+                return _source.Current;
+            }
+        }
+
+        object? IEnumerator.Current
+        {
+            get
+            {
+                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
+                return Current;
+            }
+        }
+
         public void Reset() => _source.Reset();
 
         public bool MoveNext()

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -46,14 +46,7 @@ namespace MoreLinq.Test
             }
         }
 
-        object? IEnumerator.Current
-        {
-            get
-            {
-                GetCurrentCalled?.Invoke(this, EventArgs.Empty);
-                return Current;
-            }
-        }
+        object? IEnumerator.Current => this.Current;
 
         public void Reset() => _source.Reset();
 


### PR DESCRIPTION
This PR updates the assertions made in `TestingSequence`:
* Per the [specification](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose), it is not a failure to call `.Dispose()` multiple times. The `.Dispose()` method is expected to be idempotent, such that it is callable multiple times without throwing an exception. Updated to allow relying on this specification via `Options.AllowRepeatedDispoals`.
* Per the [specification](https://learn.microsoft.com/en-us/dotnet/api/system.collections.ienumerator.movenext?view=net-7.0#remarks), it is not a failure to call `.MoveNext()` after receiving a `false` response. The enumerator is simply expected to continue to return `false` for each following call. As such, we should not be afraid to take advantage of such behavior when it makes code easier (see #905 for examples). Updated to allow relying on this specification via `Options.AllowRepeatedMoveNexts`.
* While most `IEnumerator`s do not complain when calling `.MoveNext()` after disposal, it does indicate an error in our code to expect that `.MoveNext()` is a valid behavior after we have disposed the iterator. As such, we should fail directly.
* While most `IEnumerator`s return a default or the last value when calling `.Current` after `.MoveNext()` returns `false`, the spec does not make any promises on the usefulness of `.Current` in this situation. More importantly, we should be relying on `.MoveNext()` return value and not attempting to reference `.Current` in these cases. As such, we should fail directly.
* While most `IEnumerator`s do not complain when calling `.Current` after disposal, it does indicate an error in our code to expect that `.Current` is a valid behavior after we have disposed the iterator. As such, we should fail directly.
* Changing `AllowMultipleEnumerations` to an exact expectation of how many times the sequence should be enumerated.
* Disallowing multiple simultaneous enumerations.
* Adding unit tests to prove `TestingSequence` validates what it claims it validates; giving us better confidence that invalid MoreLinq and MoreLinq.Test code is written correctly.