### PR TITLE
Improve list optimisation in `CountDown`

### DIFF
--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -65,11 +65,11 @@ namespace MoreLinq
 
             IEnumerable<TResult> IterateList(IListLike<T> list)
             {
-                var count = list.Count;
-                var countdown = Math.Min(count, count);
+                var listCount = list.Count;
+                var countdown = Math.Min(count, listCount);
 
-                for (var i = 0; i < count; i++)
-                    yield return resultSelector(list[i], count - i <= count ? --countdown : null);
+                for (var i = 0; i < listCount; i++)
+                    yield return resultSelector(list[i], listCount - i <= count ? --countdown : null);
             }
 
             IEnumerable<TResult> IterateCollection(int i)

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -65,15 +65,11 @@ namespace MoreLinq
 
             IEnumerable<TResult> IterateList(IListLike<T> list)
             {
-                var countdown = Math.Min(count, list.Count);
+                var count = list.Count;
+                var countdown = Math.Min(count, count);
 
-                for (var i = 0; i < list.Count; i++)
-                {
-                    var cd = list.Count - i <= count
-                           ? --countdown
-                           : (int?) null;
-                    yield return resultSelector(list[i], cd);
-                }
+                for (var i = 0; i < count; i++)
+                    yield return resultSelector(list[i], count - i <= count ? --countdown : null);
             }
 
             IEnumerable<TResult> IterateCollection(int i)


### PR DESCRIPTION
`CountDown` has a path optimised for when the `source` parameter is a list, but it was poorly written respect to performance. It accessed the list `Count` property 3 times, twice during each iteration of the loop. Each access is a virtual dispatch so it seems to adds up, making it perform _worse_ than when the source is a sequence (zero net optimisation). This PR fixes that by accessing `Count` once, storing it in a local and then using the local throughout. This improves the performance by 40%.

## Before this PR

|            Method |               Source |     Mean |    Error |   StdDev |   Median | Allocated |
|------------------ |--------------------- |---------:|---------:|---------:|---------:|----------:|
| MoreLinqCountDown |       Int32[1000000] | 21.31 ms | 0.426 ms | 1.209 ms | 21.02 ms |     119 B |
| MoreLinqCountDown | Syste(...)rator [36] | 19.30 ms | 0.496 ms | 1.440 ms | 18.54 ms |     179 B |

See [`benchmarks-before.log.txt`](https://github.com/morelinq/MoreLINQ/files/10483667/benchmarks-before.log.txt) for full details.

## After this PR

|            Method |               Source |     Mean |    Error |   StdDev |   Median | Allocated |
|------------------ |--------------------- |---------:|---------:|---------:|---------:|----------:|
| MoreLinqCountDown |       Int32[1000000] | 12.83 ms | 0.318 ms | 0.934 ms | 12.63 ms |     100 B |
| MoreLinqCountDown | Syste(...)rator [36] | 20.65 ms | 0.631 ms | 1.851 ms | 20.01 ms |     179 B |

See [`benchmarks-after.log.txt`](https://github.com/morelinq/MoreLINQ/files/10483669/benchmarks-after.log.txt) for full details.

## Additional Information

    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.1105)
    Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
    .NET SDK=7.0.102
      [Host] : .NET 7.0.2 (7.0.222.60605), X86 RyuJIT AVX2

See also:

- [`Benchmark.linq`](http://share.linqpad.net/d63764.linq) for benchmarking code for [LINQPad](https://www.linqpad.net/).
- PR #472 for some related discussion.
