### PR TITLE
Enforce and address code style issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,6 +60,9 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 
+# Indentation
+csharp_indent_case_contents_when_block = false
+
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = omit_if_default
 
@@ -74,3 +77,6 @@ csharp_using_directive_placement = inside_namespace
 
 # IDE0048: Add parentheses for clarity
 dotnet_diagnostic.IDE0048.severity = suggestion
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -35,7 +35,7 @@ csharp_style_var_elsewhere = true:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none
-csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_constructors = true
 csharp_style_expression_bodied_operators = false:none
 
 # Prefer property-like constructs to have an expression-body

--- a/.editorconfig
+++ b/.editorconfig
@@ -80,3 +80,6 @@ dotnet_diagnostic.IDE0048.severity = suggestion
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0046: Convert to conditional expression
+dotnet_diagnostic.IDE0046.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -28,6 +28,9 @@ max_line_length = 100
 [*.cs]
 dotnet_analyzer_diagnostic.category-Style.severity = warning
 
+# IDE0022: Use expression/block body for methods
+dotnet_diagnostic.IDE0022.severity = suggestion
+
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,8 @@ indent_size = 4
 max_line_length = 100
 
 [*.cs]
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
@@ -60,4 +62,15 @@ csharp_preserve_single_line_blocks = true
 
 # Modifier preferences
 dotnet_style_require_accessibility_modifiers = omit_if_default
-dotnet_diagnostic.IDE0040.severity = warning
+
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline
+
+# IDE0061: Use block body for local functions
+csharp_style_expression_bodied_local_functions = true
+
+# IDE0065: Misplaced using directive
+csharp_using_directive_placement = inside_namespace
+
+# IDE0048: Add parentheses for clarity
+dotnet_diagnostic.IDE0048.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,7 +34,7 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 
 # Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_methods = true
 csharp_style_expression_bodied_constructors = true
 csharp_style_expression_bodied_operators = false:none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,27 +32,27 @@ dotnet_analyzer_diagnostic.category-Style.severity = warning
 dotnet_diagnostic.IDE0022.severity = suggestion
 
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true
 csharp_style_expression_bodied_constructors = true
-csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_operators = true
 
 # Prefer property-like constructs to have an expression-body
-csharp_style_expression_bodied_properties = true:none
-csharp_style_expression_bodied_indexers = true:none
-csharp_style_expression_bodied_accessors = true:none
+csharp_style_expression_bodied_properties = true
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_accessors = true
 
 # Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_throw_expression = true
+csharp_style_conditional_delegate_call = true
+csharp_prefer_simple_default_expression = true
 
 # Spacing
 csharp_space_after_cast = false

--- a/MoreLinq.Test/.editorconfig
+++ b/MoreLinq.Test/.editorconfig
@@ -26,3 +26,6 @@ dotnet_diagnostic.CA1707.severity = none
 
 # CA1308: Normalize strings to uppercase
 dotnet_diagnostic.CA1308.severity = none
+
+# IDE0047: Remove unnecessary parentheses
+dotnet_diagnostic.IDE0047.severity = suggestion

--- a/MoreLinq.Test/.editorconfig
+++ b/MoreLinq.Test/.editorconfig
@@ -29,3 +29,8 @@ dotnet_diagnostic.CA1308.severity = none
 
 # IDE0047: Remove unnecessary parentheses
 dotnet_diagnostic.IDE0047.severity = suggestion
+
+[*{Test,Tests}.cs]
+
+# IDE0022: Use expression/block body for methods
+dotnet_diagnostic.IDE0022.severity = none

--- a/MoreLinq.Test/AcquireTest.cs
+++ b/MoreLinq.Test/AcquireTest.cs
@@ -69,7 +69,7 @@ namespace MoreLinq.Test
         sealed class Disposable : IDisposable
         {
             public bool Disposed { get; private set; }
-            public void Dispose() { Disposed = true; }
+            public void Dispose() => Disposed = true;
         }
     }
 }

--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -112,8 +112,8 @@ namespace MoreLinq.Test
                         0, (s, e) => s + e.Num,
                         0, (s, e) => e.Num % 2 == 0 ? s + e.Num : s,
                         0, (s, _) => s + 1,
-                        (int?)null, (s, e) => s is {} n ? Math.Min(n, e.Num) : e.Num,
-                        (int?)null, (s, e) => s is {} n ? Math.Max(n, e.Num) : e.Num,
+                        (int?)null, (s, e) => s is { } n ? Math.Min(n, e.Num) : e.Num,
+                        (int?)null, (s, e) => s is { } n ? Math.Max(n, e.Num) : e.Num,
                         new HashSet<int>(), (s, e) => { _ = s.Add(e.Str.Length); return s; },
                         new List<(int Num, string Str)>(), (s, e) => { s.Add((e.Num, e.Str)); return s; },
                         (sum, esum, count, min, max, lengths, items) => new

--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -114,7 +114,7 @@ namespace MoreLinq.Test
                         0, (s, _) => s + 1,
                         (int?)null, (s, e) => s is {} n ? Math.Min(n, e.Num) : e.Num,
                         (int?)null, (s, e) => s is {} n ? Math.Max(n, e.Num) : e.Num,
-                        new HashSet<int>(), (s, e) => { s.Add(e.Str.Length); return s; },
+                        new HashSet<int>(), (s, e) => { _ = s.Add(e.Str.Length); return s; },
                         new List<(int Num, string Str)>(), (s, e) => { s.Add((e.Num, e.Str)); return s; },
                         (sum, esum, count, min, max, lengths, items) => new
                         {

--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -81,7 +81,7 @@ namespace MoreLinq.Test
         [Test]
         public void AppendWithSharedSource()
         {
-            var first  = new [] { 1 }.Append(2);
+            var first  = new[] { 1 }.Append(2);
             var second = first.Append(3).Append(4);
             var third  = first.Append(4).Append(8);
 

--- a/MoreLinq.Test/AppendTest.cs
+++ b/MoreLinq.Test/AppendTest.cs
@@ -54,7 +54,7 @@ namespace MoreLinq.Test
         [Test]
         public void AppendIsLazyInHeadSequence()
         {
-            new BreakingSequence<string>().Append("tail");
+            _ = new BreakingSequence<string>().Append("tail");
         }
         #endregion
 

--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -104,13 +104,13 @@ namespace MoreLinq.Test
         [Test]
         public void AssertCountIsLazy()
         {
-            new BreakingSequence<object>().AssertCount(0);
+            _ = new BreakingSequence<object>().AssertCount(0);
         }
 
         [Test]
         public void AssertCountWithCollectionIsLazy()
         {
-            new BreakingCollection<int>(new int[5]).AssertCount(0);
+            _ = new BreakingCollection<int>(new int[5]).AssertCount(0);
         }
 
         [Test]
@@ -133,7 +133,7 @@ namespace MoreLinq.Test
         [Test]
         public void AssertCountWithReadOnlyCollectionIsLazy()
         {
-            new BreakingReadOnlyCollection<object>(5).AssertCount(0);
+            _ = new BreakingReadOnlyCollection<object>(5).AssertCount(0);
         }
     }
 }

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
         sealed class ValueException : Exception
         {
             public object Value { get; }
-            public ValueException(object value) { Value = value; }
+            public ValueException(object value) => Value = value;
         }
     }
 }

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -26,8 +26,8 @@ namespace MoreLinq.Test
         [Test]
         public void AssertIsLazy()
         {
-            new BreakingSequence<object>().Assert(BreakingFunc.Of<object, bool>());
-            new BreakingSequence<object>().Assert(BreakingFunc.Of<object, bool>(), BreakingFunc.Of<object, Exception>());
+            _ = new BreakingSequence<object>().Assert(BreakingFunc.Of<object, bool>());
+            _ = new BreakingSequence<object>().Assert(BreakingFunc.Of<object, bool>(), BreakingFunc.Of<object, Exception>());
         }
 
         [Test]

--- a/MoreLinq.Test/AssertTest.cs
+++ b/MoreLinq.Test/AssertTest.cs
@@ -33,7 +33,7 @@ namespace MoreLinq.Test
         [Test]
         public void AssertSequenceWithValidAllElements()
         {
-            var source = new[] {2, 4, 6, 8};
+            var source = new[] { 2, 4, 6, 8 };
             source.Assert(n => n % 2 == 0).AssertSequenceEqual(source);
         }
 

--- a/MoreLinq.Test/Async/AsyncEnumerable.cs
+++ b/MoreLinq.Test/Async/AsyncEnumerable.cs
@@ -511,19 +511,19 @@ namespace MoreLinq.Test.Async
             LinqEnumerable.ToArrayAsync(source);
 
         public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector)
-            where TKey: notnull =>
+            where TKey : notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector);
 
         public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-            where TKey: notnull =>
+            where TKey : notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, comparer);
 
         public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
-            where TKey: notnull =>
+            where TKey : notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, elementSelector);
 
         public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
-            where TKey: notnull =>
+            where TKey : notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, elementSelector, comparer);
 
         public static ValueTask<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source) =>

--- a/MoreLinq.Test/BacksertTest.cs
+++ b/MoreLinq.Test/BacksertTest.cs
@@ -26,7 +26,7 @@ namespace MoreLinq.Test
         [Test]
         public void BacksertIsLazy()
         {
-            new BreakingSequence<int>().Backsert(new BreakingSequence<int>(), 0);
+            _ = new BreakingSequence<int>().Backsert(new BreakingSequence<int>(), 0);
         }
 
         [Test]

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -92,7 +92,7 @@ namespace MoreLinq.Test
         [Test]
         public void BatchIsLazy()
         {
-            new BreakingSequence<object>().Batch(1);
+            _ = new BreakingSequence<object>().Batch(1);
         }
 
         [TestCase(SourceKind.BreakingCollection  , 0)]

--- a/MoreLinq.Test/BreakingCollection.cs
+++ b/MoreLinq.Test/BreakingCollection.cs
@@ -24,7 +24,7 @@ namespace MoreLinq.Test
     {
         protected readonly IList<T> List;
 
-        public BreakingCollection(params T[] values) : this ((IList<T>) values) {}
+        public BreakingCollection(params T[] values) : this((IList<T>)values) { }
         public BreakingCollection(IList<T> list) => List = list;
 
         public int Count => List.Count;

--- a/MoreLinq.Test/BreakingList.cs
+++ b/MoreLinq.Test/BreakingList.cs
@@ -30,8 +30,8 @@ namespace MoreLinq.Test
 
     sealed class BreakingList<T> : BreakingCollection<T>, IList<T>
     {
-        public BreakingList() : this(new List<T>()) {}
-        public BreakingList(List<T> list) : base(list) {}
+        public BreakingList() : this(new List<T>()) { }
+        public BreakingList(List<T> list) : base(list) { }
 
         public int IndexOf(T item) => List.IndexOf(item);
         public void Insert(int index, T item) => throw new NotImplementedException();

--- a/MoreLinq.Test/BreakingReadOnlyCollection.cs
+++ b/MoreLinq.Test/BreakingReadOnlyCollection.cs
@@ -23,7 +23,7 @@ namespace MoreLinq.Test
     {
         readonly IReadOnlyCollection<T> _collection;
 
-        public BreakingReadOnlyCollection(params T[] values) : this ((IReadOnlyCollection<T>) values) {}
+        public BreakingReadOnlyCollection(params T[] values) : this((IReadOnlyCollection<T>)values) { }
         public BreakingReadOnlyCollection(IReadOnlyCollection<T> collection) => _collection = collection;
         public int Count => _collection.Count;
     }

--- a/MoreLinq.Test/BreakingReadOnlyList.cs
+++ b/MoreLinq.Test/BreakingReadOnlyList.cs
@@ -31,8 +31,8 @@ namespace MoreLinq.Test
     {
         readonly IReadOnlyList<T> _list;
 
-        public BreakingReadOnlyList(params T[] values) : this ((IReadOnlyList<T>) values) {}
-        public BreakingReadOnlyList(IReadOnlyList<T> list) : base (list)
+        public BreakingReadOnlyList(params T[] values) : this((IReadOnlyList<T>)values) { }
+        public BreakingReadOnlyList(IReadOnlyList<T> list) : base(list)
             => _list = list;
 
         public T this[int index] => _list[index];

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -31,9 +31,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestCartesianIsLazy()
         {
-            new BreakingSequence<string>()
-                .Cartesian(new BreakingSequence<int>(),
-                           BreakingFunc.Of<string, int, bool>());
+            var bs = new BreakingSequence<string>();
+            _ = bs.Cartesian(new BreakingSequence<int>(), BreakingFunc.Of<string, int, bool>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -81,7 +81,7 @@ namespace MoreLinq.Test
         {
             const int countA = 100;
             const int countB = 75;
-            const int expectedCount = countA*countB;
+            const int expectedCount = countA * countB;
             using var sequenceA = Enumerable.Range(1, countA).AsTestingSequence();
             using var sequenceB = Enumerable.Range(1, countB).AsTestingSequence();
 

--- a/MoreLinq.Test/ChooseTest.cs
+++ b/MoreLinq.Test/ChooseTest.cs
@@ -26,8 +26,7 @@ namespace MoreLinq.Test
         [Test]
         public void IsLazy()
         {
-            new BreakingSequence<object>()
-                .Choose(BreakingFunc.Of<object, (bool, object)>());
+            _ = new BreakingSequence<object>().Choose(BreakingFunc.Of<object, (bool, object)>());
         }
 
         [Test]

--- a/MoreLinq.Test/ChooseTest.cs
+++ b/MoreLinq.Test/ChooseTest.cs
@@ -75,7 +75,7 @@ namespace MoreLinq.Test
         public void ThoseThatAreIntegers()
         {
             new int?[] { 0, 1, 2, null, 4, null, 6, null, null, 9 }
-                .Choose(e => e is {} n ? Option.Some(n) : Option<int>.None)
+                .Choose(e => e is { } n ? Option.Some(n) : Option<int>.None)
                 .AssertSequenceEqual(0, 1, 2, 4, 6, 9);
         }
 

--- a/MoreLinq.Test/CountByTest.cs
+++ b/MoreLinq.Test/CountByTest.cs
@@ -85,7 +85,7 @@ namespace MoreLinq.Test
         [Test]
         public void CountByIsLazy()
         {
-            new BreakingSequence<string>().CountBy(BreakingFunc.Of<string, int>());
+            _ = new BreakingSequence<string>().CountBy(BreakingFunc.Of<string, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -38,7 +38,7 @@ namespace MoreLinq.Test
             const int count = 10;
             Enumerable.Range(1, count)
                       .CountDown(-1000, (_, cd) => cd)
-                      .AssertSequenceEqual(Enumerable.Repeat((int?) null, count));
+                      .AssertSequenceEqual(Enumerable.Repeat((int?)null, count));
         }
 
         static IEnumerable<T> GetData<T>(Func<int[], int, int?[], T> selector)

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -28,8 +28,8 @@ namespace MoreLinq.Test
         [Test]
         public void IsLazy()
         {
-            new BreakingSequence<object>()
-                .CountDown(42, BreakingFunc.Of<object, int?, object>());
+            var bs = new BreakingSequence<object>();
+            _ = bs.CountDown(42, BreakingFunc.Of<object, int?, object>());
         }
 
         [Test]

--- a/MoreLinq.Test/CurrentThreadCultureScope.cs
+++ b/MoreLinq.Test/CurrentThreadCultureScope.cs
@@ -24,14 +24,7 @@ namespace MoreLinq.Test
         public CurrentThreadCultureScope(CultureInfo @new) :
             base(CultureInfo.CurrentCulture) => Install(@new);
 
-        protected override void Restore(CultureInfo old)
-        {
-            Install(old);
-        }
-
-        static void Install(CultureInfo value)
-        {
-            CultureInfo.CurrentCulture = value;
-        }
+        protected override void Restore(CultureInfo old) => Install(old);
+        static void Install(CultureInfo value) => CultureInfo.CurrentCulture = value;
     }
 }

--- a/MoreLinq.Test/CurrentThreadCultureScope.cs
+++ b/MoreLinq.Test/CurrentThreadCultureScope.cs
@@ -22,10 +22,7 @@ namespace MoreLinq.Test
     sealed class CurrentThreadCultureScope : Scope<CultureInfo>
     {
         public CurrentThreadCultureScope(CultureInfo @new) :
-            base(CultureInfo.CurrentCulture)
-        {
-            Install(@new);
-        }
+            base(CultureInfo.CurrentCulture) => Install(@new);
 
         protected override void Restore(CultureInfo old)
         {

--- a/MoreLinq.Test/DistinctByTest.cs
+++ b/MoreLinq.Test/DistinctByTest.cs
@@ -34,7 +34,7 @@ namespace MoreLinq.Test
         [Test]
         public void DistinctByIsLazy()
         {
-            new BreakingSequence<string>().DistinctBy(BreakingFunc.Of<string, int>());
+            _ = new BreakingSequence<string>().DistinctBy(BreakingFunc.Of<string, int>());
         }
 
         [Test]
@@ -56,8 +56,8 @@ namespace MoreLinq.Test
         [Test]
         public void DistinctByIsLazyWithComparer()
         {
-            new BreakingSequence<string>()
-                .DistinctBy(BreakingFunc.Of<string, string>(), StringComparer.Ordinal);
+            var bs = new BreakingSequence<string>();
+            _ = bs.DistinctBy(BreakingFunc.Of<string, string>(), StringComparer.Ordinal);
         }
     }
 }

--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -24,17 +24,17 @@ namespace MoreLinq.Test
     [TestFixture]
     public class EndsWithTest
     {
-        [TestCase(new[] {1, 2, 3}, new[] {2, 3}, ExpectedResult = true)]
-        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, ExpectedResult = true)]
-        [TestCase(new[] {1, 2, 3}, new[] {0, 1, 2, 3}, ExpectedResult = false)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 2, 3 }, ExpectedResult = true)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, ExpectedResult = true)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 0, 1, 2, 3 }, ExpectedResult = false)]
         public bool EndsWithWithIntegers(IEnumerable<int> first, IEnumerable<int> second)
         {
             return first.EndsWith(second);
         }
 
