### PR TITLE
Fix collection-optimized paths to be at iteration-time

### DIFF
--- a/MoreLinq.Test/AssertCountTest.cs
+++ b/MoreLinq.Test/AssertCountTest.cs
@@ -18,6 +18,7 @@
 namespace MoreLinq.Test
 {
     using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -113,13 +114,6 @@ namespace MoreLinq.Test
             _ = new BreakingCollection<int>(new int[5]).AssertCount(0);
         }
 
-        [Test]
-        public void AssertCountWithMatchingCollectionCount()
-        {
-            var xs = new[] { 123, 456, 789 };
-            Assert.That(xs, Is.SameAs(xs.AssertCount(3)));
-        }
-
         [TestCase(3, 2, "Sequence contains too many elements when exactly 2 were expected.")]
         [TestCase(3, 4, "Sequence contains too few elements when exactly 4 were expected.")]
         public void AssertCountWithMismatchingCollectionCount(int sourceCount, int count, string message)
@@ -134,6 +128,16 @@ namespace MoreLinq.Test
         public void AssertCountWithReadOnlyCollectionIsLazy()
         {
             _ = new BreakingReadOnlyCollection<object>(5).AssertCount(0);
+        }
+
+        [Test]
+        public void AssertCountUsesCollectionCountAtIterationTime()
+        {
+            var stack = new Stack<int>(Enumerable.Range(1, 3));
+            var result = stack.AssertCount(4);
+            stack.Push(4);
+            result.Consume();
+            Assert.Pass();
         }
     }
 }

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -211,5 +211,14 @@ namespace MoreLinq.Test
                 protected override IEnumerable<T> Items => _collection;
             }
         }
+
+        [Test]
+        public void UsesCollectionCountAtIterationTime()
+        {
+            var stack = new Stack<int>(Enumerable.Range(1, 3));
+            var result = stack.CountDown(2, (_, cd) => cd);
+            stack.Push(4);
+            result.AssertSequenceEqual(null, null, 1, 0);
+        }
     }
 }

--- a/MoreLinq.Test/FallbackIfEmptyTest.cs
+++ b/MoreLinq.Test/FallbackIfEmptyTest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -36,37 +37,32 @@ namespace MoreLinq.Test
             // ReSharper restore PossibleMultipleEnumeration
         }
 
-        [TestCase(SourceKind.BreakingCollection)]
-        [TestCase(SourceKind.BreakingReadOnlyCollection)]
-        public void FallbackIfEmptyPreservesSourceCollectionIfPossible(SourceKind sourceKind)
-        {
-            var source = new[] { 1 }.ToSourceKind(sourceKind);
-            // ReSharper disable PossibleMultipleEnumeration
-            Assert.That(source.FallbackIfEmpty(12), Is.SameAs(source));
-            Assert.That(source.FallbackIfEmpty(12, 23), Is.SameAs(source));
-            Assert.That(source.FallbackIfEmpty(12, 23, 34), Is.SameAs(source));
-            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45), Is.SameAs(source));
-            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45, 56), Is.SameAs(source));
-            Assert.That(source.FallbackIfEmpty(12, 23, 34, 45, 56, 67), Is.SameAs(source));
-            // ReSharper restore PossibleMultipleEnumeration
-        }
-
-        [TestCase(SourceKind.BreakingCollection)]
-        [TestCase(SourceKind.BreakingReadOnlyCollection)]
-        public void FallbackIfEmptyPreservesFallbackCollectionIfPossible(SourceKind sourceKind)
-        {
-            var source = new int[0].ToSourceKind(sourceKind);
-            var fallback = new[] { 1 };
-            Assert.That(source.FallbackIfEmpty(fallback), Is.SameAs(fallback));
-            Assert.That(source.FallbackIfEmpty(fallback.AsEnumerable()), Is.SameAs(fallback));
-        }
-
         [Test]
         public void FallbackIfEmptyWithEmptyNullableSequence()
         {
             var source = Enumerable.Empty<int?>().Select(x => x);
             var fallback = (int?)null;
             source.FallbackIfEmpty(fallback).AssertSequenceEqual(fallback);
+        }
+
+        [Test]
+        public void FallbackUsesCollectionCountAtIterationTime()
+        {
+            var source = new List<int>();
+
+            var results = new[]
+            {
+                source.FallbackIfEmpty(-1),
+                source.FallbackIfEmpty(-1, -2),
+                source.FallbackIfEmpty(-1, -2, -3),
+                source.FallbackIfEmpty(-1, -2, -3, -4),
+                source.FallbackIfEmpty(-1, -2, -3, -4, -5),
+            };
+
+            source.Add(123);
+
+            foreach (var result in results)
+                result.AssertSequenceEqual(123);
         }
     }
 }

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -133,6 +133,14 @@ namespace MoreLinq.Test
             }
         }
 
