### PR TITLE
Revert integration of T4 code generation into project file

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -157,7 +157,6 @@
 
   <ItemGroup>
     <None Include="..\COPYING.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
-    <None Include="*.g.tt" />
     <None Update="Aggregate.g.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Aggregate.g.cs</LastGenOutput>
@@ -247,34 +246,5 @@
       <DependentUpon>ToDelimitedString.g.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <Target Name="_CollectTextTemplates">
-    <ItemGroup>
-      <TextTemplate Include="%(None.Identity)" Condition="'%(None.Generator)' == 'TextTemplatingFileGenerator'">
-        <LastGenOutput>%(None.LastGenOutput)</LastGenOutput>
-      </TextTemplate>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_TransformTextTemplate" Inputs="$(TextTemplate)" Outputs="$(TextTemplateOutput)">
-    <Exec Command="dotnet t4 -h &gt; /dev/null" IgnoreExitCode="True" Condition="'$(WINDIR)' == ''">
-      <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
-    </Exec>
-    <Exec Command="dotnet t4 -h &gt; NUL" IgnoreExitCode="True" Condition="'$(WINDIR)' != ''">
-      <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
-    </Exec>
-    <Exec Command="dotnet tool restore" Condition="$(_TestExitCode) != 0" />
-    <Exec Command="dotnet t4 $(TextTemplate)" />
-  </Target>
-
-  <Target Name="TransformTextTemplates"
-          DependsOnTargets="_CollectTextTemplates">
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="_TransformTextTemplate"
-             Properties="TextTemplate=%(TextTemplate.Identity);TextTemplateOutput=%(TextTemplate.LastGenOutput)"  />
-  </Target>
-
-  <Target Name="_TransformTextTemplates"
-          AfterTargets="BeforeBuild" DependsOnTargets="TransformTextTemplates" />
 
 </Project>

--- a/MoreLinq/tt.cmd
+++ b/MoreLinq/tt.cmd
@@ -1,0 +1,8 @@
+@echo off
+pushd "%~dp0"
+for /f "tokens=*" %%f in ('dir /s /b *.tt') do (
+    echo>&2 dotnet t4 "%%f"
+    dotnet t4 "%%f" || goto :end
+)
+:end
+popd

--- a/MoreLinq/tt.sh
+++ b/MoreLinq/tt.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+find . -name "*.tt" -print0 | xargs -0 -t -L 1 sh -c '(dotnet t4 "$0" || exit 255)'

--- a/build.cmd
+++ b/build.cmd
@@ -13,6 +13,7 @@ if "%1"=="docs" shift & goto :docs
 dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.g.cs -x "[/\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