-        [TestCase(new[] {'1', '2', '3'}, new[] {'2', '3'}, ExpectedResult = true)]
-        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3'}, ExpectedResult = true)]
-        [TestCase(new[] {'1', '2', '3'}, new[] {'0', '1', '2', '3'}, ExpectedResult = false)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '2', '3' }, ExpectedResult = true)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '1', '2', '3' }, ExpectedResult = true)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '0', '1', '2', '3' }, ExpectedResult = false)]
         public bool EndsWithWithChars(IEnumerable<char> first, IEnumerable<char> second)
         {
             return first.EndsWith(second);
@@ -58,7 +58,7 @@ namespace MoreLinq.Test
         [Test]
         public void EndsWithReturnsFalseIfOnlyFirstIsEmpty()
         {
-            Assert.That(new int[0].EndsWith(new[] {1,2,3}), Is.False);
+            Assert.That(new int[0].EndsWith(new[] { 1, 2, 3 }), Is.False);
         }
 
         [TestCase("", "", ExpectedResult = true)]
@@ -72,7 +72,7 @@ namespace MoreLinq.Test
         [Test]
         public void EndsWithDisposesBothSequenceEnumerators()
         {
-            using var first = TestingSequence.Of(1,2,3);
+            using var first = TestingSequence.Of(1, 2, 3);
             using var second = TestingSequence.Of(1);
 
             _ = first.EndsWith(second);
@@ -82,8 +82,8 @@ namespace MoreLinq.Test
         [SuppressMessage("ReSharper", "RedundantArgumentDefaultValue")]
         public void EndsWithUsesSpecifiedEqualityComparerOrDefault()
         {
-            var first = new[] {1,2,3};
-            var second = new[] {4,5,6};
+            var first = new[] { 1, 2, 3 };
+            var second = new[] { 4, 5, 6 };
 
             Assert.That(first.EndsWith(second), Is.False);
             Assert.That(first.EndsWith(second, null), Is.False);

--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -75,7 +75,7 @@ namespace MoreLinq.Test
             using var first = TestingSequence.Of(1,2,3);
             using var second = TestingSequence.Of(1);
 
-            first.EndsWith(second);
+            _ = first.EndsWith(second);
         }
 
         [Test]

--- a/MoreLinq.Test/EqualityComparer.cs
+++ b/MoreLinq.Test/EqualityComparer.cs
@@ -36,7 +36,7 @@ namespace MoreLinq.Test
             readonly Func<T, int> _hasher;
 
             public DelegatingComparer(Func<T?, T?, bool> comparer)
-                : this(comparer, x => x == null ? 0 : x.GetHashCode()) {}
+                : this(comparer, x => x == null ? 0 : x.GetHashCode()) { }
 
             DelegatingComparer(Func<T?, T?, bool> comparer, Func<T, int> hasher)
             {

--- a/MoreLinq.Test/EquiZipTest.cs
+++ b/MoreLinq.Test/EquiZipTest.cs
@@ -73,7 +73,7 @@ namespace MoreLinq.Test
         public void ZipIsLazy()
         {
             var bs = new BreakingSequence<int>();
-            bs.EquiZip(bs, BreakingFunc.Of<int, int, int>());
+            _ = bs.EquiZip(bs, BreakingFunc.Of<int, int, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/EvaluateTest.cs
+++ b/MoreLinq.Test/EvaluateTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestEvaluateIsLazy()
         {
-            new BreakingSequence<Func<int>>().Evaluate();
+            _ = new BreakingSequence<Func<int>>().Evaluate();
         }
 
         [Test]

--- a/MoreLinq.Test/ExceptByTest.cs
+++ b/MoreLinq.Test/ExceptByTest.cs
@@ -52,7 +52,7 @@ namespace MoreLinq.Test
         public void ExceptByWithComparer()
         {
             string[] first = { "first", "second", "third", "fourth" };
-            string[] second = { "FIRST" , "thiRD", "FIFTH" };
+            string[] second = { "FIRST", "thiRD", "FIFTH" };
             var result = first.ExceptBy(second, word => word, StringComparer.OrdinalIgnoreCase);
             result.AssertSequenceEqual("second", "fourth");
         }

--- a/MoreLinq.Test/ExceptByTest.cs
+++ b/MoreLinq.Test/ExceptByTest.cs
@@ -36,7 +36,7 @@ namespace MoreLinq.Test
         public void ExceptByIsLazy()
         {
             var bs = new BreakingSequence<string>();
-            bs.ExceptBy(bs, BreakingFunc.Of<string, int>());
+            _ = bs.ExceptBy(bs, BreakingFunc.Of<string, int>());
         }
 
         [Test]
@@ -70,7 +70,7 @@ namespace MoreLinq.Test
         public void ExceptByIsLazyWithComparer()
         {
             var bs = new BreakingSequence<string>();
-            bs.ExceptBy(bs, BreakingFunc.Of<string, string>(), StringComparer.Ordinal);
+            _ = bs.ExceptBy(bs, BreakingFunc.Of<string, string>(), StringComparer.Ordinal);
         }
     }
 }

--- a/MoreLinq.Test/ExcludeTest.cs
+++ b/MoreLinq.Test/ExcludeTest.cs
@@ -31,7 +31,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestExcludeIsLazy()
         {
-            new BreakingSequence<int>().Exclude(0, 10);
+            _ = new BreakingSequence<int>().Exclude(0, 10);
         }
 
         /// <summary>

--- a/MoreLinq.Test/FillBackwardTest.cs
+++ b/MoreLinq.Test/FillBackwardTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void FillBackwardIsLazy()
         {
-            new BreakingSequence<object>().FillBackward();
+            _ = new BreakingSequence<object>().FillBackward();
         }
 
         [Test]

--- a/MoreLinq.Test/FillForwardTest.cs
+++ b/MoreLinq.Test/FillForwardTest.cs
@@ -27,7 +27,7 @@ namespace MoreLinq.Test
         [Test]
         public void FillForwardIsLazy()
         {
-            new BreakingSequence<object>().FillForward();
+            _ = new BreakingSequence<object>().FillForward();
         }
 
         [Test]

--- a/MoreLinq.Test/FlattenTest.cs
+++ b/MoreLinq.Test/FlattenTest.cs
@@ -109,7 +109,7 @@ namespace MoreLinq.Test
         [Test]
         public void FlattenIsLazy()
         {
-            new BreakingSequence<int>().Flatten();
+            _ = new BreakingSequence<int>().Flatten();
         }
 
         // Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
@@ -220,7 +220,7 @@ namespace MoreLinq.Test
         [Test]
         public void FlattenPredicateIsLazy()
         {
-            new BreakingSequence<int>().Flatten(BreakingFunc.Of<object, bool>());
+            _ = new BreakingSequence<int>().Flatten(BreakingFunc.Of<object, bool>());
         }
 
         [Test]
@@ -298,7 +298,7 @@ namespace MoreLinq.Test
         [Test]
         public void FlattenSelectorIsLazy()
         {
-            new BreakingSequence<int>().Flatten(BreakingFunc.Of<object, IEnumerable>());
+            _ = new BreakingSequence<int>().Flatten(BreakingFunc.Of<object, IEnumerable>());
         }
 
         [Test]

--- a/MoreLinq.Test/FlattenTest.cs
+++ b/MoreLinq.Test/FlattenTest.cs
@@ -422,7 +422,7 @@ namespace MoreLinq.Test
             public readonly Tree<T>? Left;
             public readonly Tree<T>? Right;
 
-            public Tree(T value) : this(null, value, null) {}
+            public Tree(T value) : this(null, value, null) { }
             public Tree(Tree<T>? left, T value, Tree<T>? right)
             {
                 Left = left;

--- a/MoreLinq.Test/FromTest.cs
+++ b/MoreLinq.Test/FromTest.cs
@@ -59,7 +59,7 @@ namespace MoreLinq.Test
         [TestCase(4)]
         public void TestFromInvokesMethodsMultipleTimes(int numArgs)
         {
-            var evals = new [] { 0, 0, 0, 0 };
+            var evals = new[] { 0, 0, 0, 0 };
             int F1() { evals[0]++; return -2; }
             int F2() { evals[1]++; return -2; }
             int F3() { evals[2]++; return -2; }

--- a/MoreLinq.Test/FromTest.cs
+++ b/MoreLinq.Test/FromTest.cs
@@ -26,10 +26,10 @@ namespace MoreLinq.Test
         public void TestFromIsLazy()
         {
             var breakingFunc = BreakingFunc.Of<int>();
-            MoreEnumerable.From(breakingFunc);
-            MoreEnumerable.From(breakingFunc, breakingFunc);
-            MoreEnumerable.From(breakingFunc, breakingFunc, breakingFunc);
-            MoreEnumerable.From(breakingFunc, breakingFunc, breakingFunc, breakingFunc);
+            _ = MoreEnumerable.From(breakingFunc);
+            _ = MoreEnumerable.From(breakingFunc, breakingFunc);
+            _ = MoreEnumerable.From(breakingFunc, breakingFunc, breakingFunc);
+            _ = MoreEnumerable.From(breakingFunc, breakingFunc, breakingFunc, breakingFunc);
         }
 
         [TestCase(1)]

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -34,7 +34,7 @@ namespace MoreLinq.Test
             var bf = BreakingFunc.Of<int, int>();
             var bfg = BreakingFunc.Of<int, IEnumerable<int>, IEnumerable<int>, int>();
 
-            bs.FullGroupJoin(bs, bf, bf, bfg);
+            _ = bs.FullGroupJoin(bs, bf, bf, bfg);
         }
 
         [TestCase(CustomResult)]

--- a/MoreLinq.Test/GenerateTest.cs
+++ b/MoreLinq.Test/GenerateTest.cs
@@ -41,7 +41,7 @@ namespace MoreLinq.Test
         [Test]
         public void GenerateIsLazy()
         {
-            MoreEnumerable.Generate(0, BreakingFunc.Of<int, int>());
+            _ = MoreEnumerable.Generate(0, BreakingFunc.Of<int, int>());
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace MoreLinq.Test
         [Test]
         public void GenerateByIndexIsLazy()
         {
-            MoreEnumerable.GenerateByIndex(BreakingFunc.Of<int, int>());
+            _ = MoreEnumerable.GenerateByIndex(BreakingFunc.Of<int, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/GroupAdjacentTest.cs
+++ b/MoreLinq.Test/GroupAdjacentTest.cs
@@ -32,12 +32,12 @@ namespace MoreLinq.Test
             var bfo = BreakingFunc.Of<object, object>();
             var bfg = BreakingFunc.Of<int, IEnumerable<object>, IEnumerable<object>>();
 
-            bs.GroupAdjacent(bf);
-            bs.GroupAdjacent(bf, bfo);
-            bs.GroupAdjacent(bf, bfo, EqualityComparer<int>.Default);
-            bs.GroupAdjacent(bf, EqualityComparer<int>.Default);
-            bs.GroupAdjacent(bf, bfg);
-            bs.GroupAdjacent(bf, bfg, EqualityComparer<int>.Default);
+            _ = bs.GroupAdjacent(bf);
+            _ = bs.GroupAdjacent(bf, bfo);
+            _ = bs.GroupAdjacent(bf, bfo, EqualityComparer<int>.Default);
+            _ = bs.GroupAdjacent(bf, EqualityComparer<int>.Default);
+            _ = bs.GroupAdjacent(bf, bfg);
+            _ = bs.GroupAdjacent(bf, bfg, EqualityComparer<int>.Default);
         }
 
         [Test]

--- a/MoreLinq.Test/IndexByTest.cs
+++ b/MoreLinq.Test/IndexByTest.cs
@@ -72,7 +72,7 @@ namespace MoreLinq.Test
         [Test]
         public void IndexByIsLazy()
         {
-            new BreakingSequence<string>().IndexBy(BreakingFunc.Of<string, char>());
+            _ = new BreakingSequence<string>().IndexBy(BreakingFunc.Of<string, char>());
         }
 
         [Test]

--- a/MoreLinq.Test/IndexTest.cs
+++ b/MoreLinq.Test/IndexTest.cs
@@ -26,8 +26,8 @@ namespace MoreLinq.Test
         public void IndexIsLazy()
         {
             var bs = new BreakingSequence<object>();
-            bs.Index();
-            bs.Index(0);
+            _ = bs.Index();
+            _ = bs.Index(0);
         }
 
         [Test]

--- a/MoreLinq.Test/InsertTest.cs
+++ b/MoreLinq.Test/InsertTest.cs
@@ -83,7 +83,7 @@ namespace MoreLinq.Test
         [Test]
         public void InsertIsLazy()
         {
-            new BreakingSequence<int>().Insert(new BreakingSequence<int>(), 0);
+            _ = new BreakingSequence<int>().Insert(new BreakingSequence<int>(), 0);
         }
     }
 }

--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestInterleaveIsLazy()
         {
-            new BreakingSequence<int>().Interleave(new BreakingSequence<int>());
+            _ = new BreakingSequence<int>().Interleave(new BreakingSequence<int>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/LagTest.cs
+++ b/MoreLinq.Test/LagTest.cs
@@ -31,8 +31,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestLagIsLazy()
         {
-            new BreakingSequence<int>().Lag(5, BreakingFunc.Of<int, int, int>());
-            new BreakingSequence<int>().Lag(5, -1, BreakingFunc.Of<int, int, int>());
+            _ = new BreakingSequence<int>().Lag(5, BreakingFunc.Of<int, int, int>());
+            _ = new BreakingSequence<int>().Lag(5, -1, BreakingFunc.Of<int, int, int>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/LeadTest.cs
+++ b/MoreLinq.Test/LeadTest.cs
@@ -31,8 +31,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestLeadIsLazy()
         {
-            new BreakingSequence<int>().Lead(5, BreakingFunc.Of<int, int, int>());
-            new BreakingSequence<int>().Lead(5, -1, BreakingFunc.Of<int, int, int>());
+            _ = new BreakingSequence<int>().Lead(5, BreakingFunc.Of<int, int, int>());
+            _ = new BreakingSequence<int>().Lead(5, -1, BreakingFunc.Of<int, int, int>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/MaxByTest.cs
+++ b/MoreLinq.Test/MaxByTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void MaxByIsLazy()
         {
-            new BreakingSequence<int>().MaxBy(BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().MaxBy(BreakingFunc.Of<int, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -148,7 +148,7 @@ namespace MoreLinq.Test
 
             var memoized = xs.Memoize();
 
-            using ((IDisposable) memoized)
+            using ((IDisposable)memoized)
                 memoized.Take(1).Consume();
         }
 
@@ -204,7 +204,7 @@ namespace MoreLinq.Test
 
             void Run()
             {
-                using ((IDisposable) memoized)
+                using ((IDisposable)memoized)
                     memoized.Take(1).Consume();
             }
 
@@ -219,7 +219,7 @@ namespace MoreLinq.Test
         {
             var sequence = Enumerable.Range(1, 10);
             var memoized = sequence.Memoize();
-            var disposable = (IDisposable) memoized;
+            var disposable = (IDisposable)memoized;
 
             using var reader = memoized.Read();
             Assert.That(reader.Read(), Is.EqualTo(1));
@@ -306,7 +306,7 @@ namespace MoreLinq.Test
             for (var i = 0; i < 2; i++)
                 Assert.That(memo.First, Throws.TypeOf<TestException>().And.SameAs(error));
 
-            ((IDisposable) memo).Dispose();
+            ((IDisposable)memo).Dispose();
             Assert.That(memo.Single(), Is.EqualTo(obj));
         }
     }

--- a/MoreLinq.Test/MemoizeTest.cs
+++ b/MoreLinq.Test/MemoizeTest.cs
@@ -101,7 +101,7 @@ namespace MoreLinq.Test
         [Test]
         public void MemoizeIsLazy()
         {
-            new BreakingSequence<int>().Memoize();
+            _ = new BreakingSequence<int>().Memoize();
         }
 
         [TestCase(SourceKind.BreakingCollection)]

--- a/MoreLinq.Test/MinByTest.cs
+++ b/MoreLinq.Test/MinByTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void MinByIsLazy()
         {
-            new BreakingSequence<int>().MinBy(BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().MinBy(BreakingFunc.Of<int, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -5,54 +5,54 @@
     <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
-	  <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>
-	  <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-	  <IsPackable>false</IsPackable>
-	  <ApplicationIcon />
-	  <WarningsNotAsErrors>618</WarningsNotAsErrors>
+    <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <IsPackable>false</IsPackable>
+    <ApplicationIcon />
+    <WarningsNotAsErrors>618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-	  <ProjectReference Include="..\MoreLinq\MoreLinq.csproj" />
+    <ProjectReference Include="..\MoreLinq\MoreLinq.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="coverlet.collector" Version="3.2.0">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-	  </PackageReference>
-	  <PackageReference Include="Delegating" Version="1.3.1" />
-	  <PackageReference Include="IsExternalInit" Version="1.0.3">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		  <PrivateAssets>all</PrivateAssets>
-	  </PackageReference>
-	  <PackageReference Include="NUnit" Version="3.13.3" />
-	  <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	  <PackageReference Include="NUnitLite" Version="3.13.3" />
-	  <PackageReference Include="PolySharp" Version="1.9.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	  <PackageReference Include="System.Reactive" Version="3.1.1" />
-	  <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Delegating" Version="1.3.1" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnitLite" Version="3.13.3" />
+    <PackageReference Include="PolySharp" Version="1.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-	  <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <Compile Remove="Program.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-	  <Compile Remove="Async\*.cs" />
+    <Compile Remove="Async\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -5,55 +5,54 @@
     <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
-    <OutputType>Exe</OutputType>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <IsPackable>false</IsPackable>
-    <ApplicationIcon />
-    <OutputTypeEx>library</OutputTypeEx>
-    <StartupObject>MoreLinq.Test.Program</StartupObject>
-    <WarningsNotAsErrors>618</WarningsNotAsErrors>
+	  <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>
+	  <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+	  <IsPackable>false</IsPackable>
+	  <ApplicationIcon />
+	  <WarningsNotAsErrors>618</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MoreLinq\MoreLinq.csproj" />
+	  <ProjectReference Include="..\MoreLinq\MoreLinq.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Delegating" Version="1.3.1" />
-    <PackageReference Include="IsExternalInit" Version="1.0.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NUnitLite" Version="3.13.3" />
-    <PackageReference Include="PolySharp" Version="1.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+	  <PackageReference Include="coverlet.collector" Version="3.2.0">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	  <PackageReference Include="Delegating" Version="1.3.1" />
+	  <PackageReference Include="IsExternalInit" Version="1.0.3">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	  <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		  <PrivateAssets>all</PrivateAssets>
+	  </PackageReference>
+	  <PackageReference Include="NUnit" Version="3.13.3" />
+	  <PackageReference Include="NUnit.Analyzers" Version="3.5.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="NUnitLite" Version="3.13.3" />
+	  <PackageReference Include="PolySharp" Version="1.9.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="System.Reactive" Version="3.1.1" />
+	  <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+	  <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <Compile Remove="Program.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Compile Remove="Async\*.cs" />
+	  <Compile Remove="Async\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MoreLinq.Test/MoveTest.cs
+++ b/MoreLinq.Test/MoveTest.cs
@@ -48,7 +48,7 @@ namespace MoreLinq.Test
         [Test]
         public void MoveIsLazy()
         {
-            new BreakingSequence<int>().Move(0, 0, 0);
+            _ = new BreakingSequence<int>().Move(0, 0, 0);
         }
 
         [TestCaseSource(nameof(MoveSource))]

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -71,7 +71,7 @@ namespace MoreLinq.Test
             GetTestCases(canBeNull: true, testCaseFactory: (method, args, _) => () => method.Invoke(null, args));
 
         static IEnumerable<ITestCaseData> GetTestCases(bool canBeNull, Func<MethodInfo, object?[], string, Action> testCaseFactory) =>
-            from m in typeof (MoreEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            from m in typeof(MoreEnumerable).GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             from t in CreateTestCases(m, canBeNull, testCaseFactory)
             select t;
 
@@ -81,14 +81,14 @@ namespace MoreLinq.Test
             var parameters = method.GetParameters().ToList();
 
             return from param in parameters
-                where IsReferenceType(param) && CanBeNull(param) == canBeNull
-                let arguments = parameters.Select(p => p == param ? null : CreateInstance(p.ParameterType)).ToArray()
-                let testCase = testCaseFactory(method, arguments,
+                   where IsReferenceType(param) && CanBeNull(param) == canBeNull
+                   let arguments = parameters.Select(p => p == param ? null : CreateInstance(p.ParameterType)).ToArray()
+                   let testCase = testCaseFactory(method, arguments,
 #pragma warning disable CA2201 // Do not raise reserved exception types
-                                               param.Name ?? throw new NullReferenceException())
+                                                  param.Name ?? throw new NullReferenceException())
 #pragma warning restore CA2201 // Do not raise reserved exception types
-                let testName = GetTestName(methodDefinition, param)
-                select (ITestCaseData) new TestCaseData(testCase).SetName(testName);
+                   let testName = GetTestName(methodDefinition, param)
+                   select (ITestCaseData)new TestCaseData(testCase).SetName(testName);
         }
 
         static string GetTestName(MethodInfo definition, ParameterInfo parameter) =>
@@ -120,7 +120,7 @@ namespace MoreLinq.Test
         static bool CanBeNull(ParameterInfo parameter)
         {
             var nullableTypes =
-                from t in new[] { typeof (IEqualityComparer<>), typeof (IComparer<>) }
+                from t in new[] { typeof(IEqualityComparer<>), typeof(IComparer<>) }
                 select t.GetTypeInfo();
 
             var nullableParameters = new[]
@@ -143,8 +143,8 @@ namespace MoreLinq.Test
 
         static object CreateInstance(Type type)
         {
-            if (type == typeof (int)) return 7; // int is used as size/length/range etc. avoid ArgumentOutOfRange for '0'.
-            if (type == typeof (string)) return "";
+            if (type == typeof(int)) return 7; // int is used as size/length/range etc. avoid ArgumentOutOfRange for '0'.
+            if (type == typeof(string)) return "";
             if (type == typeof(TaskScheduler)) return TaskScheduler.Default;
             if (type == typeof(IEnumerable<int>)) return new[] { 1, 2, 3 }; // Provide non-empty sequence for MinBy/MaxBy.
             if (typeof(Delegate).IsAssignableFrom(type)) return CreateDelegateInstance(type);
@@ -185,7 +185,7 @@ namespace MoreLinq.Test
         {
             Debug.Assert(type.IsGenericType && type.IsInterface);
             var name = type.Name[1..]; // Delete first character, i.e. the 'I' in IEnumerable
-            var definition = typeof (GenericArgs).GetTypeInfo().GetNestedType(name);
+            var definition = typeof(GenericArgs).GetTypeInfo().GetNestedType(name);
             Debug.Assert(definition is not null);
             var instance = Activator.CreateInstance(definition.MakeGenericType(type.GetGenericArguments()));
             Debug.Assert(instance is not null);

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -184,7 +184,7 @@ namespace MoreLinq.Test
         static object CreateGenericInterfaceInstance(TypeInfo type)
         {
             Debug.Assert(type.IsGenericType && type.IsInterface);
-            var name = type.Name.Substring(1); // Delete first character, i.e. the 'I' in IEnumerable
+            var name = type.Name[1..]; // Delete first character, i.e. the 'I' in IEnumerable
             var definition = typeof (GenericArgs).GetTypeInfo().GetNestedType(name);
             Debug.Assert(definition is not null);
             var instance = Activator.CreateInstance(definition.MakeGenericType(type.GetGenericArguments()));

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -35,7 +35,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartIsLazy()
         {
-            new BreakingSequence<int>().PadStart(0);
+            _ = new BreakingSequence<int>().PadStart(0);
         }
 
         public class PadStartWithDefaultPadding
@@ -70,7 +70,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartWithPaddingIsLazy()
         {
-            new BreakingSequence<int>().PadStart(0, -1);
+            _ = new BreakingSequence<int>().PadStart(0, -1);
         }
 
         public class PadStartWithPadding
@@ -105,7 +105,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartWithSelectorIsLazy()
         {
-            new BreakingSequence<int>().PadStart(0, BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().PadStart(0, BreakingFunc.Of<int, int>());
         }
 
         public class PadStartWithSelector

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -31,13 +31,13 @@ namespace MoreLinq.Test
         [Test]
         public void PadIsLazy()
         {
-            new BreakingSequence<object>().Pad(0);
+            _ = new BreakingSequence<object>().Pad(0);
         }
 
         [Test]
         public void PadWithFillerIsLazy()
         {
-            new BreakingSequence<object>().Pad(0, new object());
+            _ = new BreakingSequence<object>().Pad(0, new object());
         }
 
         public class ValueTypeElements

--- a/MoreLinq.Test/PairwiseTest.cs
+++ b/MoreLinq.Test/PairwiseTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void PairwiseIsLazy()
         {
-            new BreakingSequence<object>().Pairwise(BreakingFunc.Of<object, object, int>());
+            _ = new BreakingSequence<object>().Pairwise(BreakingFunc.Of<object, object, int>());
         }
 
         [TestCase(0)]

--- a/MoreLinq.Test/PartialSortByTest.cs
+++ b/MoreLinq.Test/PartialSortByTest.cs
@@ -71,7 +71,7 @@ namespace MoreLinq.Test
         [Test]
         public void PartialSortByIsLazy()
         {
-            new BreakingSequence<object>().PartialSortBy(1, BreakingFunc.Of<object, object>());
+            _ = new BreakingSequence<object>().PartialSortBy(1, BreakingFunc.Of<object, object>());
         }
 
         [Test, Ignore("TODO")]

--- a/MoreLinq.Test/PartialSortTest.cs
+++ b/MoreLinq.Test/PartialSortTest.cs
@@ -76,7 +76,7 @@ namespace MoreLinq.Test
         [Test]
         public void PartialSortIsLazy()
         {
-            new BreakingSequence<object>().PartialSort(1);
+            _ = new BreakingSequence<object>().PartialSort(1);
         }
 
         [Test, Ignore("TODO")]

--- a/MoreLinq.Test/PartitionTest.cs
+++ b/MoreLinq.Test/PartitionTest.cs
@@ -75,7 +75,7 @@ namespace MoreLinq.Test
             var xs = new int?[] { 1, 2, 3, null, 5, 6, 7, null, 9, 10 };
 
             var (lt5, gte5, nils) =
-                xs.GroupBy(x => x != null ? x < 5 : (bool?) null)
+                xs.GroupBy(x => x != null ? x < 5 : (bool?)null)
                   .Partition((t, f, n) => Tuple.Create(t, f, n));
 
             Assert.That(lt5,  Is.EqualTo(new[] { 1, 2, 3 }));

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -170,7 +170,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestPermutationsIsLazy()
         {
-            new BreakingSequence<int>().Permutations();
+            _ = new BreakingSequence<int>().Permutations();
         }
 
         /// <summary>

--- a/MoreLinq.Test/PipeTest.cs
+++ b/MoreLinq.Test/PipeTest.cs
@@ -39,7 +39,7 @@ namespace MoreLinq.Test
         [Test]
         public void PipeIsLazy()
         {
-            new BreakingSequence<int>().Pipe(BreakingAction.Of<int>());
+            _ = new BreakingSequence<int>().Pipe(BreakingAction.Of<int>());
         }
 
         [Test]

--- a/MoreLinq.Test/PreScanTest.cs
+++ b/MoreLinq.Test/PreScanTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void PreScanIsLazy()
         {
-            new BreakingSequence<int>().PreScan(BreakingFunc.Of<int, int, int>(), 0);
+            _ = new BreakingSequence<int>().PreScan(BreakingFunc.Of<int, int, int>(), 0);
         }
 
         [Test]

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -80,7 +80,7 @@ namespace MoreLinq.Test
         [Test]
         public void PrependWithSharedSource()
         {
-            var first  = new [] { 1 }.Prepend(2);
+            var first  = new[] { 1 }.Prepend(2);
             var second = first.Prepend(3).Prepend(4);
             var third  = first.Prepend(4).Prepend(8);
 

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -54,7 +54,7 @@ namespace MoreLinq.Test
         [Test]
         public void PrependIsLazyInTailSequence()
         {
-            new BreakingSequence<string>().Prepend("head");
+            _ = new BreakingSequence<string>().Prepend("head");
         }
 
         [TestCaseSource(nameof(PrependManySource))]

--- a/MoreLinq.Test/Program.cs
+++ b/MoreLinq.Test/Program.cs
@@ -15,19 +15,12 @@
 // limitations under the License.
 #endregion
 
-namespace MoreLinq.Test
-{
-    using System;
-    using System.Reflection;
-    using NUnit.Common;
-    using NUnitLite;
+#pragma warning disable CA1852 // Seal internal types (false positive)
 
-    static class Program
-    {
-        static int Main(string[] args)
-        {
-            using var writer = new ExtendedTextWrapper(Console.Out);
-            return new AutoRun(typeof(Program).GetTypeInfo().Assembly).Execute(args, writer, Console.In);
-        }
-    }
-}
+using System;
+using System.Reflection;
+using NUnit.Common;
+using NUnitLite;
+
+using var writer = new ExtendedTextWrapper(Console.Out);
+return new AutoRun(typeof(Program).GetTypeInfo().Assembly).Execute(args, writer, Console.In);

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -33,8 +33,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestRandomSubsetIsLazy()
         {
-            new BreakingSequence<int>().RandomSubset(10);
-            new BreakingSequence<int>().RandomSubset(10, new Random());
+            _ = new BreakingSequence<int>().RandomSubset(10);
+            _ = new BreakingSequence<int>().RandomSubset(10, new Random());
         }
 
         /// <summary>

--- a/MoreLinq.Test/RandomSubsetTest.cs
+++ b/MoreLinq.Test/RandomSubsetTest.cs
@@ -240,7 +240,7 @@ namespace MoreLinq.Test
         {
             var average = values.Average();
             var standardDeviation = StandardDeviationInternal(values, average);
-            return (standardDeviation * 100.0) / average;
+            return standardDeviation * 100.0 / average;
         }
 
         static double StandardDeviationInternal(IEnumerable<double> values, double average)

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -33,7 +33,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestRankIsLazy()
         {
-            new BreakingSequence<int>().Rank();
+            _ = new BreakingSequence<int>().Rank();
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestRankByIsLazy()
         {
-            new BreakingSequence<int>().RankBy(BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().RankBy(BreakingFunc.Of<int, int>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -175,7 +175,7 @@ namespace MoreLinq.Test
         {
             const int count = 10;
             var ordinals = Enumerable.Range(1, count);
-            var sequence = ordinals.Select( x => new DateTime(2010,x,20-x) );
+            var sequence = ordinals.Select(x => new DateTime(2010, x, 20 - x));
             // invert the CompareTo operation to Rank in reverse order (ascending to descending)
             using var tsA = sequence.AsTestingSequence();
             var resultA = tsA.Rank(Comparer<DateTime>.Create((a, b) => -a.CompareTo(b)));

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -31,7 +31,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestRepeatIsLazy()
         {
-            new BreakingSequence<int>().Repeat(5);
+            _ = new BreakingSequence<int>().Repeat(5);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestRepeatForeverIsLazy()
         {
-            new BreakingSequence<int>().Repeat();
+            _ = new BreakingSequence<int>().Repeat();
         }
     }
 }

--- a/MoreLinq.Test/ReturnTest.cs
+++ b/MoreLinq.Test/ReturnTest.cs
@@ -140,7 +140,7 @@ namespace MoreLinq.Test
             from ma in new (string MethodName, Action Action)[]
             {
                 ("Add"     , () => SomeSingleton.List.Add(new object())),
-                ("Clear"   , () => SomeSingleton.Collection.Clear()),
+                ("Clear"   ,       SomeSingleton.Collection.Clear),
                 ("Remove"  , () => SomeSingleton.Collection.Remove(SomeSingleton.Item)),
                 ("RemoveAt", () => SomeSingleton.List.RemoveAt(0)),
                 ("Insert"  , () => SomeSingleton.List.Insert(0, new object())),

--- a/MoreLinq.Test/RunLengthEncodeTest.cs
+++ b/MoreLinq.Test/RunLengthEncodeTest.cs
@@ -33,8 +33,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestRunLengthEncodeIsLazy()
         {
-            new BreakingSequence<int>().RunLengthEncode();
-            new BreakingSequence<int>().RunLengthEncode(EqualityComparer<int>.Default);
+            _ = new BreakingSequence<int>().RunLengthEncode();
+            _ = new BreakingSequence<int>().RunLengthEncode(EqualityComparer<int>.Default);
         }
 
         /// <summary>

--- a/MoreLinq.Test/ScanByTest.cs
+++ b/MoreLinq.Test/ScanByTest.cs
@@ -26,10 +26,10 @@ namespace MoreLinq.Test
         [Test]
         public void ScanByIsLazy()
         {
-            new BreakingSequence<string>().ScanBy(
-                BreakingFunc.Of<string, int>(),
-                BreakingFunc.Of<int, char>(),
-                BreakingFunc.Of<char, int, string, char>());
+            var bs = new BreakingSequence<string>();
+            _ = bs.ScanBy(BreakingFunc.Of<string, int>(),
+                          BreakingFunc.Of<int, char>(),
+                          BreakingFunc.Of<char, int, string, char>());
         }
 
         [Test]

--- a/MoreLinq.Test/ScanRightTest.cs
+++ b/MoreLinq.Test/ScanRightTest.cs
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
         [Test]
         public void ScanRightIsLazy()
         {
-            new BreakingSequence<int>().ScanRight(BreakingFunc.Of<int, int, int>());
+            _ = new BreakingSequence<int>().ScanRight(BreakingFunc.Of<int, int, int>());
         }
 
         // ScanRight(source, seed, func)
@@ -111,7 +111,7 @@ namespace MoreLinq.Test
         [Test]
         public void ScanRightSeedIsLazy()
         {
-            new BreakingSequence<int>().ScanRight(string.Empty, BreakingFunc.Of<int, string, string>());
+            _ = new BreakingSequence<int>().ScanRight(string.Empty, BreakingFunc.Of<int, string, string>());
         }
     }
 }

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -39,7 +39,7 @@ namespace MoreLinq.Test
         [Test]
         public void ScanIsLazy()
         {
-            new BreakingSequence<object>().Scan(BreakingFunc.Of<object, object, object>());
+            _ = new BreakingSequence<object>().Scan(BreakingFunc.Of<object, object, object>());
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace MoreLinq.Test
         [Test]
         public void SeededScanIsLazy()
         {
-            new BreakingSequence<object>().Scan(null, BreakingFunc.Of<object?, object, object>());
+            _ = new BreakingSequence<object>().Scan(null, BreakingFunc.Of<object?, object, object>());
         }
 
         [Test]

--- a/MoreLinq.Test/ScanTest.cs
+++ b/MoreLinq.Test/ScanTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
         public void ScanDoesNotIterateExtra()
         {
             var sequence = Enumerable.Range(1, 3).Concat(new BreakingSequence<int>()).Scan(SampleData.Plus);
-            var gold = new[] {1, 3, 6};
+            var gold = new[] { 1, 3, 6 };
             Assert.That(sequence.Consume, Throws.BreakException);
             sequence.Take(3).AssertSequenceEqual(gold);
         }

--- a/MoreLinq.Test/Scope.cs
+++ b/MoreLinq.Test/Scope.cs
@@ -24,12 +24,7 @@ namespace MoreLinq.Test
         readonly T _old;
 
         protected Scope(T current) => _old = current;
-
-        public virtual void Dispose()
-        {
-            Restore(_old);
-        }
-
+        public virtual void Dispose() => Restore(_old);
         protected abstract void Restore(T old);
     }
 }

--- a/MoreLinq.Test/Scope.cs
+++ b/MoreLinq.Test/Scope.cs
@@ -23,10 +23,7 @@ namespace MoreLinq.Test
     {
         readonly T _old;
 
-        protected Scope(T current)
-        {
-            _old = current;
-        }
+        protected Scope(T current) => _old = current;
 
         public virtual void Dispose()
         {

--- a/MoreLinq.Test/SegmentTest.cs
+++ b/MoreLinq.Test/SegmentTest.cs
@@ -33,9 +33,9 @@ namespace MoreLinq.Test
         [Test]
         public void TestSegmentIsLazy()
         {
-            new BreakingSequence<int>().Segment(BreakingFunc.Of<int, bool>());
-            new BreakingSequence<int>().Segment(BreakingFunc.Of<int, int, bool>());
-            new BreakingSequence<int>().Segment(BreakingFunc.Of<int, int, int, bool>());
+            _ = new BreakingSequence<int>().Segment(BreakingFunc.Of<int, bool>());
+            _ = new BreakingSequence<int>().Segment(BreakingFunc.Of<int, int, bool>());
+            _ = new BreakingSequence<int>().Segment(BreakingFunc.Of<int, int, int, bool>());
         }
 
         /// <summary>

--- a/MoreLinq.Test/ShuffleTest.cs
+++ b/MoreLinq.Test/ShuffleTest.cs
@@ -23,7 +23,7 @@ namespace MoreLinq.Test
     [TestFixture]
     public class ShuffleTest
     {
-        static Random seed = new(12345);
+        static readonly Random Seed = new(12345);
 
         [Test]
         public void ShuffleIsLazy()
@@ -65,14 +65,14 @@ namespace MoreLinq.Test
         [Test]
         public void ShuffleSeedIsLazy()
         {
-            new BreakingSequence<int>().Shuffle(seed);
+            new BreakingSequence<int>().Shuffle(Seed);
         }
 
         [Test]
         public void ShuffleSeed()
         {
             var source = Enumerable.Range(1, 100);
-            var result = source.Shuffle(seed);
+            var result = source.Shuffle(Seed);
 
             Assert.That(result, Is.Not.EqualTo(source));
             Assert.That(result.OrderBy(x => x), Is.EqualTo(source));
@@ -82,7 +82,7 @@ namespace MoreLinq.Test
         public void ShuffleSeedWithEmptySequence()
         {
             var source = Enumerable.Empty<int>();
-            var result = source.Shuffle(seed);
+            var result = source.Shuffle(Seed);
 
             Assert.That(result, Is.Empty);
         }
@@ -94,7 +94,7 @@ namespace MoreLinq.Test
             var sequenceClone = sequence.ToArray();
 
             // force complete enumeration of random subsets
-            sequence.Shuffle(seed).Consume();
+            sequence.Shuffle(Seed).Consume();
 
             // verify the original sequence is untouched
             Assert.That(sequence, Is.EqualTo(sequenceClone));

--- a/MoreLinq.Test/ShuffleTest.cs
+++ b/MoreLinq.Test/ShuffleTest.cs
@@ -28,7 +28,7 @@ namespace MoreLinq.Test
         [Test]
         public void ShuffleIsLazy()
         {
-            new BreakingSequence<int>().Shuffle();
+            _ = new BreakingSequence<int>().Shuffle();
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace MoreLinq.Test
         [Test]
         public void ShuffleSeedIsLazy()
         {
-            new BreakingSequence<int>().Shuffle(Seed);
+            _ = new BreakingSequence<int>().Shuffle(Seed);
         }
 
         [Test]

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -54,7 +54,7 @@ namespace MoreLinq.Test
         [Test]
         public void SkipLastIsLazy()
         {
-            new BreakingSequence<object>().SkipLast(1);
+            _ = new BreakingSequence<object>().SkipLast(1);
         }
     }
 }

--- a/MoreLinq.Test/SkipUntilTest.cs
+++ b/MoreLinq.Test/SkipUntilTest.cs
@@ -48,7 +48,7 @@ namespace MoreLinq.Test
         [Test]
         public void SkipUntilEvaluatesSourceLazily()
         {
-            new BreakingSequence<string>().SkipUntil(x => x.Length == 0);
+            _ = new BreakingSequence<string>().SkipUntil(x => x.Length == 0);
         }
 
         [Test]

--- a/MoreLinq.Test/SliceTest.cs
+++ b/MoreLinq.Test/SliceTest.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         [Test]
         public void TestSliceIsLazy()
         {
-            new BreakingSequence<int>().Slice(10, 10);
+            _ = new BreakingSequence<int>().Slice(10, 10);
         }
 
         /// <summary>

--- a/MoreLinq.Test/SortedMergeTest.cs
+++ b/MoreLinq.Test/SortedMergeTest.cs
@@ -36,7 +36,7 @@ namespace MoreLinq.Test
             var sequenceA = new BreakingSequence<int>();
             var sequenceB = new BreakingSequence<int>();
 
-            sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB);
+            _ = sequenceA.SortedMerge(OrderByDirection.Ascending, sequenceB);
         }
 
         /// <summary>

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -24,17 +24,17 @@ namespace MoreLinq.Test
     [TestFixture]
     public class StartsWithTest
     {
-        [TestCase(new[] {1, 2, 3}, new[] {1, 2}, ExpectedResult = true)]
-        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3}, ExpectedResult = true)]
-        [TestCase(new[] {1, 2, 3}, new[] {1, 2, 3, 4}, ExpectedResult = false)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 1, 2 }, ExpectedResult = true)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, ExpectedResult = true)]
+        [TestCase(new[] { 1, 2, 3 }, new[] { 1, 2, 3, 4 }, ExpectedResult = false)]
         public bool StartsWithWithIntegers(IEnumerable<int> first, IEnumerable<int> second)
         {
             return first.StartsWith(second);
         }
 
-        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2'}, ExpectedResult = true)]
-        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3'}, ExpectedResult = true)]
-        [TestCase(new[] {'1', '2', '3'}, new[] {'1', '2', '3', '4'}, ExpectedResult = false)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '1', '2' }, ExpectedResult = true)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '1', '2', '3' }, ExpectedResult = true)]
+        [TestCase(new[] { '1', '2', '3' }, new[] { '1', '2', '3', '4' }, ExpectedResult = false)]
         public bool StartsWithWithChars(IEnumerable<char> first, IEnumerable<char> second)
         {
             return first.StartsWith(second);
@@ -58,7 +58,7 @@ namespace MoreLinq.Test
         [Test]
         public void StartsWithReturnsFalseIfOnlyFirstIsEmpty()
         {
-            Assert.That(new int[0].StartsWith(new[] {1,2,3}), Is.False);
+            Assert.That(new int[0].StartsWith(new[] { 1, 2, 3 }), Is.False);
         }
 
         [TestCase("", "", ExpectedResult = true)]
@@ -72,7 +72,7 @@ namespace MoreLinq.Test
         [Test]
         public void StartsWithDisposesBothSequenceEnumerators()
         {
-            using var first = TestingSequence.Of(1,2,3);
+            using var first = TestingSequence.Of(1, 2, 3);
             using var second = TestingSequence.Of(1);
 
             _ = first.StartsWith(second);
@@ -82,8 +82,8 @@ namespace MoreLinq.Test
         [SuppressMessage("ReSharper", "RedundantArgumentDefaultValue")]
         public void StartsWithUsesSpecifiedEqualityComparerOrDefault()
         {
-            var first = new[] {1,2,3};
-            var second = new[] {4,5,6};
+            var first = new[] { 1, 2, 3 };
+            var second = new[] { 4, 5, 6 };
 
             Assert.That(first.StartsWith(second), Is.False);
             Assert.That(first.StartsWith(second, null), Is.False);

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -75,7 +75,7 @@ namespace MoreLinq.Test
             using var first = TestingSequence.Of(1,2,3);
             using var second = TestingSequence.Of(1);
 
-            first.StartsWith(second);
+            _ = first.StartsWith(second);
         }
 
         [Test]

--- a/MoreLinq.Test/SubsetTest.cs
+++ b/MoreLinq.Test/SubsetTest.cs
@@ -32,8 +32,8 @@ namespace MoreLinq.Test
         [Test]
         public void TestSubsetsIsLazy()
         {
-            new BreakingSequence<int>().Subsets();
-            new BreakingSequence<int>().Subsets(5);
+            _ = new BreakingSequence<int>().Subsets();
+            _ = new BreakingSequence<int>().Subsets(5);
         }
 
         /// <summary>

--- a/MoreLinq.Test/TagFirstLastTest.cs
+++ b/MoreLinq.Test/TagFirstLastTest.cs
@@ -34,7 +34,7 @@ namespace MoreLinq.Test
         [Test]
         public void TagFirstLastIsLazy()
         {
-            new BreakingSequence<object>().TagFirstLast(BreakingFunc.Of<object, bool, bool, object>());
+            _ = new BreakingSequence<object>().TagFirstLast(BreakingFunc.Of<object, bool, bool, object>());
         }
 
         [Test]

--- a/MoreLinq.Test/TakeEveryTest.cs
+++ b/MoreLinq.Test/TakeEveryTest.cs
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
         [Test]
         public void TakeEveryIsLazy()
         {
-            new BreakingSequence<object>().TakeEvery(1);
+            _ = new BreakingSequence<object>().TakeEvery(1);
         }
     }
 }

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -51,7 +51,7 @@ namespace MoreLinq.Test
         [Test]
         public void TakeLastIsLazy()
         {
-            new BreakingSequence<object>().TakeLast(1);
+            _ = new BreakingSequence<object>().TakeLast(1);
         }
 
         [Test]

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -57,7 +57,7 @@ namespace MoreLinq.Test
         [Test]
         public void TakeLastDisposesSequenceEnumerator()
         {
-            using var seq = TestingSequence.Of(1,2,3);
+            using var seq = TestingSequence.Of(1, 2, 3);
             seq.TakeLast(1).Consume();
         }
 

--- a/MoreLinq.Test/TakeUntilTest.cs
+++ b/MoreLinq.Test/TakeUntilTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
         [Test]
         public void TakeUntilEvaluatesSourceLazily()
         {
-            new BreakingSequence<string>().TakeUntil(x => x.Length == 0);
+            _ = new BreakingSequence<string>().TakeUntil(x => x.Length == 0);
         }
 
         [Test]

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -74,9 +74,8 @@ namespace MoreLinq.Test
             yield return input.ToSourceKind(SourceKind.BreakingCollection);
         }
 
-        internal static IEnumerable<T> ToSourceKind<T>(this IEnumerable<T> input, SourceKind sourceKind)
-        {
-            return sourceKind switch
+        internal static IEnumerable<T> ToSourceKind<T>(this IEnumerable<T> input, SourceKind sourceKind) =>
+            sourceKind switch
             {
                 SourceKind.Sequence => input.Select(x => x),
                 SourceKind.BreakingList => new BreakingList<T>(input.ToList()),
@@ -85,6 +84,5 @@ namespace MoreLinq.Test
                 SourceKind.BreakingReadOnlyCollection => new BreakingReadOnlyCollection<T>(input.ToList()),
                 _ => throw new ArgumentException(null, nameof(sourceKind))
             };
-        }
     }
 }

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -54,12 +54,10 @@ namespace MoreLinq.Test
         readonly IReadOnlyCollection<TestObject> _testObjects;
 
 
-        public ToDataTableTest()
-        {
+        public ToDataTableTest() =>
             _testObjects = Enumerable.Range(0, 3)
                                      .Select(i => new TestObject(i))
                                      .ToArray();
-        }
 
         [Test]
         public void ToDataTableNullMemberExpressionMethod()

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -86,7 +86,7 @@ namespace MoreLinq.Test
             using var dt = new DataTable();
             _ = dt.Columns.Add("AString", typeof(int));
 
-            Assert.That(() => _testObjects.ToDataTable(dt, t=>t.AString),
+            Assert.That(() => _testObjects.ToDataTable(dt, t => t.AString),
                         Throws.ArgumentException("table"));
         }
 

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
         public void ToDataTableTableWithWrongColumnNames()
         {
             using var dt = new DataTable();
-            dt.Columns.Add("Test");
+            _ = dt.Columns.Add("Test");
 
             Assert.That(() => _testObjects.ToDataTable(dt),
                         Throws.ArgumentException("table"));
@@ -84,7 +84,7 @@ namespace MoreLinq.Test
         public void ToDataTableTableWithWrongColumnDataType()
         {
             using var dt = new DataTable();
-            dt.Columns.Add("AString", typeof(int));
+            _ = dt.Columns.Add("AString", typeof(int));
 
             Assert.That(() => _testObjects.ToDataTable(dt, t=>t.AString),
                         Throws.ArgumentException("table"));
@@ -165,17 +165,17 @@ namespace MoreLinq.Test
         {
             using var dt = new DataTable();
             var columns = dt.Columns;
-            columns.Add("Column1", typeof(int));
-            columns.Add("Value", typeof(string));
-            columns.Add("Column3", typeof(int));
-            columns.Add("Name", typeof(string));
+            _ = columns.Add("Column1", typeof(int));
+            _ = columns.Add("Value", typeof(string));
+            _ = columns.Add("Column3", typeof(int));
+            _ = columns.Add("Name", typeof(string));
 
             var vars = Environment.GetEnvironmentVariables()
                                   .Cast<DictionaryEntry>()
                                   .ToArray();
 
-            vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value!.ToString() })
-                .ToDataTable(dt, e => e.Name, e => e.Value);
+            _ = vars.Select(e => new { Name = e.Key.ToString(), Value = e.Value!.ToString() })
+                    .ToDataTable(dt, e => e.Name, e => e.Value);
 
             var rows = dt.Rows.Cast<DataRow>().ToArray();
             Assert.That(rows.Length, Is.EqualTo(vars.Length));

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -15,8 +15,6 @@
 // limitations under the License.
 #endregion
 
-#nullable enable
-
 namespace MoreLinq.Test
 {
     using System;

--- a/MoreLinq.Test/TraceTest.cs
+++ b/MoreLinq.Test/TraceTest.cs
@@ -37,7 +37,7 @@ namespace MoreLinq.Test
         [Test]
         public void TraceSequenceWithSomeNullElements()
         {
-            var trace = Lines(CaptureTrace(() => new int?[] {1, null, 2, null, 3}.Trace().Consume()));
+            var trace = Lines(CaptureTrace(() => new int?[] { 1, null, 2, null, 3 }.Trace().Consume()));
             trace.AssertSequenceEqual("1", string.Empty, "2", string.Empty, "3");
         }
 

--- a/MoreLinq.Test/TraceTest.cs
+++ b/MoreLinq.Test/TraceTest.cs
@@ -93,7 +93,7 @@ namespace MoreLinq.Test
         {
             var writer = new StringWriter();
             var listener = new TextWriterTraceListener(writer);
-            Trace.Listeners.Add(listener);
+            _ = Trace.Listeners.Add(listener);
             try
             {
                 action();

--- a/MoreLinq.Test/TransposeTest.cs
+++ b/MoreLinq.Test/TransposeTest.cs
@@ -27,7 +27,7 @@ namespace MoreLinq.Test
         [Test]
         public void TransposeIsLazy()
         {
-            new BreakingSequence<BreakingSequence<int>>().Transpose();
+            _ = new BreakingSequence<BreakingSequence<int>>().Transpose();
         }
 
         [Test]

--- a/MoreLinq.Test/TraverseTest.cs
+++ b/MoreLinq.Test/TraverseTest.cs
@@ -26,13 +26,13 @@ namespace MoreLinq.Test
         [Test]
         public void TraverseDepthFirstFNullGenerator()
         {
-            MoreEnumerable.TraverseDepthFirst(new object(), _ => new BreakingSequence<object>());
+            _ = MoreEnumerable.TraverseDepthFirst(new object(), _ => new BreakingSequence<object>());
         }
 
         [Test]
         public void TraverseBreadthFirstIsStreaming()
         {
-            MoreEnumerable.TraverseBreadthFirst(new object(), _ => new BreakingSequence<object>());
+            _ = MoreEnumerable.TraverseBreadthFirst(new object(), _ => new BreakingSequence<object>());
         }
 
         [Test]

--- a/MoreLinq.Test/TrySingleTest.cs
+++ b/MoreLinq.Test/TrySingleTest.cs
@@ -92,7 +92,7 @@ namespace MoreLinq.Test
         sealed class BreakingSingleElementCollection<T> :
             BreakingSingleElementCollectionBase<T>, ICollection<T>
         {
-            public BreakingSingleElementCollection(T element) : base(element) {}
+            public BreakingSingleElementCollection(T element) : base(element) { }
 
             public void Add(T item) => throw new NotImplementedException();
             public void Clear() => throw new NotImplementedException();
@@ -105,7 +105,7 @@ namespace MoreLinq.Test
         sealed class BreakingSingleElementReadOnlyCollection<T> :
             BreakingSingleElementCollectionBase<T>, IReadOnlyCollection<T>
         {
-            public BreakingSingleElementReadOnlyCollection(T element) : base(element) {}
+            public BreakingSingleElementReadOnlyCollection(T element) : base(element) { }
         }
 
         [TestCase(SourceKind.Sequence)]

--- a/MoreLinq.Test/UnfoldTest.cs
+++ b/MoreLinq.Test/UnfoldTest.cs
@@ -52,10 +52,10 @@ namespace MoreLinq.Test
         [Test]
         public void UnfoldIsLazy()
         {
-            MoreEnumerable.Unfold(0, BreakingFunc.Of<int, (int, int)>(),
-                                     BreakingFunc.Of<(int, int), bool>(),
-                                     BreakingFunc.Of<(int, int), int>(),
-                                     BreakingFunc.Of<(int, int), int>());
+            _ = MoreEnumerable.Unfold(0, BreakingFunc.Of<int, (int, int)>(),
+                                         BreakingFunc.Of<(int, int), bool>(),
+                                         BreakingFunc.Of<(int, int), int>(),
+                                         BreakingFunc.Of<(int, int), int>());
         }
 
 

--- a/MoreLinq.Test/WindowLeftTest.cs
+++ b/MoreLinq.Test/WindowLeftTest.cs
@@ -26,20 +26,18 @@ namespace MoreLinq.Test
         [Test]
         public void WindowLeftIsLazy()
         {
-            new BreakingSequence<int>().WindowLeft(1);
+            _ = new BreakingSequence<int>().WindowLeft(1);
         }
 
         [Test]
         public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowLeft(2).GetEnumerator();
+            using var reader = sequence.WindowLeft(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
+            var window1 = reader.Read();
             window1[1] = -1;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(1));
         }
@@ -48,13 +46,11 @@ namespace MoreLinq.Test
         public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowLeft(2).GetEnumerator();
+            using var reader = sequence.WindowLeft(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
+            var window1 = reader.Read();
             window1[1] = -1;
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(1));
         }
@@ -63,12 +59,10 @@ namespace MoreLinq.Test
         public void WindowModifiedDoesNotAffectPreviousWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowLeft(2).GetEnumerator();
+            using var reader = sequence.WindowLeft(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window1 = reader.Read();
+            var window2 = reader.Read();
             window2[0] = -1;
 
             Assert.That(window1[1], Is.EqualTo(1));

--- a/MoreLinq.Test/WindowRightTest.cs
+++ b/MoreLinq.Test/WindowRightTest.cs
@@ -26,20 +26,18 @@ namespace MoreLinq.Test
         [Test]
         public void WindowRightIsLazy()
         {
-            new BreakingSequence<int>().WindowRight(1);
+            _ = new BreakingSequence<int>().WindowRight(1);
         }
 
         [Test]
         public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowRight(2).GetEnumerator();
+            using var reader = sequence.WindowRight(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
+            var window1 = reader.Read();
             window1[0] = -1;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(0));
         }
@@ -48,13 +46,11 @@ namespace MoreLinq.Test
         public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowRight(2).GetEnumerator();
+            using var reader = sequence.WindowRight(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
+            var window1 = reader.Read();
             window1[0] = -1;
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(0));
         }
@@ -63,12 +59,10 @@ namespace MoreLinq.Test
         public void WindowModifiedDoesNotAffectPreviousWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.WindowRight(2).GetEnumerator();
+            using var reader = sequence.WindowRight(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window1 = reader.Read();
+            var window2 = reader.Read();
             window2[0] = -1;
 
             Assert.That(window1[0], Is.EqualTo(0));

--- a/MoreLinq.Test/WindowTest.cs
+++ b/MoreLinq.Test/WindowTest.cs
@@ -31,20 +31,18 @@ namespace MoreLinq.Test
         [Test]
         public void TestWindowIsLazy()
         {
-            new BreakingSequence<int>().Window(1);
+            _ = new BreakingSequence<int>().Window(1);
         }
 
         [Test]
         public void WindowModifiedBeforeMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.Window(2).GetEnumerator();
+            using var reader = sequence.Window(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
+            var window1 = reader.Read();
             window1[1] = -1;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(1));
         }
@@ -53,13 +51,11 @@ namespace MoreLinq.Test
         public void WindowModifiedAfterMoveNextDoesNotAffectNextWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.Window(2).GetEnumerator();
+            using var reader = sequence.Window(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
+            var window1 = reader.Read();
             window1[1] = -1;
-            var window2 = e.Current;
+            var window2 = reader.Read();
 
             Assert.That(window2[0], Is.EqualTo(1));
         }
@@ -68,12 +64,10 @@ namespace MoreLinq.Test
         public void WindowModifiedDoesNotAffectPreviousWindow()
         {
             var sequence = Enumerable.Range(0, 3);
-            using var e = sequence.Window(2).GetEnumerator();
+            using var reader = sequence.Window(2).Read();
 
-            e.MoveNext();
-            var window1 = e.Current;
-            e.MoveNext();
-            var window2 = e.Current;
+            var window1 = reader.Read();
+            var window2 = reader.Read();
             window2[0] = -1;
 
             Assert.That(window1[1], Is.EqualTo(1));

--- a/MoreLinq.Test/ZipLongestTest.cs
+++ b/MoreLinq.Test/ZipLongestTest.cs
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             var zipped = shorter.ZipLongest(longer, Tuple.Create);
 
             var count = 0;
-            foreach(var _ in zipped.Take(10))
+            foreach (var _ in zipped.Take(10))
             {
                 if (++count == 4)
                     ((IDisposable)shorter).Dispose();

--- a/MoreLinq.Test/ZipLongestTest.cs
+++ b/MoreLinq.Test/ZipLongestTest.cs
@@ -55,7 +55,7 @@ namespace MoreLinq.Test
         public void ZipLongestIsLazy()
         {
             var bs = new BreakingSequence<int>();
-            bs.ZipLongest(bs, BreakingFunc.Of<int, int, int>());
+            _ = bs.ZipLongest(bs, BreakingFunc.Of<int, int, int>());
         }
 
         [Test]

--- a/MoreLinq.Test/ZipShortestTest.cs
+++ b/MoreLinq.Test/ZipShortestTest.cs
@@ -69,7 +69,7 @@ namespace MoreLinq.Test
         public void ZipShortestIsLazy()
         {
             var bs = new BreakingSequence<int>();
-            bs.ZipShortest(bs, BreakingFunc.Of<int, int, int>());
+            _ = bs.ZipShortest(bs, BreakingFunc.Of<int, int, int>());
         }
 
         [Test]

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -47,12 +47,11 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (func == null) throw new ArgumentNullException(nameof(func));
 
-            var list = source.ToListLike();
-
-            if (list.Count == 0)
-                throw new InvalidOperationException("Sequence contains no elements.");
-
-            return AggregateRightImpl(list, list[^1], func, list.Count - 1);
+            return source.ToListLike() switch
+            {
+                { Count: 0 } => throw new InvalidOperationException("Sequence contains no elements."),
+                var list => AggregateRightImpl(list, list[^1], func, list.Count - 1)
+            };
         }
 
         /// <summary>

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -34,6 +34,7 @@ namespace MoreLinq
         public static IEnumerable<T> Append<T>(this IEnumerable<T> head, T tail)
         {
             if (head == null) throw new ArgumentNullException(nameof(head));
+
             return head is PendNode<T> node
                 ? node.Concat(tail)
                 : PendNode<T>.WithSource(head).Concat(tail);

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -34,7 +34,6 @@ namespace MoreLinq
         public static IEnumerable<T> Append<T>(this IEnumerable<T> head, T tail)
         {
             if (head == null) throw new ArgumentNullException(nameof(head));
-
             return head is PendNode<T> node
                 ? node.Concat(tail)
                 : PendNode<T>.WithSource(head).Concat(tail);

--- a/MoreLinq/AssemblyInfo.cs
+++ b/MoreLinq/AssemblyInfo.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("MoreLINQ")]
 [assembly: AssemblyDescription("Extensions to LINQ to Objects")]
@@ -38,9 +37,9 @@ using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
 #if !NO_COM
-[assembly: ComVisible(false)]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
 
 // ID of the typelib if this project is exposed to COM.
 
-[assembly: Guid("fc632c9d-390e-4902-8c1c-3e57b08c1d38")]
+[assembly: System.Runtime.InteropServices.Guid("fc632c9d-390e-4902-8c1c-3e57b08c1d38")]
 #endif

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -22,7 +22,7 @@ namespace MoreLinq
 
     static partial class MoreEnumerable
     {
-        #if MORELINQ
+#if MORELINQ
 
         static readonly Func<int, int, Exception> DefaultErrorSelector = OnAssertCountFailure;
 
@@ -77,7 +77,7 @@ namespace MoreLinq
         internal static string FormatSequenceLengthErrorMessage(int cmp, int count) =>
             $"Sequence contains too {(cmp < 0 ? "few" : "many")} elements when exactly {count:N0} {(count == 1 ? "was" : "were")} expected.";
 
-        #endif
+#endif
 
         static IEnumerable<TSource> AssertCountImpl<TSource>(IEnumerable<TSource> source,
             int count, Func<int, int, Exception> errorSelector)
@@ -87,23 +87,23 @@ namespace MoreLinq
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
             return
-                source.TryGetCollectionCount() is {} collectionCount
+                source.TryGetCollectionCount() is { } collectionCount
                 ? collectionCount == count
                   ? source
                   : From<TSource>(() => throw errorSelector(collectionCount.CompareTo(count), count))
                 : _(); IEnumerable<TSource> _()
+            {
+                var iterations = 0;
+                foreach (var element in source)
                 {
-                    var iterations = 0;
-                    foreach (var element in source)
-                    {
-                        iterations++;
-                        if (iterations > count)
-                            throw errorSelector(1, count);
-                        yield return element;
-                    }
-                    if (iterations != count)
-                        throw errorSelector(-1, count);
+                    iterations++;
+                    if (iterations > count)
+                        throw errorSelector(1, count);
+                    yield return element;
                 }
+                if (iterations != count)
+                    throw errorSelector(-1, count);
+            }
         }
     }
 }

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -75,7 +75,7 @@ namespace MoreLinq
                 if (e.MoveNext())
                 {
                     var (_, countdown) = e.Current;
-                    if (countdown is {} n && n != index - 1)
+                    if (countdown is { } n && n != index - 1)
                         throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
 
                     do

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -79,7 +79,7 @@ namespace MoreLinq
             IEnumerable<TResult> IterateCollection(int i)
             {
                 foreach (var item in source)
-                    yield return resultSelector(item, i-- <= count ? i : (int?) null);
+                    yield return resultSelector(item, i-- <= count ? i : null);
             }
 
             IEnumerable<TResult> IterateSequence()

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -57,9 +57,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return source.TryAsListLike() is {} listLike
+            return source.TryAsListLike() is { } listLike
                    ? IterateList(listLike)
-                   : source.TryGetCollectionCount() is {} collectionCount
+                   : source.TryGetCollectionCount() is { } collectionCount
                      ? IterateCollection(collectionCount)
                      : IterateSequence();
 
@@ -71,7 +71,7 @@ namespace MoreLinq
                 {
                     var cd = list.Count - i <= count
                            ? --countdown
-                           : (int?) null;
+                           : (int?)null;
                     yield return resultSelector(list[i], cd);
                 }
             }

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -167,11 +167,11 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is {} firstCount)
+            if (first.TryGetCollectionCount() is { } firstCount)
             {
                 return firstCount.CompareTo(second.TryGetCollectionCount() ?? second.CountUpTo(firstCount + 1));
             }
-            else if (second.TryGetCollectionCount() is {} secondCount)
+            else if (second.TryGetCollectionCount() is { } secondCount)
             {
                 return first.CountUpTo(secondCount + 1).CompareTo(secondCount);
             }

--- a/MoreLinq/Delegating.cs
+++ b/MoreLinq/Delegating.cs
@@ -22,6 +22,8 @@
 
 // https://github.com/atifaziz/Delegating
 
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
 namespace Delegating
 {
     using System;

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -74,7 +74,7 @@ namespace MoreLinq
             comparer ??= EqualityComparer<T>.Default;
 
             List<T> secondList;
-#pragma warning disable IDE0075 // Simplify conditional expression
+#pragma warning disable IDE0075 // Simplify conditional expression (makes it worse)
             return second.TryGetCollectionCount() is { } secondCount
                    ? first.TryGetCollectionCount() is { } firstCount && secondCount > firstCount
                      ? false

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -74,11 +74,13 @@ namespace MoreLinq
             comparer ??= EqualityComparer<T>.Default;
 
             List<T> secondList;
+#pragma warning disable IDE0075 // Simplify conditional expression
             return second.TryGetCollectionCount() is {} secondCount
                    ? first.TryGetCollectionCount() is {} firstCount && secondCount > firstCount
                      ? false
                      : Impl(second, secondCount)
                    : Impl(secondList = second.ToList(), secondList.Count);
+#pragma warning restore IDE0075 // Simplify conditional expression
 
             bool Impl(IEnumerable<T> snd, int count)
             {

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -75,8 +75,8 @@ namespace MoreLinq
 
             List<T> secondList;
 #pragma warning disable IDE0075 // Simplify conditional expression
-            return second.TryGetCollectionCount() is {} secondCount
-                   ? first.TryGetCollectionCount() is {} firstCount && secondCount > firstCount
+            return second.TryGetCollectionCount() is { } secondCount
+                   ? first.TryGetCollectionCount() is { } firstCount && secondCount > firstCount
                      ? false
                      : Impl(second, secondCount)
                    : Impl(secondList = second.ToList(), secondList.Count);

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -79,7 +79,9 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return _(); IEnumerable<TSource>_()
+            return Impl();
+
+            IEnumerable<TSource> Impl()
             {
                 // TODO Use ToHashSet
                 var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);
@@ -89,7 +91,7 @@ namespace MoreLinq
                     if (keys.Contains(key))
                         continue;
                     yield return element;
-                    keys.Add(key);
+                    _ = keys.Add(key);
                 }
             }
         }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -27,7 +27,6 @@ namespace MoreLinq.Experimental
     using System.Runtime.ExceptionServices;
     using System.Threading;
     using System.Threading.Tasks;
-    using Unit = System.ValueTuple;
 
     /// <summary>
     /// Represents options for a query whose results evaluate asynchronously.
@@ -751,7 +750,7 @@ namespace MoreLinq.Experimental
 
             static Task CreateCompletedTask()
             {
-                var tcs = new TaskCompletionSource<Unit>();
+                var tcs = new TaskCompletionSource<System.ValueTuple>();
                 tcs.SetResult(default);
                 return tcs.Task;
             }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -527,8 +527,10 @@ namespace MoreLinq.Experimental
                     var nextKey = 0;
                     var holds = ordered ? new List<(int, T, Task<TTaskResult>)>() : null;
 
+#pragma warning disable IDE0011 // Add braces
                     using (var notice = notices.GetConsumingEnumerable(consumerCancellationTokenSource.Token)
                                                .GetEnumerator())
+#pragma warning restore IDE0011 // Add braces
                     while (true)
                     {
                         try

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -200,6 +200,7 @@ namespace MoreLinq.Experimental
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (value == null) throw new ArgumentNullException(nameof(value));
+
             return source.WithOptions(source.Options.WithScheduler(value));
         }
 

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -200,7 +200,6 @@ namespace MoreLinq.Experimental
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (value == null) throw new ArgumentNullException(nameof(value));
-
             return source.WithOptions(source.Options.WithScheduler(value));
         }
 

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -652,7 +652,7 @@ namespace MoreLinq.Experimental
                         onEnd();
                 }
 
-                var concurrencyGate = maxConcurrency is {} count
+                var concurrencyGate = maxConcurrency is { } count
                                     ? new ConcurrencyGate(count)
                                     : ConcurrencyGate.Unbounded;
 
@@ -742,7 +742,7 @@ namespace MoreLinq.Experimental
 
         static class CompletedTask
         {
-            #if NETSTANDARD1_0
+#if NETSTANDARD1_0
 
             public static readonly Task Instance = CreateCompletedTask();
 
@@ -753,11 +753,11 @@ namespace MoreLinq.Experimental
                 return tcs.Task;
             }
 
-            #else
+#else
 
             public static readonly Task Instance = Task.CompletedTask;
 
-            #endif
+#endif
         }
 
         sealed class ConcurrencyGate
@@ -770,7 +770,7 @@ namespace MoreLinq.Experimental
                 _semaphore = semaphore;
 
             public ConcurrencyGate(int max) :
-                this(new SemaphoreSlim(max, max)) {}
+                this(new SemaphoreSlim(max, max)) { }
 
             public Task EnterAsync(CancellationToken token)
             {

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -426,11 +426,11 @@ namespace MoreLinq.Experimental
 
             return
                 AwaitQuery.Create(
-                    options => _(options.MaxConcurrency,
-                                 options.Scheduler ?? TaskScheduler.Default,
-                                 options.PreserveOrder));
+                    options => Impl(options.MaxConcurrency,
+                                    options.Scheduler ?? TaskScheduler.Default,
+                                    options.PreserveOrder));
 
-            IEnumerable<TResult> _(int? maxConcurrency, TaskScheduler scheduler, bool ordered)
+            IEnumerable<TResult> Impl(int? maxConcurrency, TaskScheduler scheduler, bool ordered)
             {
                 // A separate task will enumerate the source and launch tasks.
                 // It will post all progress as notices to the collection below.
@@ -466,7 +466,7 @@ namespace MoreLinq.Experimental
                     // completes and another, an end-notice, when all tasks have
                     // completed.
 
-                    Task.Factory.StartNew(
+                    _ = Task.Factory.StartNew(
                         async () =>
                         {
                             try
@@ -668,7 +668,7 @@ namespace MoreLinq.Experimental
                         return;
                     }
 
-                    Interlocked.Increment(ref pendingCount);
+                    _ = Interlocked.Increment(ref pendingCount);
 
                     var item = enumerator.Current;
                     var task = starter(item);
@@ -677,9 +677,7 @@ namespace MoreLinq.Experimental
                     // along with the necessary housekeeping, in case it
                     // completes before maximum concurrency is reached.
 
-                    #pragma warning disable 4014 // https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs4014
-
-                    task.ContinueWith(cancellationToken: cancellationToken,
+                    _ = task.ContinueWith(cancellationToken: cancellationToken,
                         continuationOptions: TaskContinuationOptions.ExecuteSynchronously,
                         scheduler: TaskScheduler.Current,
                         continuationAction: t =>
@@ -692,8 +690,6 @@ namespace MoreLinq.Experimental
                             onTaskCompletion(item, t);
                             OnPendingCompleted();
                         });
-
-                    #pragma warning restore 4014
                 }
 
                 OnPendingCompleted();

--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -115,7 +115,7 @@ namespace MoreLinq.Experimental
                     };
                     return resultSelector(one, item);
                 }
-                case {}:
+                case not null:
                     return resultSelector(many, default);
                 default:
                 {

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -161,7 +161,7 @@ namespace MoreLinq
             int? count, T? fallback1, T? fallback2, T? fallback3, T? fallback4,
             IEnumerable<T>? fallback)
         {
-            return source.TryGetCollectionCount() is {} collectionCount
+            return source.TryGetCollectionCount() is { } collectionCount
                  ? collectionCount == 0 ? Fallback() : source
                  : _();
 

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -134,7 +134,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
-
             return source.FallbackIfEmpty((IEnumerable<T>)fallback);
         }
 
@@ -155,7 +154,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
-
             return FallbackIfEmptyImpl(source, null, default, default, default, default, fallback);
         }
 

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -134,6 +134,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
+
             return source.FallbackIfEmpty((IEnumerable<T>)fallback);
         }
 
@@ -154,6 +155,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (fallback == null) throw new ArgumentNullException(nameof(fallback));
+
             return FallbackIfEmptyImpl(source, null, default, default, default, default, fallback);
         }
 

--- a/MoreLinq/FillForward.cs
+++ b/MoreLinq/FillForward.cs
@@ -112,7 +112,7 @@ namespace MoreLinq
             {
                 if (predicate(item))
                 {
-                    yield return seed is (true, {} someSeed)
+                    yield return seed is (true, { } someSeed)
                                ? fillSelector != null
                                  ? fillSelector(item, someSeed)
                                  : someSeed

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -137,11 +137,11 @@ namespace MoreLinq
                     {
                         e = stack.Pop();
 
-                        reloop:
+                    reloop:
 
                         while (e.MoveNext())
                         {
-                            if (selector(e.Current) is {} inner)
+                            if (selector(e.Current) is { } inner)
                             {
                                 stack.Push(e);
                                 e = inner.GetEnumerator();

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -228,7 +228,9 @@ namespace MoreLinq
             if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
             if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return Impl();
+
+            IEnumerable<TResult> Impl()
             {
                 var seconds = second.Select(e => new KeyValuePair<TKey, TSecond>(secondKeySelector(e), e)).ToArray();
                 var secondLookup = seconds.ToLookup(e => e.Key, e => e.Value, comparer);
@@ -237,7 +239,7 @@ namespace MoreLinq
                 foreach (var fe in first)
                 {
                     var key = firstKeySelector(fe);
-                    firstKeys.Add(key);
+                    _ = firstKeys.Add(key);
 
                     using var se = secondLookup[key].GetEnumerator();
 

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -273,7 +273,7 @@ namespace MoreLinq
                 var key = keySelector(iterator.Current);
                 var element = elementSelector(iterator.Current);
 
-                if (group is (var k, {} members))
+                if (group is (var k, { } members))
                 {
                     if (comparer.Equals(k, key))
                     {
@@ -290,7 +290,7 @@ namespace MoreLinq
             }
 
             {
-                if (group is (var k, {} members))
+                if (group is (var k, { } members))
                     yield return resultSelector(k, members);
             }
         }
@@ -304,9 +304,9 @@ namespace MoreLinq
                 new(key, members);
         }
 
-        #if !NO_SERIALIZATION_ATTRIBUTES
+#if !NO_SERIALIZATION_ATTRIBUTES
         [Serializable]
-        #endif
+#endif
         sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>
         {
             readonly IEnumerable<TElement> _members;

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -53,7 +53,7 @@ namespace MoreLinq
         {
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
-            if (index < 0)  throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative.");
+            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative.");
 
             return _(); IEnumerable<T> _()
             {
@@ -65,7 +65,7 @@ namespace MoreLinq
                     yield return iter.Current;
 
                 if (i < index)
-                   throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
+                    throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
 
                 foreach (var item in second)
                     yield return item;

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -50,9 +50,9 @@ namespace MoreLinq
             if (otherSequences.Any(s => s == null))
                 throw new ArgumentNullException(nameof(otherSequences), "One or more sequences passed to Interleave was null.");
 
-            return _(otherSequences.Prepend(sequence));
+            return Impl(otherSequences.Prepend(sequence));
 
-            static IEnumerable<T> _(IEnumerable<IEnumerable<T>> sequences)
+            static IEnumerable<T> Impl(IEnumerable<IEnumerable<T>> sequences)
             {
                 var enumerators = new LinkedList<IEnumerator<T>>();
 
@@ -64,7 +64,7 @@ namespace MoreLinq
                     {
                         var enumerator = sequence.GetEnumerator();
 
-                        enumerators.AddLast(enumerator);
+                        _ = enumerators.AddLast(enumerator);
                         if (enumerator.MoveNext())
                         {
                             yield return enumerator.Current;
@@ -72,7 +72,7 @@ namespace MoreLinq
                         else // Dispose and remove empty sequence
                         {
                             enumerator.Dispose();
-                            enumerators.Remove(enumerator);
+                            _ = enumerators.Remove(enumerator);
                         }
                     }
 

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -25,6 +25,7 @@
 #endregion
 
 #pragma warning disable IDE0040 // Add accessibility modifiers
+#pragma warning disable IDE0032 // Use auto property
 
 namespace MoreLinq
 {

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -26,6 +26,7 @@
 
 #pragma warning disable IDE0040 // Add accessibility modifiers
 #pragma warning disable IDE0032 // Use auto property
+#pragma warning disable IDE0017 // Simplify object initialization
 
 namespace MoreLinq
 {

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -215,7 +215,7 @@ namespace MoreLinq
             if (selector == null) throw new ArgumentNullException(nameof(selector));
 
             comparer ??= Comparer<TKey>.Default;
-            return new ExtremaEnumerable<TSource, TKey>(source, selector, (x, y) => comparer.Compare(x, y));
+            return new ExtremaEnumerable<TSource, TKey>(source, selector, comparer.Compare);
         }
 
         sealed class ExtremaEnumerable<T, TKey> : IExtremaEnumerable<T>

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -279,7 +279,7 @@ namespace MoreLinq
 
                     public override void Add(ref Queue<T>? store, int? limit, T item)
                     {
-                        if (limit is {} n && store is {} queue && queue.Count == n)
+                        if (limit is { } n && store is { } queue && queue.Count == n)
                             _ = queue.Dequeue();
                         (store ??= new Queue<T>()).Enqueue(item);
                     }

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -348,6 +348,8 @@ namespace MoreLinq
                         case 0:
                             extrema.Add(ref store, limit, item);
                             break;
+                        default:
+                            break;
                     }
                 }
 

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -280,7 +280,7 @@ namespace MoreLinq
                     public override void Add(ref Queue<T>? store, int? limit, T item)
                     {
                         if (limit is {} n && store is {} queue && queue.Count == n)
-                            queue.Dequeue();
+                            _ = queue.Dequeue();
                         (store ??= new Queue<T>()).Enqueue(item);
                     }
                 }

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -63,7 +63,7 @@ namespace MoreLinq
 
             IEnumerable<T> _(int bufferStartIndex, int bufferSize, int bufferYieldIndex)
             {
-                bool hasMore = true;
+                var hasMore = true;
                 bool MoveNext(IEnumerator<T> e) => hasMore && (hasMore = e.MoveNext());
 
                 using var e = source.GetEnumerator();

--- a/MoreLinq/OrderBy.cs
+++ b/MoreLinq/OrderBy.cs
@@ -53,6 +53,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
             return direction == OrderByDirection.Ascending
                        ? source.OrderBy(keySelector, comparer)
                        : source.OrderByDescending(keySelector, comparer);
@@ -88,6 +89,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
             return direction == OrderByDirection.Ascending
                        ? source.ThenBy(keySelector, comparer)
                        : source.ThenByDescending(keySelector, comparer);

--- a/MoreLinq/OrderBy.cs
+++ b/MoreLinq/OrderBy.cs
@@ -53,7 +53,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-
             return direction == OrderByDirection.Ascending
                        ? source.OrderBy(keySelector, comparer)
                        : source.OrderByDescending(keySelector, comparer);
@@ -89,7 +88,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-
             return direction == OrderByDirection.Ascending
                        ? source.ThenBy(keySelector, comparer)
                        : source.ThenByDescending(keySelector, comparer);

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -78,6 +78,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (width < 0) throw new ArgumentException(null, nameof(width));
+
             return PadImpl(source, width, padding, null);
         }
 
@@ -110,6 +111,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
+
             return PadImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -78,7 +78,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-
             return PadImpl(source, width, padding, null);
         }
 
@@ -111,7 +110,6 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-
             return PadImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -78,6 +78,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (width < 0) throw new ArgumentException(null, nameof(width));
+
             return PadStartImpl(source, width, padding, null);
         }
 
@@ -112,6 +113,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
+
             return PadStartImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -78,7 +78,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-
             return PadStartImpl(source, width, padding, null);
         }
 
@@ -113,7 +112,6 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
             if (width < 0) throw new ArgumentException(null, nameof(width));
-
             return PadStartImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -119,42 +119,42 @@ namespace MoreLinq
             int width, T? padding, Func<int, T>? paddingSelector)
         {
             return
-                source.TryGetCollectionCount() is {} collectionCount
+                source.TryGetCollectionCount() is { } collectionCount
                 ? collectionCount >= width
                   ? source
                   : Enumerable.Range(0, width - collectionCount)
                               .Select(i => paddingSelector != null ? paddingSelector(i) : padding!)
                               .Concat(source)
                 : _(); IEnumerable<T> _()
+            {
+                var array = new T[width];
+                var count = 0;
+
+                using (var e = source.GetEnumerator())
                 {
-                    var array = new T[width];
-                    var count = 0;
+                    for (; count < width && e.MoveNext(); count++)
+                        array[count] = e.Current;
 
-                    using (var e = source.GetEnumerator())
+                    if (count == width)
                     {
-                        for (; count < width && e.MoveNext(); count++)
-                            array[count] = e.Current;
+                        for (var i = 0; i < count; i++)
+                            yield return array[i];
 
-                        if (count == width)
-                        {
-                            for (var i = 0; i < count; i++)
-                                yield return array[i];
+                        while (e.MoveNext())
+                            yield return e.Current;
 
-                            while (e.MoveNext())
-                                yield return e.Current;
-
-                            yield break;
-                        }
+                        yield break;
                     }
-
-                    var len = width - count;
-
-                    for (var i = 0; i < len; i++)
-                        yield return paddingSelector != null ? paddingSelector(i) : padding!;
-
-                    for (var i = 0; i < count; i++)
-                        yield return array[i];
                 }
+
+                var len = width - count;
+
+                for (var i = 0; i < len; i++)
+                    yield return paddingSelector != null ? paddingSelector(i) : padding!;
+
+                for (var i = 0; i < count; i++)
+                    yield return array[i];
+            }
         }
     }
 }

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -184,6 +184,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
             return PartialSortByImpl(source, count, keySelector, comparer, null);
         }
 

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -184,7 +184,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-
             return PartialSortByImpl(source, count, keySelector, comparer, null);
         }
 

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -243,7 +243,7 @@ namespace MoreLinq
                 if (keys != null)
                 {
                     var key = Assume.NotNull(keySelector)(item);
-                    if (Insert(keys, key, keyComparer) is {} i)
+                    if (Insert(keys, key, keyComparer) is { } i)
                     {
                         if (top.Count == count)
                             top.RemoveAt(count - 1);

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -113,6 +113,7 @@ namespace MoreLinq
             Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
             return source.Partition(key1: true, key2: false, (t, f, _) => resultSelector(t, f));
         }
 
@@ -140,6 +141,7 @@ namespace MoreLinq
             Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
             return source.Partition(key1: true, key2: false, key3: null, (t, f, n, _) => resultSelector(t, f, n));
         }
 

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -113,7 +113,6 @@ namespace MoreLinq
             Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-
             return source.Partition(key1: true, key2: false, (t, f, _) => resultSelector(t, f));
         }
 
@@ -141,7 +140,6 @@ namespace MoreLinq
             Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
-
             return source.Partition(key1: true, key2: false, key3: null, (t, f, n, _) => resultSelector(t, f, n));
         }
 

--- a/MoreLinq/PendNode.cs
+++ b/MoreLinq/PendNode.cs
@@ -101,7 +101,7 @@ namespace MoreLinq
                 }
             }
 
-            var source = (Source) current;
+            var source = (Source)current;
 
             foreach (var item in source.Value)
                 yield return item;

--- a/MoreLinq/PendNode.cs
+++ b/MoreLinq/PendNode.cs
@@ -111,7 +111,7 @@ namespace MoreLinq
                 if (i == 4) { yield return concat4!; i--; }
                 if (i == 3) { yield return concat3!; i--; }
                 if (i == 2) { yield return concat2!; i--; }
-                if (i == 1) { yield return concat1!; i--; }
+                if (i == 1) { yield return concat1!; }
                 yield break;
             }
 

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -99,7 +99,7 @@ namespace MoreLinq
                 _generatorIterator = _generator.GetEnumerator();
                 // we must advance the nested loop iterator to the initial element,
                 // this ensures that we only ever produce N!-1 calls to NextPermutation()
-                _generatorIterator.MoveNext();
+                _ = _generatorIterator.MoveNext();
                 _hasMoreResults = true; // there's always at least one permutation: the original set itself
             }
 