+        [Test]
+        public void PadStartUsesCollectionCountAtIterationTime()
+        {
+            var queue = new Queue<int>(Enumerable.Range(1, 3));
+            var result = queue.PadStart(4, -1);
+            queue.Enqueue(4);
+            result.AssertSequenceEqual(1, 2, 3, 4);
+        }
 
         static void AssertEqual<T>(ICollection<T> input, Func<IEnumerable<T>, IEnumerable<T>> op, IEnumerable<T> expected)
         {

--- a/MoreLinq.Test/SkipLastTest.cs
+++ b/MoreLinq.Test/SkipLastTest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using System.Collections.Generic;
     using NUnit.Framework;
 
     [TestFixture]
@@ -55,6 +56,15 @@ namespace MoreLinq.Test
         public void SkipLastIsLazy()
         {
             _ = new BreakingSequence<object>().SkipLast(1);
+        }
+
+        [Test]
+        public void SkipLastUsesCollectionCountAtIterationTime()
+        {
+            var list = new List<int> { 1, 2, 3, 4 };
+            var result = list.SkipLast(2);
+            list.Add(5);
+            result.AssertSequenceEqual(1, 2, 3);
         }
     }
 }

--- a/MoreLinq.Test/TakeLastTest.cs
+++ b/MoreLinq.Test/TakeLastTest.cs
@@ -70,6 +70,15 @@ namespace MoreLinq.Test
             sequence.TakeLast(3).AssertSequenceEqual(8, 9, 10);
         }
 
+        [Test]
+        public void TakeLastUsesCollectionCountAtIterationTime()
+        {
+            var list = new List<int> { 1, 2, 3, 4 };
+            var result = list.TakeLast(3);
+            list.Add(5);
+            result.AssertSequenceEqual(3, 4, 5);
+        }
+
         static void AssertTakeLast<T>(ICollection<T> input, int count, Action<IEnumerable<T>> action)
         {
             // Test that the behaviour does not change whether a collection

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -86,13 +86,14 @@ namespace MoreLinq
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
-            return
-                source.TryGetCollectionCount() is { } collectionCount
-                ? collectionCount == count
-                  ? source
-                  : From<TSource>(() => throw errorSelector(collectionCount.CompareTo(count), count))
-                : _(); IEnumerable<TSource> _()
+            return _(); IEnumerable<TSource> _()
             {
+                if (source.TryAsCollectionLike() is { Count: var collectionCount }
+                    && collectionCount.CompareTo(count) is var comparison && comparison != 0)
+                {
+                    throw errorSelector(comparison, count);
+                }
+
                 var iterations = 0;
                 foreach (var element in source)
                 {

--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -1,0 +1,52 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2023 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a union over list types implementing either <see
+    /// cref="ICollection{T}"/> or <see cref="IReadOnlyCollection{T}"/>,
+    /// allowing both to be treated the same.
+    /// </summary>
+
+    readonly struct CollectionLike<T>
+    {
+        readonly ICollection<T>? _rw;
+        readonly IReadOnlyCollection<T>? _rx;
+
+        public CollectionLike(ICollection<T> collection)
+        {
+            _rw = collection ?? throw new ArgumentNullException(nameof(collection));
+            _rx = null;
+        }
+
+        public CollectionLike(IReadOnlyCollection<T> collection)
+        {
+            _rw = null;
+            _rx = collection ?? throw new ArgumentNullException(nameof(collection));
+        }
+
+        public int Count => _rw?.Count ?? _rx?.Count ?? 0;
+
+        public IEnumerator<T> GetEnumerator() =>
+            _rw?.GetEnumerator() ?? _rx?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
+    }
+}

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -59,8 +59,8 @@ namespace MoreLinq
 
             return source.TryAsListLike() is { } listLike
                    ? IterateList(listLike)
-                   : source.TryGetCollectionCount() is { } collectionCount
-                     ? IterateCollection(collectionCount)
+                   : source.TryAsCollectionLike() is { } collectionLike
+                     ? IterateCollection(collectionLike)
                      : IterateSequence();
 
             IEnumerable<TResult> IterateList(IListLike<T> list)
@@ -72,9 +72,10 @@ namespace MoreLinq
                     yield return resultSelector(list[i], listCount - i <= count ? --countdown : null);
             }
 
-            IEnumerable<TResult> IterateCollection(int i)
+            IEnumerable<TResult> IterateCollection(CollectionLike<T> collection)
             {
-                foreach (var item in source)
+                var i = collection.Count;
+                foreach (var item in collection)
                     yield return resultSelector(item, i-- <= count ? i : null);
             }
 

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -136,7 +136,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            var count = source.TryGetCollectionCount() ?? source.CountUpTo(limit);
+            var count = source.TryAsCollectionLike()?.Count ?? source.CountUpTo(limit);
 
             return count >= min && count <= max;
         }
@@ -167,11 +167,11 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is { } firstCount)
+            if (first.TryAsCollectionLike() is { Count: var firstCount })
             {
-                return firstCount.CompareTo(second.TryGetCollectionCount() ?? second.CountUpTo(firstCount + 1));
+                return firstCount.CompareTo(second.TryAsCollectionLike()?.Count ?? second.CountUpTo(firstCount + 1));
             }
