### PR TITLE
Fix home when setting path during CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ install:
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 3.1.10 --skip-non-versioned-files
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 6.0.11 --skip-non-versioned-files
-- sh: export PATH="~/.dotnet:$PATH"
+- sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info
 build_script:


### PR DESCRIPTION
The CI config prepends `~/.dotnet` to `PATH` for builds on Ubuntu. [`~` works for Bash, but not much else](https://stackoverflow.com/a/58150161/6682) so this PR updates the config to use `$HOME/.dotnet`.