--- a/MoreLinq/Prepend.cs
+++ b/MoreLinq/Prepend.cs
@@ -44,7 +44,6 @@ namespace MoreLinq
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-
             return source is PendNode<TSource> node
                  ? node.Prepend(value)
                  : PendNode<TSource>.WithSource(source).Prepend(value);

--- a/MoreLinq/Prepend.cs
+++ b/MoreLinq/Prepend.cs
@@ -44,6 +44,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
+
             return source is PendNode<TSource> node
                  ? node.Prepend(value)
                  : PendNode<TSource>.WithSource(source).Prepend(value);

--- a/MoreLinq/Random.cs
+++ b/MoreLinq/Random.cs
@@ -161,12 +161,7 @@ namespace MoreLinq
         public static IEnumerable<int> Random(Random rand, int minValue, int maxValue)
         {
             if (rand == null) throw new ArgumentNullException(nameof(rand));
-
-            if (minValue > maxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minValue),
-                    $"The argument minValue ({minValue}) is greater than maxValue ({maxValue})");
-            }
+            if (minValue > maxValue) throw new ArgumentOutOfRangeException(nameof(minValue), $"The argument minValue ({minValue}) is greater than maxValue ({maxValue})");
 
             return RandomImpl(rand, r => r.Next(minValue, maxValue));
         }

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -109,7 +109,7 @@ namespace MoreLinq.Reactive
                 // Remove any observers that were marked for deletion during
                 // iteration.
 