-            else if (second.TryGetCollectionCount() is { } secondCount)
+            else if (second.TryAsCollectionLike() is { Count: var secondCount })
             {
                 return first.CountUpTo(secondCount + 1).CompareTo(secondCount);
             }

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -75,8 +75,8 @@ namespace MoreLinq
 
             List<T> secondList;
 #pragma warning disable IDE0075 // Simplify conditional expression (makes it worse)
-            return second.TryGetCollectionCount() is { } secondCount
-                   ? first.TryGetCollectionCount() is { } firstCount && secondCount > firstCount
+            return second.TryAsCollectionLike() is { Count: var secondCount }
+                   ? first.TryAsCollectionLike() is { Count: var firstCount } && secondCount > firstCount
                      ? false
                      : Impl(second, secondCount)
                    : Impl(secondList = second.ToList(), secondList.Count);

--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -101,11 +101,11 @@ namespace MoreLinq.Experimental
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            switch (source.TryGetCollectionCount())
+            switch (source.TryAsCollectionLike())
             {
-                case 0:
+                case { Count: 0 }:
                     return resultSelector(zero, default);
-                case 1:
+                case { Count: 1 }:
                 {
                     var item = source switch
                     {

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -161,14 +161,11 @@ namespace MoreLinq
             int? count, T? fallback1, T? fallback2, T? fallback3, T? fallback4,
             IEnumerable<T>? fallback)
         {
-            return source.TryGetCollectionCount() is { } collectionCount
-                 ? collectionCount == 0 ? Fallback() : source
-                 : _();
-
-            IEnumerable<T> _()
+            return _(); IEnumerable<T> _()
             {
-                using (var e = source.GetEnumerator())
+                if (source.TryAsCollectionLike() is null or { Count: > 0 })
                 {
+                    using var e = source.GetEnumerator();
                     if (e.MoveNext())
                     {
                         do { yield return e.Current; }
@@ -177,15 +174,14 @@ namespace MoreLinq
                     }
                 }
 
-                foreach (var item in Fallback())
-                    yield return item;
-            }
+                if (fallback is { } someFallback)
+                {
+                    Debug.Assert(count is null);
 
-            IEnumerable<T> Fallback()
-            {
-                return fallback ?? FallbackOnArgs();
-
-                IEnumerable<T> FallbackOnArgs()
+                    foreach (var item in someFallback)
+                        yield return item;
+                }
+                else
                 {
                     Debug.Assert(count is >= 1 and <= 4);
 

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -27,12 +27,12 @@ namespace MoreLinq
 
     public static partial class MoreEnumerable
     {
-        internal static int? TryGetCollectionCount<T>(this IEnumerable<T> source) =>
+        internal static CollectionLike<T>? TryAsCollectionLike<T>(this IEnumerable<T> source) =>
             source switch
             {
                 null => throw new ArgumentNullException(nameof(source)),
-                ICollection<T> collection => collection.Count,
-                IReadOnlyCollection<T> collection => collection.Count,
+                ICollection<T> collection => new CollectionLike<T>(collection),
+                IReadOnlyCollection<T> collection => new CollectionLike<T>(collection),
                 _ => null
             };
 

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -38,7 +38,6 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
 
             return count < 1 ? source
-                 : source.TryGetCollectionCount() is { } collectionCount ? source.Take(collectionCount - count)
                  : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
                          .TakeWhile(e => e.Countdown == null)
                          .Select(e => e.Element);

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -73,8 +73,8 @@ namespace MoreLinq
             if (first == null) throw new ArgumentNullException(nameof(first));
             if (second == null) throw new ArgumentNullException(nameof(second));
 
-            if (first.TryGetCollectionCount() is { } firstCount &&
-                second.TryGetCollectionCount() is { } secondCount &&
+            if (first.TryAsCollectionLike() is { Count: var firstCount } &&
+                second.TryAsCollectionLike() is { Count: var secondCount } &&
                 secondCount > firstCount)
             {
                 return false;

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -51,11 +51,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
 
             return count < 1 ? Enumerable.Empty<TSource>()
-                 : source.TryGetCollectionCount() is { } collectionCount
-                   ? source.Slice(Math.Max(0, collectionCount - count), int.MaxValue)
-                   : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
-                           .SkipWhile(e => e.Countdown == null)
-                           .Select(e => e.Element);
+                 : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
+                         .SkipWhile(e => e.Countdown == null)
+                         .Select(e => e.Element);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #943.

It fixes the optimised path in the following operators for when the source is a collection:

- `AssertCount`
- `CountDown`
- `FallbackIfEmpty`
- `PadStart`
- `SkipLast`
- `TakeLast`

All of the above operators have deferred execution semantics, but they were binding to the source collection count when invoked and not when the resulting sequence was iterated. Consequently, if the source collection was updated before iteration, the (cached) count and the resulting sequence would be incorrect.

Tests have been added to avoid regressions in the future.

Some tests were removed because the optimisations they were exercising couldn't be maintained anymore. For example, if `AssertCount` could determine that the source was a collection and had the right count, then it would return the source reference as-is. Now, the count is asserted when iteration start.