+  && call MoreLinq\tt ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
 goto :EOF
 

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ codegen() {
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq
 codegen MoreLinq/Extensions.ToDataTable.g.cs -i "[/\\\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq
+MoreLinq/tt.sh
 if [[ -z "$1" ]]; then
     configs="Debug Release"
 else


### PR DESCRIPTION
This reverts commit f669558facbbec9269a466c81594d5db8a19b4d1 from merge of PR #776.

The integration required parallel builds to be turned off for **MoreLinq**. Since PR #776, more frameworks are being targeted and this slows the build down considerably, taking per target 5 seconds (on my machine) and a total time of approximately 44 seconds:

    13:15:15:755	Rebuild started...
    13:15:16:123	Restored A:\MoreLINQ\main\bld\ExtensionsGenerator\MoreLinq.ExtensionsGenerator.csproj (in 38 ms).
    13:15:16:123	Restored A:\MoreLINQ\main\MoreLinq\MoreLinq.csproj (in 127 ms).
    13:15:16:372	1>------ Rebuild All started: Project: MoreLinq.ExtensionsGenerator, Configuration: Debug Any CPU ------
    13:15:16:374	2>------ Rebuild All started: Project: MoreLinq, Configuration: Debug Any CPU ------
    13:15:16:383	Restored A:\MoreLINQ\main\MoreLinq.Test\MoreLinq.Test.csproj (in 381 ms).
    13:15:17:577	1>MoreLinq.ExtensionsGenerator -> A:\MoreLINQ\main\bld\ExtensionsGenerator\bin\Debug\net7.0\MoreLinq.ExtensionsGenerator.dll
    13:15:24:161	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\net462\MoreLinq.dll
    13:15:29:861	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard1.0\MoreLinq.dll
    13:15:36:302	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard2.0\MoreLinq.dll
    13:15:43:464	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard2.1\MoreLinq.dll
    13:15:50:057	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\net6.0\MoreLinq.dll
    13:15:50:388	3>------ Rebuild All started: Project: MoreLinq.Test, Configuration: Debug Any CPU ------
    13:15:53:399	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net6.0\MoreLinq.Test.dll
    13:15:57:360	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\netcoreapp3.1\MoreLinq.Test.dll
    13:15:58:028	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net462\MoreLinq.Test.exe
    13:15:59:206	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net7.0\MoreLinq.Test.dll
    13:15:59:255	========== Rebuild All: 3 succeeded, 0 failed, 0 skipped ==========
    13:15:59:255	========== Elapsed 00:43.519 ==========

Reverting means that parallel builds can be enabled again and as a result, the total build time drop to approximately half:

    13:16:23:133	Rebuild started...
    13:16:23:338	Restored A:\MoreLINQ\main\bld\ExtensionsGenerator\MoreLinq.ExtensionsGenerator.csproj (in 24 ms).
    13:16:23:395	Restored A:\MoreLINQ\main\MoreLinq\MoreLinq.csproj (in 86 ms).
    13:16:23:508	Restored A:\MoreLINQ\main\MoreLinq.Test\MoreLinq.Test.csproj (in 260 ms).
    13:16:23:513	1>------ Rebuild All started: Project: MoreLinq.ExtensionsGenerator, Configuration: Debug Any CPU ------
    13:16:23:516	2>------ Rebuild All started: Project: MoreLinq, Configuration: Debug Any CPU ------
    13:16:25:174	1>MoreLinq.ExtensionsGenerator -> A:\MoreLINQ\main\bld\ExtensionsGenerator\bin\Debug\net7.0\MoreLinq.ExtensionsGenerator.dll
    13:16:25:641	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\net462\MoreLinq.dll
    13:16:27:179	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard1.0\MoreLinq.dll
    13:16:28:777	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard2.0\MoreLinq.dll
    13:16:30:275	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\netstandard2.1\MoreLinq.dll
    13:16:32:248	2>MoreLinq -> A:\MoreLINQ\main\MoreLinq\bin\Debug\net6.0\MoreLinq.dll
    13:16:32:387	3>------ Rebuild All started: Project: MoreLinq.Test, Configuration: Debug Any CPU ------
    13:16:35:260	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net6.0\MoreLinq.Test.dll
    13:16:40:810	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net462\MoreLinq.Test.exe
    13:16:41:595	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\netcoreapp3.1\MoreLinq.Test.dll
    13:16:42:223	3>MoreLinq.Test -> A:\MoreLINQ\main\MoreLinq.Test\bin\Debug\net7.0\MoreLinq.Test.dll
    13:16:42:289	========== Rebuild All: 3 succeeded, 0 failed, 0 skipped ==========
    13:16:42:289	========== Elapsed 00:19.232 ==========

The cost of integrating T4 (which is rarely invoked) does not seem to justify the cost of doubling the build times. There's a small inconvenience to having to remember keeping the generated code fresh if the template is change by invoking the help shell scripts if you're not using Visual Studio, where it happens the moment the template is saved. The freshness of the generated code is asserting during CI build

https://github.com/morelinq/MoreLINQ/blob/62914fb870b41c3e7e067cd88b21c5aeda67f432/appveyor.yml#L79-L83