-                observers.RemoveAll(o => o == null);
+                _ = observers.RemoveAll(o => o == null);
             }
         }
 

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -35,7 +35,6 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Repeat count must be greater than or equal to zero.");
-
             return RepeatImpl(sequence, count);
         }
 

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -35,6 +35,7 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Repeat count must be greater than or equal to zero.");
+
             return RepeatImpl(sequence, count);
         }
 

--- a/MoreLinq/ReverseComparer.cs
+++ b/MoreLinq/ReverseComparer.cs
@@ -23,10 +23,8 @@ namespace MoreLinq
     {
         readonly IComparer<T> _underlying;
 
-        public ReverseComparer(IComparer<T>? underlying)
-        {
+        public ReverseComparer(IComparer<T>? underlying) =>
             _underlying = underlying ?? Comparer<T>.Default;
-        }
 
         public int Compare
 #if NETCOREAPP3_1_OR_GREATER

--- a/MoreLinq/RightJoin.cs
+++ b/MoreLinq/RightJoin.cs
@@ -59,6 +59,7 @@ namespace MoreLinq
             Func<TSource, TSource, TResult> bothSelector)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
             return first.RightJoin(second, keySelector,
                                    secondSelector, bothSelector,
                                    null);
@@ -105,6 +106,7 @@ namespace MoreLinq
             IEqualityComparer<TKey>? comparer)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+
             return first.RightJoin(second,
                                    keySelector, keySelector,
                                    secondSelector, bothSelector,

--- a/MoreLinq/RightJoin.cs
+++ b/MoreLinq/RightJoin.cs
@@ -59,7 +59,6 @@ namespace MoreLinq
             Func<TSource, TSource, TResult> bothSelector)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-
             return first.RightJoin(second, keySelector,
                                    secondSelector, bothSelector,
                                    null);
@@ -106,7 +105,6 @@ namespace MoreLinq
             IEqualityComparer<TKey>? comparer)
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-
             return first.RightJoin(second,
                                    keySelector, keySelector,
                                    secondSelector, bothSelector,

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -47,8 +47,7 @@ namespace MoreLinq
 
         public static IEnumerable<KeyValuePair<T, int>> RunLengthEncode<T>(this IEnumerable<T> sequence, IEqualityComparer<T>? comparer)
         {
-            if (sequence == null)
-                throw new ArgumentNullException(nameof(sequence));
+            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 
             return _(comparer ?? EqualityComparer<T>.Default);
 

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -94,8 +94,8 @@ namespace MoreLinq
 
                     if (newSegmentPredicate(current, previous, index))
                     {
-                         yield return segment;              // yield the completed segment
-                         segment = new List<T> { current }; // start a new segment
+                        yield return segment;              // yield the completed segment
+                        segment = new List<T> { current }; // start a new segment
                     }
                     else // not a new segment, append and continue
                     {

--- a/MoreLinq/SequenceException.cs
+++ b/MoreLinq/SequenceException.cs
@@ -27,7 +27,7 @@ namespace MoreLinq
     /// </summary>
 
 #if !NO_EXCEPTION_SERIALIZATION
-    [ Serializable ]
+    [Serializable]
 #endif
     public class SequenceException : Exception
     {
@@ -38,7 +38,7 @@ namespace MoreLinq
         /// </summary>
 
         public SequenceException() :
-            this(null) {}
+            this(null) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SequenceException"/> class
@@ -69,7 +69,7 @@ namespace MoreLinq
         /// <param name="context">The contextual information about the source or destination.</param>
 
         protected SequenceException(SerializationInfo info, StreamingContext context) :
-            base(info, context) {}
+            base(info, context) { }
 #endif
     }
 }

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -41,9 +41,9 @@ namespace MoreLinq
                 return source;
 
             return
-                source.TryGetCollectionCount() is {} collectionCount
+                source.TryGetCollectionCount() is { } collectionCount
                 ? source.Take(collectionCount - count)
-                : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd ))
+                : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
                         .TakeWhile(e => e.Countdown == null)
                         .Select(e => e.Element);
         }

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -37,15 +37,11 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            if (count < 1)
-                return source;
-
-            return
-                source.TryGetCollectionCount() is { } collectionCount
-                ? source.Take(collectionCount - count)
-                : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
-                        .TakeWhile(e => e.Countdown == null)
-                        .Select(e => e.Element);
+            return count < 1 ? source
+                 : source.TryGetCollectionCount() is { } collectionCount ? source.Take(collectionCount - count)
+                 : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
+                         .TakeWhile(e => e.Countdown == null)
+                         .Select(e => e.Element);
         }
     }
 }

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -73,8 +73,8 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is {} firstCount &&
-                second.TryGetCollectionCount() is {} secondCount &&
+            if (first.TryGetCollectionCount() is { } firstCount &&
+                second.TryGetCollectionCount() is { } secondCount &&
                 secondCount > firstCount)
             {
                 return false;

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -191,7 +191,7 @@ namespace MoreLinq
 
                     ExtractSubset();
 
-                    _continue = (_indices[0] != _z);
+                    _continue = _indices[0] != _z;
                     return true;
                 }
 

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -47,6 +47,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (step <= 0) throw new ArgumentOutOfRangeException(nameof(step));
+
             return source.Where((_, i) => i % step == 0);
         }
     }

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -47,7 +47,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (step <= 0) throw new ArgumentOutOfRangeException(nameof(step));
-
             return source.Where((_, i) => i % step == 0);
         }
     }

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -50,15 +50,12 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            if (count < 1)
-                return Enumerable.Empty<TSource>();
-
-            return
-                source.TryGetCollectionCount() is { } collectionCount
-                ? source.Slice(Math.Max(0, collectionCount - count), int.MaxValue)
-                : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
-                        .SkipWhile(e => e.Countdown == null)
-                        .Select(e => e.Element);
+            return count < 1 ? Enumerable.Empty<TSource>()
+                 : source.TryGetCollectionCount() is { } collectionCount
+                   ? source.Slice(Math.Max(0, collectionCount - count), int.MaxValue)
+                   : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
+                           .SkipWhile(e => e.Countdown == null)
+                           .Select(e => e.Element);
         }
     }
 }

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -54,7 +54,7 @@ namespace MoreLinq
                 return Enumerable.Empty<TSource>();
 
             return
-                source.TryGetCollectionCount() is {} collectionCount
+                source.TryGetCollectionCount() is { } collectionCount
                 ? source.Slice(Math.Max(0, collectionCount - count), int.MaxValue)
                 : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
                         .SkipWhile(e => e.Countdown == null)

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -121,7 +121,7 @@ namespace MoreLinq
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
             var lastIndex = -1;
-            var indexed = (List<KeyValuePair<int, T>>?) null;
+            var indexed = (List<KeyValuePair<int, T>>?)null;
             List<KeyValuePair<int, T>> Indexed() => indexed ??= new List<KeyValuePair<int, T>>();
 
             foreach (var e in source)

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -126,7 +126,9 @@ namespace MoreLinq
 
             foreach (var e in source)
             {
+#pragma warning disable IDE0010 // Add missing cases (false negative)
                 switch (indexSelector(e))
+#pragma warning restore IDE0010 // Add missing cases
                 {
                     case < 0:
 #pragma warning disable CA2201 // Do not raise reserved exception types

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -191,8 +191,8 @@ namespace MoreLinq
 
             var schemas = from m in members
                           let type = m.MemberType == MemberTypes.Property
-                                   ? ((PropertyInfo) m).PropertyType
-                                   : ((FieldInfo) m).FieldType
+                                   ? ((PropertyInfo)m).PropertyType
+                                   : ((FieldInfo)m).FieldType
                           select new
                           {
                               Member = m,

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -47,6 +47,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
         }
 

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -47,7 +47,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
         }
 

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -57,8 +57,9 @@ namespace MoreLinq
 
             foreach (var value in source)
             {
-                if (i++ > 0) sb.Append(delimiter);
-                append(sb, value);
+                if (i++ > 0)
+                    _ = sb.Append(delimiter);
+                _ = append(sb, value);
             }
 
             return sb.ToString();

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -37,7 +37,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source)
         {
-            return Trace(source, (string?) null);
+            return Trace(source, (string?)null);
         }
 
         /// <summary>

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -86,7 +86,6 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
-
             return TraceImpl(source, formatter);
         }
 

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -86,6 +86,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+
             return TraceImpl(source, formatter);
         }
 

--- a/MoreLinq/Transpose.cs
+++ b/MoreLinq/Transpose.cs
@@ -58,7 +58,9 @@ namespace MoreLinq
 
             return _(); IEnumerable<IEnumerable<T>> _()
             {
+#pragma warning disable IDE0007 // Use implicit type (false positive)
                 IEnumerator<T>?[] enumerators = source.Select(e => e.GetEnumerator()).Acquire();
+#pragma warning restore IDE0007 // Use implicit type
 
                 try
                 {

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -117,7 +117,7 @@ static void Run(IEnumerable<string> args)
 
     var abbreviatedTypeNodes = Enumerable
         .Range(0, 26)
-        .Select(a => (char) ('a' + a))
+        .Select(a => (char)('a' + a))
         .Select(ch => new SimpleTypeKey(ch.ToString()))
         .ToArray();
 
@@ -243,7 +243,7 @@ static void Run(IEnumerable<string> args)
     var indent2 = indent + indent;
     var indent3 = indent2 + indent;
 
-    var baseImports = new []
+    var baseImports = new[]
     {
         "System",
         "System.CodeDom.Compiler",
@@ -403,7 +403,7 @@ abstract class TypeKey : IComparable<TypeKey>
 
 sealed class SimpleTypeKey : TypeKey
 {
-    public SimpleTypeKey(string name) : base(name) {}
+    public SimpleTypeKey(string name) : base(name) { }
     public override string ToString() => Name;
     public override ImmutableList<TypeKey> Parameters => ImmutableList<TypeKey>.Empty;
 }
@@ -411,7 +411,7 @@ sealed class SimpleTypeKey : TypeKey
 abstract class ParameterizedTypeKey : TypeKey
 {
     protected ParameterizedTypeKey(string name, TypeKey parameter) :
-        this(name, ImmutableList.Create(parameter)) {}
+        this(name, ImmutableList.Create(parameter)) { }
 
     protected ParameterizedTypeKey(string name, ImmutableList<TypeKey> parameters) :
         base(name) => Parameters = parameters;
@@ -422,7 +422,7 @@ abstract class ParameterizedTypeKey : TypeKey
 sealed class GenericTypeKey : ParameterizedTypeKey
 {
     public GenericTypeKey(string name, ImmutableList<TypeKey> parameters) :
-        base(name, parameters) {}
+        base(name, parameters) { }
 
     public override string ToString() =>
         Name + "<" + string.Join(", ", Parameters) + ">";
@@ -430,14 +430,14 @@ sealed class GenericTypeKey : ParameterizedTypeKey
 
 sealed class NullableTypeKey : ParameterizedTypeKey
 {
-    public NullableTypeKey(TypeKey underlying) : base("?", underlying) {}
+    public NullableTypeKey(TypeKey underlying) : base("?", underlying) { }
     public override string ToString() => Parameters.Single() + "?";
 }
 
 sealed class TupleTypeKey : ParameterizedTypeKey
 {
     public TupleTypeKey(ImmutableList<TypeKey> parameters) :
-        base("()", parameters) {}
+        base("()", parameters) { }
 
     public override string ToString() =>
         "(" + string.Join(", ", Parameters) + ")";

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -460,9 +460,12 @@ sealed class ArrayTypeKey : ParameterizedTypeKey
         {
             if (Ranks.Count.CompareTo(a.Ranks.Count) is var rlc and not 0)
                 return rlc;
+
             if (Ranks.Zip(a.Ranks, (us, them) => (Us: us, Them: them))
                      .Aggregate(0, (c, r) => c == 0 ? r.Us.CompareTo(r.Them) : c) is var rc and not 0)
+            {
                 return rc;
+            }
         }
 
         return base.CompareParameters(other);


### PR DESCRIPTION
Code style analysis was already configured to be enforced:

https://github.com/morelinq/MoreLINQ/blob/9c17aae35a5d8194776bc348028e78b36c023d6b/Directory.Build.props#L7

However, this PR:

- sets up the severity such that they are truly enforced through warnings/errors,
- addresses identified issues in the current code base, and
- configures individual styles as needed

Many formatting inconsistencies and issue were addressed by temporarily setting the severity of the [IDE0055](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0055) rule to warning before settling on suggestion (because unfortunately many IDE0055 issues trigger on code deliberately formatted for improving readability).