### PR TITLE
Improve Error Checking Code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,3 +86,7 @@ dotnet_diagnostic.IDE0055.severity = suggestion
 
 # IDE0046: Convert to conditional expression
 dotnet_diagnostic.IDE0046.severity = suggestion
+
+# Inform the CA1062 analyzer that Guard.IsNotNull will do null-check for us
+# CA1062: Validate arguments of public methods
+dotnet_code_quality.CA1062.null_check_validation_methods = IsNotNull

--- a/MoreLinq.Test/Extensions.cs
+++ b/MoreLinq.Test/Extensions.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Diagnostics;
     using System.Globalization;
@@ -39,7 +40,7 @@ namespace MoreLinq.Test
         [DebuggerStepThrough]
         public static string ToInvariantString<T>(this T formattable, string? format) where T : IFormattable
         {
-            if (formattable is null) throw new ArgumentNullException(nameof(formattable));
+            Guard.IsNotNull(formattable);
             return formattable.ToString(format, CultureInfo.InvariantCulture);
         }
     }

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -29,7 +29,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartWithNegativeWidth()
         {
-            Assert.That(() => new int[0].PadStart(-1), Throws.ArgumentException("width"));
+            Assert.That(() => new int[0].PadStart(-1), Throws.ArgumentOutOfRangeException("width"));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartWithPaddingWithNegativeWidth()
         {
-            Assert.That(() => new int[0].PadStart(-1, 1), Throws.ArgumentException("width"));
+            Assert.That(() => new int[0].PadStart(-1, 1), Throws.ArgumentOutOfRangeException("width"));
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadStartWithSelectorWithNegativeWidth()
         {
-            Assert.That(() => new int[0].PadStart(-1, x => x), Throws.ArgumentException("width"));
+            Assert.That(() => new int[0].PadStart(-1, x => x), Throws.ArgumentOutOfRangeException("width"));
         }
 
         [Test]

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void PadNegativeWidth()
         {
-            Assert.That(() => new object[0].Pad(-1), Throws.ArgumentException("width"));
+            Assert.That(() => new object[0].Pad(-1), Throws.ArgumentOutOfRangeException("width"));
         }
 
         [Test]

--- a/MoreLinq.Test/SequenceReader.cs
+++ b/MoreLinq.Test/SequenceReader.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -24,7 +25,7 @@ namespace MoreLinq.Test
     {
         public static SequenceReader<T> Read<T>(this IEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return new SequenceReader<T>(source);
         }
     }
@@ -59,7 +60,7 @@ namespace MoreLinq.Test
 
         static IEnumerator<T> GetEnumerator(IEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.GetEnumerator();
         }
 

--- a/MoreLinq/Acquire.cs
+++ b/MoreLinq/Acquire.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Acquire.cs
+++ b/MoreLinq/Acquire.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -41,7 +42,7 @@ namespace MoreLinq
         public static TSource[] Acquire<TSource>(this IEnumerable<TSource> source)
             where TSource : IDisposable
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             var disposables = new List<TSource>();
             try

--- a/MoreLinq/Aggregate.g.cs
+++ b/MoreLinq/Aggregate.g.cs
@@ -27,6 +27,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -59,10 +60,10 @@ namespace MoreLinq
             TAccumulate2 seed2, Func<TAccumulate2, T, TAccumulate2> accumulator2,
             Func<TAccumulate1, TAccumulate2, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -80,6 +81,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -126,10 +128,10 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult2>> accumulator2,
             Func<TResult1, TResult2, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -156,6 +158,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -192,11 +195,11 @@ namespace MoreLinq
             TAccumulate3 seed3, Func<TAccumulate3, T, TAccumulate3> accumulator3,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -216,6 +219,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -265,11 +269,11 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult3>> accumulator3,
             Func<TResult1, TResult2, TResult3, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -299,6 +303,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -339,12 +344,12 @@ namespace MoreLinq
             TAccumulate4 seed4, Func<TAccumulate4, T, TAccumulate4> accumulator4,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -366,6 +371,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -418,12 +424,12 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult4>> accumulator4,
             Func<TResult1, TResult2, TResult3, TResult4, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -456,6 +462,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -500,13 +507,13 @@ namespace MoreLinq
             TAccumulate5 seed5, Func<TAccumulate5, T, TAccumulate5> accumulator5,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -530,6 +537,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -585,13 +593,13 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult5>> accumulator5,
             Func<TResult1, TResult2, TResult3, TResult4, TResult5, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -627,6 +635,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -675,14 +684,14 @@ namespace MoreLinq
             TAccumulate6 seed6, Func<TAccumulate6, T, TAccumulate6> accumulator6,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -708,6 +717,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -766,14 +776,14 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult6>> accumulator6,
             Func<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -812,6 +822,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -864,15 +875,15 @@ namespace MoreLinq
             TAccumulate7 seed7, Func<TAccumulate7, T, TAccumulate7> accumulator7,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (accumulator7 == null) throw new ArgumentNullException(nameof(accumulator7));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(accumulator7);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -900,6 +911,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -961,15 +973,15 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult7>> accumulator7,
             Func<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (accumulator7 == null) throw new ArgumentNullException(nameof(accumulator7));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(accumulator7);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];
@@ -1011,6 +1023,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -1067,16 +1080,16 @@ namespace MoreLinq
             TAccumulate8 seed8, Func<TAccumulate8, T, TAccumulate8> accumulator8,
             Func<TAccumulate1, TAccumulate2, TAccumulate3, TAccumulate4, TAccumulate5, TAccumulate6, TAccumulate7, TAccumulate8, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (accumulator7 == null) throw new ArgumentNullException(nameof(accumulator7));
-            if (accumulator8 == null) throw new ArgumentNullException(nameof(accumulator8));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(accumulator7);
+            Guard.IsNotNull(accumulator8);
+            Guard.IsNotNull(resultSelector);
 
             var a1 = seed1;
             var a2 = seed2;
@@ -1106,6 +1119,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -1170,16 +1184,16 @@ namespace MoreLinq.Experimental
             Func<IObservable<T>, IObservable<TResult8>> accumulator8,
             Func<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6, TResult7, TResult8, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (accumulator1 == null) throw new ArgumentNullException(nameof(accumulator1));
-            if (accumulator2 == null) throw new ArgumentNullException(nameof(accumulator2));
-            if (accumulator3 == null) throw new ArgumentNullException(nameof(accumulator3));
-            if (accumulator4 == null) throw new ArgumentNullException(nameof(accumulator4));
-            if (accumulator5 == null) throw new ArgumentNullException(nameof(accumulator5));
-            if (accumulator6 == null) throw new ArgumentNullException(nameof(accumulator6));
-            if (accumulator7 == null) throw new ArgumentNullException(nameof(accumulator7));
-            if (accumulator8 == null) throw new ArgumentNullException(nameof(accumulator8));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(accumulator1);
+            Guard.IsNotNull(accumulator2);
+            Guard.IsNotNull(accumulator3);
+            Guard.IsNotNull(accumulator4);
+            Guard.IsNotNull(accumulator5);
+            Guard.IsNotNull(accumulator6);
+            Guard.IsNotNull(accumulator7);
+            Guard.IsNotNull(accumulator8);
+            Guard.IsNotNull(resultSelector);
 
             var r1 = new (bool, TResult1)[1];
             var r2 = new (bool, TResult2)[1];

--- a/MoreLinq/Aggregate.g.cs
+++ b/MoreLinq/Aggregate.g.cs
@@ -27,7 +27,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -158,7 +158,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -303,7 +303,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -462,7 +462,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -635,7 +635,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -822,7 +822,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -1023,7 +1023,7 @@ namespace MoreLinq.Experimental
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Aggregate.g.tt
+++ b/MoreLinq/Aggregate.g.tt
@@ -70,6 +70,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -104,11 +105,11 @@ namespace MoreLinq
 <#      } #>
             Func<<#= string.Join(", ", from x in o.Arguments select "TAccumulate" + x.Number) #>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 <#      foreach (var arg in o.Arguments) { #>
-            if (accumulator<#= arg.Number #> == null) throw new ArgumentNullException(nameof(accumulator<#= arg.Number #>));
+            Guard.IsNotNull(accumulator<#= arg.Number #>);
 <#      } #>
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
 <#      foreach (var arg in o.Arguments) { #>
             var a<#= arg.Number #> = seed<#= arg.Number #>;
@@ -128,6 +129,7 @@ namespace MoreLinq
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Reactive;
@@ -177,11 +179,11 @@ namespace MoreLinq.Experimental
 <#      } #>
             Func<<#= string.Join(", ", from x in o.Arguments select "TResult" + x.Number) #>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 <#      foreach (var arg in o.Arguments) { #>
-            if (accumulator<#= arg.Number #> == null) throw new ArgumentNullException(nameof(accumulator<#= arg.Number #>));
+            Guard.IsNotNull(accumulator<#= arg.Number #>);
 <#      } #>
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
 <#      foreach (var arg in o.Arguments) { #>
             var r<#= arg.Number #> = new (bool, TResult<#= arg.Number #>)[1];

--- a/MoreLinq/Aggregate.g.tt
+++ b/MoreLinq/Aggregate.g.tt
@@ -70,7 +70,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -44,8 +45,8 @@ namespace MoreLinq
 
         public static TSource AggregateRight<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (func == null) throw new ArgumentNullException(nameof(func));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(func);
 
             return source.ToListLike() switch
             {
@@ -79,8 +80,8 @@ namespace MoreLinq
 
         public static TAccumulate AggregateRight<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (func == null) throw new ArgumentNullException(nameof(func));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(func);
 
             var list = source.ToListLike();
 
@@ -115,9 +116,9 @@ namespace MoreLinq
 
         public static TResult AggregateRight<TSource, TAccumulate, TResult>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (func == null) throw new ArgumentNullException(nameof(func));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(func);
+            Guard.IsNotNull(resultSelector);
 
             return resultSelector(source.AggregateRight(seed, func));
         }

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -50,7 +50,7 @@ namespace MoreLinq
 
             return source.ToListLike() switch
             {
-                { Count: 0 } => throw new InvalidOperationException("Sequence contains no elements."),
+                { Count: 0 } => ThrowHelper.ThrowInvalidOperationException<TSource>("Sequence contains no elements."),
                 var list => AggregateRightImpl(list, list[^1], func, list.Count - 1)
             };
         }

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using CommunityToolkit.Diagnostics;
+	using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable
@@ -37,7 +37,7 @@ namespace MoreLinq
         public static IEnumerable<T> Append<T>(this IEnumerable<T> head, T tail)
 #endif
         {
-            if (head == null) throw new ArgumentNullException(nameof(head));
+            Guard.IsNotNull(head);
             return head is PendNode<T> node
                 ? node.Concat(tail)
                 : PendNode<T>.WithSource(head).Concat(tail);

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -62,8 +63,8 @@ namespace MoreLinq
         public static IEnumerable<TSource> Assert<TSource>(this IEnumerable<TSource> source,
             Func<TSource, bool> predicate, Func<TSource, Exception>? errorSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -68,7 +68,7 @@ namespace MoreLinq
             int count, Func<int, int, Exception> errorSelector)
         {
             Guard.IsNotNull(source);
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+            Guard.IsGreaterThanOrEqualTo(count, 0);
             Guard.IsNotNull(errorSelector);
 
             return _(); IEnumerable<TSource> _()

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -66,9 +67,9 @@ namespace MoreLinq
         public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source,
             int count, Func<int, int, Exception> errorSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
-            if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
+            Guard.IsNotNull(errorSelector);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -61,10 +61,10 @@ namespace MoreLinq
         {
             Guard.IsNotNull(first);
             Guard.IsNotNull(second);
+            Guard.IsGreaterThanOrEqualTo(index, 0);
 
             return index switch
             {
-                < 0 => throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative."),
                 0 => first.Concat(second),
                 _ => _()
             };
@@ -77,7 +77,10 @@ namespace MoreLinq
                 {
                     var (_, countdown) = e.Current;
                     if (countdown is { } n && n != index - 1)
-                        throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException(
+                            nameof(index), "Insertion index is greater than the length of the first sequence.");
+                    }
 
                     do
                     {

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Linq;
     using System.Collections.Generic;

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Linq;
     using System.Collections.Generic;
@@ -58,8 +59,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> Backsert<T>(this IEnumerable<T> first, IEnumerable<T> second, int index)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
 
             return index switch
             {

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -84,7 +84,7 @@ namespace MoreLinq
             Func<TSource[], TResult> resultSelector)
         {
             Guard.IsNotNull(source);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
             Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -82,9 +83,9 @@ namespace MoreLinq
         public static IEnumerable<TResult> Batch<TSource, TResult>(this IEnumerable<TSource> source, int size,
             Func<TSource[], TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Cartesian.g.cs
+++ b/MoreLinq/Cartesian.g.cs
@@ -27,6 +27,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;
@@ -65,9 +66,9 @@ namespace MoreLinq
             IEnumerable<T2> second,
             Func<T1, T2, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -118,10 +119,10 @@ namespace MoreLinq
             IEnumerable<T3> third,
             Func<T1, T2, T3, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -179,11 +180,11 @@ namespace MoreLinq
             IEnumerable<T4> fourth,
             Func<T1, T2, T3, T4, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -248,12 +249,12 @@ namespace MoreLinq
             IEnumerable<T5> fifth,
             Func<T1, T2, T3, T4, T5, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (fifth == null) throw new ArgumentNullException(nameof(fifth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(fifth);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -325,13 +326,13 @@ namespace MoreLinq
             IEnumerable<T6> sixth,
             Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (fifth == null) throw new ArgumentNullException(nameof(fifth));
-            if (sixth == null) throw new ArgumentNullException(nameof(sixth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(fifth);
+            Guard.IsNotNull(sixth);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -410,14 +411,14 @@ namespace MoreLinq
             IEnumerable<T7> seventh,
             Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (fifth == null) throw new ArgumentNullException(nameof(fifth));
-            if (sixth == null) throw new ArgumentNullException(nameof(sixth));
-            if (seventh == null) throw new ArgumentNullException(nameof(seventh));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(fifth);
+            Guard.IsNotNull(sixth);
+            Guard.IsNotNull(seventh);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -503,15 +504,15 @@ namespace MoreLinq
             IEnumerable<T8> eighth,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (fifth == null) throw new ArgumentNullException(nameof(fifth));
-            if (sixth == null) throw new ArgumentNullException(nameof(sixth));
-            if (seventh == null) throw new ArgumentNullException(nameof(seventh));
-            if (eighth == null) throw new ArgumentNullException(nameof(eighth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(fifth);
+            Guard.IsNotNull(sixth);
+            Guard.IsNotNull(seventh);
+            Guard.IsNotNull(eighth);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Cartesian.g.cs
+++ b/MoreLinq/Cartesian.g.cs
@@ -27,7 +27,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -32,6 +32,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;
@@ -111,9 +112,9 @@ IEnumerable<T<#= arg.Number #>> <#= arg.Ordinal #>,
 Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TResult> resultSelector)
         {
 <#      foreach (var arg in o.Arguments) { #>
-            if (<#= arg.Ordinal #> == null) throw new ArgumentNullException(nameof(<#= arg.Ordinal #>));
+            Guard.IsNotNull(<#= arg.Ordinal #>);
 <#      } #>
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -32,7 +32,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;

--- a/MoreLinq/Choose.cs
+++ b/MoreLinq/Choose.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -52,8 +53,8 @@ namespace MoreLinq
         public static IEnumerable<TResult> Choose<T, TResult>(this IEnumerable<T> source,
             Func<T, (bool, TResult)> chooser)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (chooser == null) throw new ArgumentNullException(nameof(chooser));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(chooser);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Choose.cs
+++ b/MoreLinq/Choose.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -34,14 +35,16 @@ namespace MoreLinq
 
         public CollectionLike(ICollection<T> collection)
         {
-            _rw = collection ?? throw new ArgumentNullException(nameof(collection));
+            Guard.IsNotNull(collection);
+            _rw = collection;
             _ro = null;
         }
 
         public CollectionLike(IReadOnlyCollection<T> collection)
         {
+            Guard.IsNotNull(collection);
             _rw = null;
-            _ro = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ro = collection;
         }
 
         public int Count => _rw?.Count ?? _ro?.Count ?? 0;
@@ -55,7 +58,7 @@ namespace MoreLinq
         public static CollectionLike<T>? TryAsCollectionLike<T>(this IEnumerable<T> source) =>
             source switch
             {
-                null => throw new ArgumentNullException(nameof(source)),
+                null => ThrowHelper.ThrowArgumentNullException<CollectionLike<T>?>(nameof(source)),
                 ICollection<T> collection => new(collection),
                 IReadOnlyCollection<T> collection => new(collection),
                 _ => null

--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq
 {
     using CommunityToolkit.Diagnostics;
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/MoreLinq/Consume.cs
+++ b/MoreLinq/Consume.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable
@@ -31,7 +31,7 @@ namespace MoreLinq
 
         public static void Consume<T>(this IEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             foreach (var _ in source)
             {
             }

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -52,8 +53,8 @@ namespace MoreLinq
 
         public static IEnumerable<KeyValuePair<TKey, int>> CountBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
 
             return _(); IEnumerable<KeyValuePair<TKey, int>> _()
             {

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -54,8 +55,8 @@ namespace MoreLinq
         public static IEnumerable<TResult> CountDown<T, TResult>(this IEnumerable<T> source,
             int count, Func<T, int?, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             return source.TryAsListLike() is { } listLike
                    ? IterateList(listLike)

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -134,7 +135,7 @@ namespace MoreLinq
 
         static bool QuantityIterator<T>(IEnumerable<T> source, int limit, int min, int max)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             var count = source.TryAsCollectionLike()?.Count ?? source.CountUpTo(limit);
 
@@ -164,8 +165,8 @@ namespace MoreLinq
 
         public static int CompareCount<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
 
             if (first.TryAsCollectionLike() is { Count: var firstCount })
             {

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -17,10 +17,9 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
-    using System.Drawing;
 
     static partial class MoreEnumerable
     {

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -20,6 +20,7 @@ namespace MoreLinq
 	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
+    using System.Drawing;
 
     static partial class MoreEnumerable
     {
@@ -45,7 +46,7 @@ namespace MoreLinq
 
         public static bool AtLeast<T>(this IEnumerable<T> source, int count)
         {
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(count, 0);
 
             return QuantityIterator(source, count, count, int.MaxValue);
         }
@@ -72,7 +73,7 @@ namespace MoreLinq
 
         public static bool AtMost<T>(this IEnumerable<T> source, int count)
         {
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(count, 0);
 
             return QuantityIterator(source, count + 1, 0, count);
         }
@@ -98,7 +99,7 @@ namespace MoreLinq
 
         public static bool Exactly<T>(this IEnumerable<T> source, int count)
         {
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(count, 0);
 
             return QuantityIterator(source, count + 1, count, count);
         }
@@ -127,8 +128,8 @@ namespace MoreLinq
 
         public static bool CountBetween<T>(this IEnumerable<T> source, int min, int max)
         {
-            if (min < 0) throw new ArgumentOutOfRangeException(nameof(min), "Minimum count cannot be negative.");
-            if (max < min) throw new ArgumentOutOfRangeException(nameof(max), "Maximum count must be greater than or equal to the minimum count.");
+            Guard.IsGreaterThanOrEqualTo(min, 0);
+            Guard.IsGreaterThanOrEqualTo(max, min);
 
             return QuantityIterator(source, max + 1, min, max);
         }

--- a/MoreLinq/Delegating.cs
+++ b/MoreLinq/Delegating.cs
@@ -26,6 +26,7 @@
 
 namespace Delegating
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Threading;
 
@@ -44,8 +45,11 @@ namespace Delegating
     {
         Action? _delegatee;
 
-        public DelegatingDisposable(Action delegatee) =>
-            _delegatee = delegatee ?? throw new ArgumentNullException(nameof(delegatee));
+        public DelegatingDisposable(Action delegatee)
+        {
+            Guard.IsNotNull(delegatee);
+            _delegatee = delegatee;
+        }
 
         public void Dispose()
         {
@@ -66,7 +70,8 @@ namespace Delegating
                                   Action<Exception>? onError = null,
                                   Action? onCompleted = null)
         {
-            _onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
+            Guard.IsNotNull(onNext);
+            _onNext = onNext;
             _onError = onError;
             _onCompleted = onCompleted;
         }

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -75,8 +76,8 @@ namespace MoreLinq
             Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
 #endif
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -68,8 +68,8 @@ namespace MoreLinq
 
         public static bool EndsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
 
             comparer ??= EqualityComparer<T>.Default;
 

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -64,9 +65,9 @@ namespace MoreLinq
             IEnumerable<TSecond> second,
             Func<TFirst, TSecond, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(resultSelector);
 
             return EquiZipImpl<TFirst, TSecond, object, object, TResult>(first, second, null, null, (a, b, _, _) => resultSelector(a, b));
         }
@@ -116,10 +117,10 @@ namespace MoreLinq
             IEnumerable<T2> second, IEnumerable<T3> third,
             Func<T1, T2, T3, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(resultSelector);
 
             return EquiZipImpl<T1, T2, T3, object, TResult>(first, second, third, null, (a, b, c, _) => resultSelector(a, b, c));
         }
@@ -172,11 +173,11 @@ namespace MoreLinq
             IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth,
             Func<T1, T2, T3, T4, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(resultSelector);
 
             return EquiZipImpl(first, second, third, fourth, resultSelector);
         }

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Evaluate.cs
+++ b/MoreLinq/Evaluate.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -36,8 +37,11 @@ namespace MoreLinq
         /// <returns>A sequence with results from invoking <paramref name="functions"/>.</returns>
         /// <exception cref="ArgumentNullException">When <paramref name="functions"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions) =>
-            from f in functions ?? throw new ArgumentNullException(nameof(functions))
-            select f();
+        public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)
+        {
+            Guard.IsNotNull(functions);
+            return from f in functions
+                   select f();
+        }
     }
 }

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -75,9 +76,9 @@ namespace MoreLinq
             Func<TSource, TKey> keySelector,
             IEqualityComparer<TKey>? keyComparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(keySelector);
 
             return Impl();
 

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -34,7 +35,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> Exclude<T>(this IEnumerable<T> sequence, int startIndex, int count)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
             if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
 
             return count switch

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     public static partial class MoreEnumerable

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -36,11 +36,11 @@ namespace MoreLinq
         public static IEnumerable<T> Exclude<T>(this IEnumerable<T> sequence, int startIndex, int count)
         {
             Guard.IsNotNull(sequence);
-            if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
+            Guard.IsGreaterThanOrEqualTo(startIndex, 0);
+            Guard.IsGreaterThanOrEqualTo(count, 0);
 
             return count switch
             {
-                < 0 => throw new ArgumentOutOfRangeException(nameof(count)),
                 0 => sequence,
                 _ => _()
             };

--- a/MoreLinq/Experimental/Aggregate.cs
+++ b/MoreLinq/Experimental/Aggregate.cs
@@ -18,6 +18,7 @@
 namespace MoreLinq.Experimental
 {
     using System;
+    using CommunityToolkit.Diagnostics;
     using Reactive;
 
     static partial class ExperimentalEnumerable
@@ -26,17 +27,17 @@ namespace MoreLinq.Experimental
         {
             var aggregator = aggregatorSelector(subject);
             return ReferenceEquals(aggregator, subject)
-                 ? throw new ArgumentException("Aggregator cannot be identical to the source.", paramName)
+                 ? ThrowHelper.ThrowArgumentException<IDisposable>(paramName, "Aggregator cannot be identical to the source.")
                  : aggregator.Subscribe(s =>
                      r[0] = r[0].Defined
-                         ? throw new InvalidOperationException(
+                         ? ThrowHelper.ThrowInvalidOperationException<(bool, TResult)>(
                              $"Aggregator supplied for parameter \"{paramName}\" produced multiple results when only one is allowed.")
                          : (true, s));
         }
 
         static T GetAggregateResult<T>((bool Defined, T Value) result, string paramName) =>
             !result.Defined
-            ? throw new InvalidOperationException($"Aggregator supplied for parameter \"{paramName}\" has an undefined result.")
+            ? ThrowHelper.ThrowInvalidOperationException<T>($"Aggregator supplied for parameter \"{paramName}\" has an undefined result.")
             : result.Value;
     }
 }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Concurrent;
@@ -64,12 +65,14 @@ namespace MoreLinq.Experimental
 
         AwaitQueryOptions(int? maxConcurrency, TaskScheduler scheduler, bool preserveOrder)
         {
-            MaxConcurrency = maxConcurrency is null or > 0
+            Guard.IsNotNull(maxConcurrency);
+            Guard.IsNotNull(scheduler);
+            MaxConcurrency = maxConcurrency is > 0
                            ? maxConcurrency
                            : throw new ArgumentOutOfRangeException(
                                  nameof(maxConcurrency), maxConcurrency,
                                  "Maximum concurrency must be 1 or greater.");
-            Scheduler      = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+            Scheduler      = scheduler;
             PreserveOrder  = preserveOrder;
         }
 
@@ -146,7 +149,7 @@ namespace MoreLinq.Experimental
 
         public static IEnumerable<T> AsSequential<T>(this IAwaitQuery<T> source)
         {
-            if (source is null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return MaxConcurrency(source, 1);
         }
 
@@ -163,7 +166,7 @@ namespace MoreLinq.Experimental
 
         public static IAwaitQuery<T> MaxConcurrency<T>(this IAwaitQuery<T> source, int value)
         {
-            if (source is null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.WithOptions(source.Options.WithMaxConcurrency(value));
         }
 
@@ -179,7 +182,7 @@ namespace MoreLinq.Experimental
 
         public static IAwaitQuery<T> UnboundedConcurrency<T>(this IAwaitQuery<T> source)
         {
-            if (source is null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.WithOptions(source.Options.WithMaxConcurrency(null));
         }
 
@@ -196,8 +199,8 @@ namespace MoreLinq.Experimental
 
         public static IAwaitQuery<T> Scheduler<T>(this IAwaitQuery<T> source, TaskScheduler value)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (value == null) throw new ArgumentNullException(nameof(value));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(value);
             return source.WithOptions(source.Options.WithScheduler(value));
         }
 
@@ -249,7 +252,7 @@ namespace MoreLinq.Experimental
 
         public static IAwaitQuery<T> PreserveOrder<T>(this IAwaitQuery<T> source, bool value)
         {
-            if (source is null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.WithOptions(source.Options.WithPreserveOrder(value));
         }
 
@@ -419,8 +422,8 @@ namespace MoreLinq.Experimental
             Func<T, CancellationToken, Task<TTaskResult>> evaluator,
             Func<T, Task<TTaskResult>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (evaluator == null) throw new ArgumentNullException(nameof(evaluator));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(evaluator);
 
             return
                 AwaitQuery.Create(
@@ -634,10 +637,10 @@ namespace MoreLinq.Experimental
             int? maxConcurrency,
             CancellationToken cancellationToken)
         {
-            if (enumerator == null) throw new ArgumentNullException(nameof(enumerator));
-            if (starter == null) throw new ArgumentNullException(nameof(starter));
-            if (onTaskCompletion == null) throw new ArgumentNullException(nameof(onTaskCompletion));
-            if (onEnd == null) throw new ArgumentNullException(nameof(onEnd));
+            Guard.IsNotNull(enumerator);
+            Guard.IsNotNull(starter);
+            Guard.IsNotNull(onTaskCompletion);
+            Guard.IsNotNull(onEnd);
             if (maxConcurrency < 1) throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
 
             using (enumerator)
@@ -718,7 +721,7 @@ namespace MoreLinq.Experimental
 
             public IAwaitQuery<T> WithOptions(AwaitQueryOptions options)
             {
-                if (options == null) throw new ArgumentNullException(nameof(options));
+                Guard.IsNotNull(options);
                 return Options == options ? this : new AwaitQuery<T>(_impl, options);
             }
 

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -67,11 +67,9 @@ namespace MoreLinq.Experimental
         {
             Guard.IsNotNull(maxConcurrency);
             Guard.IsNotNull(scheduler);
-            MaxConcurrency = maxConcurrency is > 0
-                           ? maxConcurrency
-                           : throw new ArgumentOutOfRangeException(
-                                 nameof(maxConcurrency), maxConcurrency,
-                                 "Maximum concurrency must be 1 or greater.");
+            Guard.IsGreaterThan(maxConcurrency.Value, 0);
+
+            MaxConcurrency = maxConcurrency;
             Scheduler      = scheduler;
             PreserveOrder  = preserveOrder;
         }
@@ -641,7 +639,8 @@ namespace MoreLinq.Experimental
             Guard.IsNotNull(starter);
             Guard.IsNotNull(onTaskCompletion);
             Guard.IsNotNull(onEnd);
-            if (maxConcurrency < 1) throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+            Guard.IsNotNull(maxConcurrency);
+            Guard.IsGreaterThanOrEqualTo(maxConcurrency.Value, 0);
 
             using (enumerator)
             {

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -275,7 +275,7 @@ namespace MoreLinq.Experimental
                     return _array[index];
                 }
 
-                set => throw new NotSupportedException();
+                set => ThrowHelper.ThrowNotSupportedException();
             }
 
             public void Dispose()

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -77,7 +77,7 @@ namespace MoreLinq.Experimental
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(pool);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
             Guard.IsNotNull(resultSelector);
 
             return source.Batch(size, pool, current => current,
@@ -142,7 +142,7 @@ namespace MoreLinq.Experimental
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(pool);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
             Guard.IsNotNull(bucketProjectionSelector);
             Guard.IsNotNull(resultSelector);
 
@@ -160,7 +160,7 @@ namespace MoreLinq.Experimental
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(pool);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
 
             ICurrentBufferProvider<T> Cursor(IEnumerator<(T[], int)> source) =>
                 new CurrentPoolArrayProvider<T>(source, pool);
@@ -269,7 +269,12 @@ namespace MoreLinq.Experimental
 
             public override T this[int index]
             {
-                get => index >= 0 && index < Count ? _array[index] : throw new ArgumentOutOfRangeException(nameof(index));
+                get
+                {
+                    Guard.IsBetween(index, -1, Count);
+                    return _array[index];
+                }
+
                 set => throw new NotSupportedException();
             }
 

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -19,6 +19,7 @@
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Buffers;
     using System.Collections.Generic;
@@ -74,10 +75,10 @@ namespace MoreLinq.Experimental
                                     ArrayPool<TSource> pool,
                                     Func<ICurrentBuffer<TSource>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (pool == null) throw new ArgumentNullException(nameof(pool));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(pool);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return source.Batch(size, pool, current => current,
                                 current => resultSelector((ICurrentBuffer<TSource>)current));
@@ -139,11 +140,11 @@ namespace MoreLinq.Experimental
                 Func<ICurrentBuffer<TSource>, IEnumerable<TBucket>> bucketProjectionSelector,
                 Func<IEnumerable<TBucket>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (pool == null) throw new ArgumentNullException(nameof(pool));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(pool);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
-            if (bucketProjectionSelector == null) throw new ArgumentNullException(nameof(bucketProjectionSelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(bucketProjectionSelector);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {
@@ -157,8 +158,8 @@ namespace MoreLinq.Experimental
         static ICurrentBufferProvider<T>
             Batch<T>(this IEnumerable<T> source, int size, ArrayPool<T> pool)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (pool == null) throw new ArgumentNullException(nameof(pool));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(pool);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
             ICurrentBufferProvider<T> Cursor(IEnumerator<(T[], int)> source) =>

--- a/MoreLinq/Experimental/CurrentBuffer.cs
+++ b/MoreLinq/Experimental/CurrentBuffer.cs
@@ -19,6 +19,7 @@
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -86,8 +87,8 @@ namespace MoreLinq.Experimental
 
         public virtual void CopyTo(T[] array, int arrayIndex)
         {
-            if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, null);
-            if (arrayIndex + Count > array.Length) throw new ArgumentException(null, nameof(arrayIndex));
+            Guard.IsGreaterThanOrEqualTo(arrayIndex, 0);
+            Guard.IsLessThanOrEqualTo(arrayIndex, array.Length - Count);
 
             for (int i = 0, j = arrayIndex; i < Count; i++, j++)
                 array[j] = this[i];

--- a/MoreLinq/Experimental/CurrentBuffer.cs
+++ b/MoreLinq/Experimental/CurrentBuffer.cs
@@ -97,11 +97,11 @@ namespace MoreLinq.Experimental
         public virtual IEnumerator<T> GetEnumerator() => this.Take(Count).GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        void IList<T>.Insert(int index, T item) => throw new NotSupportedException();
-        void IList<T>.RemoveAt(int index) => throw new NotSupportedException();
-        void ICollection<T>.Add(T item) => throw new NotSupportedException();
-        void ICollection<T>.Clear() => throw new NotSupportedException();
-        bool ICollection<T>.Remove(T item) => throw new NotSupportedException();
+        void IList<T>.Insert(int index, T item) => ThrowHelper.ThrowNotSupportedException();
+        void IList<T>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
+        void ICollection<T>.Add(T item) => ThrowHelper.ThrowNotSupportedException();
+        void ICollection<T>.Clear() => ThrowHelper.ThrowNotSupportedException();
+        bool ICollection<T>.Remove(T item) => ThrowHelper.ThrowNotSupportedException<bool>();
     }
 }
 

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -114,7 +114,7 @@ namespace MoreLinq.Experimental
                     lock (_locker)
                     {
                         if (_cache == null) // Cache disposed during iteration?
-                            throw new ObjectDisposedException(nameof(MemoizedEnumerable<T>));
+                            ThrowHelper.ThrowObjectDisposedException(nameof(MemoizedEnumerable<T>));
 
                         if (index >= _cache.Count)
                         {

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -54,7 +55,7 @@ namespace MoreLinq.Experimental
         public static IEnumerable<T> Memoize<T>(this IEnumerable<T> source) =>
             source switch
             {
-                null => throw new ArgumentNullException(nameof(source)),
+                null => ThrowHelper.ThrowArgumentNullException<IEnumerable<T>>(nameof(source)),
                 ICollection<T> => source,
                 IReadOnlyCollection<T> => source,
                 MemoizedEnumerable<T> => source,
@@ -73,7 +74,8 @@ namespace MoreLinq.Experimental
 
         public MemoizedEnumerable(IEnumerable<T> sequence)
         {
-            _source = sequence ?? throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
+            _source = sequence;
             _locker = new object();
         }
 

--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Experimental
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -98,8 +99,8 @@ namespace MoreLinq.Experimental
             TCardinality zero, TCardinality one, TCardinality many,
             Func<TCardinality, T?, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             switch (source.TryAsCollectionLike())
             {

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1496,7 +1496,8 @@ namespace MoreLinq.Extensions
         /// <returns>A sequence with results from invoking <paramref name="functions"/>.</returns>
         /// <exception cref="ArgumentNullException">When <paramref name="functions"/> is <c>null</c>.</exception>
 
-        public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)             => MoreEnumerable.Evaluate(functions);
+        public static IEnumerable<T> Evaluate<T>(this IEnumerable<Func<T>> functions)
+            => MoreEnumerable.Evaluate(functions);
 
     }
 

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable
@@ -44,7 +44,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return FallbackIfEmptyImpl(source, 1, fallback, default, default, default, null);
         }
 
@@ -65,7 +65,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return FallbackIfEmptyImpl(source, 2, fallback1, fallback2, default, default, null);
         }
 
@@ -88,7 +88,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2, T fallback3)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return FallbackIfEmptyImpl(source, 3, fallback1, fallback2, fallback3, default, null);
         }
 
@@ -113,7 +113,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, T fallback1, T fallback2, T fallback3, T fallback4)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return FallbackIfEmptyImpl(source, 4, fallback1, fallback2, fallback3, fallback4, null);
         }
 
@@ -132,8 +132,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, params T[] fallback)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (fallback == null) throw new ArgumentNullException(nameof(fallback));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(fallback);
             return source.FallbackIfEmpty((IEnumerable<T>)fallback);
         }
 
@@ -152,8 +152,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> FallbackIfEmpty<T>(this IEnumerable<T> source, IEnumerable<T> fallback)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (fallback == null) throw new ArgumentNullException(nameof(fallback));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(fallback);
             return FallbackIfEmptyImpl(source, null, default, default, default, default, fallback);
         }
 

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -65,8 +66,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return FillBackwardImpl(source, predicate, null);
         }
@@ -98,9 +99,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> FillBackward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            if (fillSelector == null) throw new ArgumentNullException(nameof(fillSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
+            Guard.IsNotNull(fillSelector);
 
             return FillBackwardImpl(source, predicate, fillSelector);
         }

--- a/MoreLinq/FillForward.cs
+++ b/MoreLinq/FillForward.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -65,8 +66,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> FillForward<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return FillForwardImpl(source, predicate, null);
         }
@@ -97,9 +98,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> FillForward<T>(this IEnumerable<T> source, Func<T, bool> predicate, Func<T, T, T> fillSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            if (fillSelector == null) throw new ArgumentNullException(nameof(fillSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
+            Guard.IsNotNull(fillSelector);
 
             return FillForwardImpl(source, predicate, fillSelector);
         }

--- a/MoreLinq/FillForward.cs
+++ b/MoreLinq/FillForward.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -19,7 +19,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Linq;
     using System.Collections;

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -19,6 +19,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Linq;
     using System.Collections;
@@ -75,7 +76,7 @@ namespace MoreLinq
 /*...................................*/ >
             Flatten(this IEnumerable source, Func<IEnumerable, bool> predicate)
         {
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(predicate);
 
             return Flatten(source, obj => obj is IEnumerable inner && predicate(inner) ? inner : null);
         }
@@ -116,8 +117,8 @@ namespace MoreLinq
 #nullable restore
 /*....................*/ IEnumerable?> selector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (selector == null) throw new ArgumentNullException(nameof(selector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(selector);
 
             return _();
 

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -31,7 +31,7 @@ namespace MoreLinq
             {
                 elements[i] = i < count ? item : throw LengthError(1);
                 i++;
-            }
+        }
 
             if (i < count)
                 throw LengthError(-1);
@@ -39,6 +39,6 @@ namespace MoreLinq
             return elements;
 
             InvalidOperationException LengthError(int cmp) => new(FormatSequenceLengthErrorMessage(cmp, count));
-        }
     }
+}
 }

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -27,6 +27,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -27,7 +27,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -32,7 +32,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -32,6 +32,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ForEach.cs
+++ b/MoreLinq/ForEach.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -31,8 +32,8 @@ namespace MoreLinq
 
         public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (action == null) throw new ArgumentNullException(nameof(action));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(action);
 
             foreach (var element in source)
                 action(element);
@@ -49,8 +50,8 @@ namespace MoreLinq
 
         public static void ForEach<T>(this IEnumerable<T> source, Action<T, int> action)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (action == null) throw new ArgumentNullException(nameof(action));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(action);
 
             var index = 0;
             foreach (var element in source)

--- a/MoreLinq/ForEach.cs
+++ b/MoreLinq/ForEach.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -109,7 +110,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(params Func<T>[] functions)
         {
-            if (functions == null) throw new ArgumentNullException(nameof(functions));
+            Guard.IsNotNull(functions);
             return Evaluate(functions);
         }
     }

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -141,11 +142,11 @@ namespace MoreLinq
             Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (firstKeySelector == null) throw new ArgumentNullException(nameof(firstKeySelector));
-            if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(firstKeySelector);
+            Guard.IsNotNull(secondKeySelector);
+            Guard.IsNotNull(resultSelector);
 
             return _(comparer ?? EqualityComparer<TKey>.Default);
 

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -64,7 +65,7 @@ namespace MoreLinq
             Func<TSource, TResult> secondSelector,
             Func<TSource, TSource, TResult> bothSelector)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.FullJoin(second, keySelector,
                                   firstSelector, secondSelector, bothSelector,
                                   null);
@@ -115,7 +116,7 @@ namespace MoreLinq
             Func<TSource, TSource, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.FullJoin(second,
                                   keySelector, keySelector,
                                   firstSelector, secondSelector, bothSelector,
@@ -220,13 +221,13 @@ namespace MoreLinq
             Func<TFirst, TSecond, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (firstKeySelector == null) throw new ArgumentNullException(nameof(firstKeySelector));
-            if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
-            if (firstSelector == null) throw new ArgumentNullException(nameof(firstSelector));
-            if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
-            if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(firstKeySelector);
+            Guard.IsNotNull(secondKeySelector);
+            Guard.IsNotNull(firstSelector);
+            Guard.IsNotNull(secondSelector);
+            Guard.IsNotNull(bothSelector);
 
             return Impl();
 

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Generate.cs
+++ b/MoreLinq/Generate.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Generate.cs
+++ b/MoreLinq/Generate.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -43,7 +44,7 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Generate<TResult>(TResult initial, Func<TResult, TResult> generator)
         {
-            if (generator == null) throw new ArgumentNullException(nameof(generator));
+            Guard.IsNotNull(generator);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/GenerateByIndex.cs
+++ b/MoreLinq/GenerateByIndex.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -42,7 +43,7 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> GenerateByIndex<TResult>(Func<int, TResult> generator)
         {
-            if (generator == null) throw new ArgumentNullException(nameof(generator));
+            Guard.IsNotNull(generator);
 
             return MoreEnumerable.Sequence(0, int.MaxValue)
                                  .Select(generator);

--- a/MoreLinq/GenerateByIndex.cs
+++ b/MoreLinq/GenerateByIndex.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/GlobalRandom.cs
+++ b/MoreLinq/GlobalRandom.cs
@@ -21,6 +21,7 @@ namespace MoreLinq
 {
     using System;
 #if !NET6_0_OR_GREATER
+    using CommunityToolkit.Diagnostics;
     using System.Threading;
 #endif
 
@@ -70,7 +71,7 @@ namespace MoreLinq
                 // randomizing operator from the outer class then they will
                 // need to be overriden.
 
-                throw new NotImplementedException();
+                return ThrowHelper.ThrowNotSupportedException<double>();
             }
         }
 #endif // NET6_0_OR_GREATER

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -84,8 +85,8 @@ namespace MoreLinq
             Func<TSource, TKey> keySelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
 
             return GroupAdjacent(source, keySelector, IdFn, comparer);
         }
@@ -161,9 +162,9 @@ namespace MoreLinq
             Func<TSource, TElement> elementSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            if (elementSelector == null) throw new ArgumentNullException(nameof(elementSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
+            Guard.IsNotNull(elementSelector);
 
             return GroupAdjacentImpl(source, keySelector, elementSelector, CreateGroupAdjacentGrouping,
                                      comparer ?? EqualityComparer<TKey>.Default);
@@ -201,9 +202,9 @@ namespace MoreLinq
             Func<TSource, TKey> keySelector,
             Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
+            Guard.IsNotNull(resultSelector);
 
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);
@@ -247,9 +248,9 @@ namespace MoreLinq
             Func<TKey, IEnumerable<TSource>, TResult> resultSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
+            Guard.IsNotNull(resultSelector);
 
             // This should be removed once the target framework is bumped to something that supports covariance
             TResult ResultSelectorWrapper(TKey key, IList<TSource> group) => resultSelector(key, group);

--- a/MoreLinq/Index.cs
+++ b/MoreLinq/Index.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -53,7 +53,7 @@ namespace MoreLinq
 
         public static IEnumerable<KeyValuePair<int, TSource>> Index<TSource>(this IEnumerable<TSource> source, int startIndex)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.Select((item, index) => new KeyValuePair<int, TSource>(startIndex + index, item));
         }
     }

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -51,8 +52,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> Insert<T>(this IEnumerable<T> first, IEnumerable<T> second, int index)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
             if (index < 0) throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative.");
 
             return _(); IEnumerable<T> _()

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -54,7 +54,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(first);
             Guard.IsNotNull(second);
-            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(index, 0);
 
             return _(); IEnumerable<T> _()
             {
@@ -65,8 +65,7 @@ namespace MoreLinq
                 while (++i < index && iter.MoveNext())
                     yield return iter.Current;
 
-                if (i < index)
-                    throw new ArgumentOutOfRangeException(nameof(index), "Insertion index is greater than the length of the first sequence.");
+                Guard.IsLessThanOrEqualTo(i, index);
 
                 foreach (var item in second)
                     yield return item;

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -52,10 +53,10 @@ namespace MoreLinq
 
         public static IEnumerable<T> Interleave<T>(this IEnumerable<T> sequence, params IEnumerable<T>[] otherSequences)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
-            if (otherSequences == null) throw new ArgumentNullException(nameof(otherSequences));
+            Guard.IsNotNull(sequence);
+            Guard.IsNotNull(otherSequences);
             if (otherSequences.Any(s => s == null))
-                throw new ArgumentNullException(nameof(otherSequences), "One or more sequences passed to Interleave was null.");
+                ThrowHelper.ThrowArgumentNullException(nameof(otherSequences), "One or more sequences passed to Interleave was null.");
 
             return Impl(otherSequences.Prepend(sequence));
 

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -82,7 +82,7 @@ namespace MoreLinq
             // NOTE: Theoretically, we could assume that negative (or zero-offset) lags could be
             //       re-written as: sequence.Lead( -lagBy, resultSelector ). However, I'm not sure
             //       that it's an intuitive - or even desirable - behavior. So it's being omitted.
-            if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            Guard.IsGreaterThan(offset, 0);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -47,8 +48,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector is null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             return source.Select(Some)
                          .Lag(offset, default, (curr, lag) => resultSelector(curr.Value, lag is (true, var some) ? some : default));
@@ -76,8 +77,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lag<TSource, TResult>(this IEnumerable<TSource> source, int offset, TSource defaultLagValue, Func<TSource, TSource, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
             // NOTE: Theoretically, we could assume that negative (or zero-offset) lags could be
             //       re-written as: sequence.Lead( -lagBy, resultSelector ). However, I'm not sure
             //       that it's an intuitive - or even desirable - behavior. So it's being omitted.

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -79,7 +79,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(resultSelector);
-            if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            Guard.IsGreaterThan(offset, 0);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -47,8 +48,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, Func<TSource, TSource?, TResult> resultSelector)
         {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector is null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             return source.Select(Some)
                          .Lead(offset, default, (curr, lead) => resultSelector(curr.Value, lead is (true, var some) ? some : default));
@@ -76,8 +77,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Lead<TSource, TResult>(this IEnumerable<TSource> source, int offset, TSource defaultLeadValue, Func<TSource, TSource, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
             if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
 
             return _(); IEnumerable<TResult> _()

--- a/MoreLinq/LeftJoin.cs
+++ b/MoreLinq/LeftJoin.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -59,7 +60,7 @@ namespace MoreLinq
             Func<TSource, TResult> firstSelector,
             Func<TSource, TSource, TResult> bothSelector)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.LeftJoin(second, keySelector,
                                   firstSelector, bothSelector,
                                   null);
@@ -105,7 +106,7 @@ namespace MoreLinq
             Func<TSource, TSource, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.LeftJoin(second,
                                   keySelector, keySelector,
                                   firstSelector, bothSelector,
@@ -200,12 +201,12 @@ namespace MoreLinq
             Func<TFirst, TSecond, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (firstKeySelector == null) throw new ArgumentNullException(nameof(firstKeySelector));
-            if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
-            if (firstSelector == null) throw new ArgumentNullException(nameof(firstSelector));
-            if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(firstKeySelector);
+            Guard.IsNotNull(secondKeySelector);
+            Guard.IsNotNull(firstSelector);
+            Guard.IsNotNull(bothSelector);
 
             return
                 from f in first.GroupJoin(second, firstKeySelector, secondKeySelector,

--- a/MoreLinq/LeftJoin.cs
+++ b/MoreLinq/LeftJoin.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq
 {
     using CommunityToolkit.Diagnostics;
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -51,7 +51,7 @@ namespace MoreLinq
 
         public T this[int index] => _rw is { } rw ? rw[index]
                                   : _ro is { } rx ? rx[index]
-                                  : throw new ArgumentOutOfRangeException(nameof(index));
+                                  : ThrowHelper.ThrowInvalidOperationException<T>("Invalid `ListLike` construction.");
     }
 
     static class ListLike

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -34,14 +35,16 @@ namespace MoreLinq
 
         public ListLike(IList<T> list)
         {
-            _rw = list ?? throw new ArgumentNullException(nameof(list));
+            Guard.IsNotNull(list);
+            _rw = list;
             _ro = null;
         }
 
         public ListLike(IReadOnlyList<T> list)
         {
+            Guard.IsNotNull(list);
             _rw = null;
-            _ro = list ?? throw new ArgumentNullException(nameof(list));
+            _ro = list;
         }
 
         public int Count => _rw?.Count ?? _ro?.Count ?? 0;
@@ -61,7 +64,7 @@ namespace MoreLinq
         public static ListLike<T>? TryAsListLike<T>(this IEnumerable<T> source) =>
             source switch
             {
-                null => throw new ArgumentNullException(nameof(source)),
+                null => ThrowHelper.ThrowArgumentNullException<ListLike<T>?>(nameof(source)),
                 IList<T> list => new(list),
                 IReadOnlyList<T> list => new(list),
                 _ => null

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -275,6 +275,6 @@ namespace MoreLinq
         void IList<TElement>.RemoveAt(int index) => ThrowModificationNotSupportedException();
 
         [DoesNotReturn]
-        static void ThrowModificationNotSupportedException() => throw new NotSupportedException("Grouping is immutable.");
+        static void ThrowModificationNotSupportedException() => ThrowHelper.ThrowNotSupportedException("Grouping is immutable.");
     }
 }

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -30,6 +30,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -258,9 +259,11 @@ namespace MoreLinq
 
         TElement IList<TElement>.this[int index]
         {
-            get => index < 0 || index >= _count
-                   ? throw new ArgumentOutOfRangeException(nameof(index))
-                   : _elements[index];
+            get
+            {
+                Guard.IsBetween(index, -1, _count);
+                return _elements[index];
+            }
 
             set => ThrowModificationNotSupportedException();
         }

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -81,5 +81,5 @@ namespace MoreLinq
         {
             return source.Maxima(selector, comparer);
         }
-    }
-}
+            }
+                    }

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -71,7 +72,7 @@ namespace MoreLinq
 
         public static T First<T>(this IExtremaEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.Take(1).AsEnumerable().First();
         }
 
@@ -89,7 +90,7 @@ namespace MoreLinq
 
         public static T? FirstOrDefault<T>(this IExtremaEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.Take(1).AsEnumerable().FirstOrDefault();
         }
 
@@ -107,7 +108,7 @@ namespace MoreLinq
 
         public static T Last<T>(this IExtremaEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.TakeLast(1).AsEnumerable().Last();
         }
 
@@ -125,7 +126,7 @@ namespace MoreLinq
 
         public static T? LastOrDefault<T>(this IExtremaEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.TakeLast(1).AsEnumerable().LastOrDefault();
         }
 
@@ -146,7 +147,7 @@ namespace MoreLinq
         public static T Single<T>(this IExtremaEnumerable<T> source)
 #pragma warning restore CA1720 // Identifier contains type name
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.Take(2).AsEnumerable().Single();
         }
 
@@ -165,7 +166,7 @@ namespace MoreLinq
 
         public static T? SingleOrDefault<T>(this IExtremaEnumerable<T> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.Take(2).AsEnumerable().SingleOrDefault();
         }
 
@@ -211,8 +212,8 @@ namespace MoreLinq
         public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (selector == null) throw new ArgumentNullException(nameof(selector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(selector);
 
             comparer ??= Comparer<TKey>.Default;
             return new ExtremaEnumerable<TSource, TKey>(source, selector, comparer.Compare);

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     /// <summary>

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -29,7 +30,7 @@ namespace MoreLinq
     {
         static int CountUpTo<T>(this IEnumerable<T> source, int max)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (max < 0) throw new ArgumentOutOfRangeException(nameof(max), "The maximum count argument cannot be negative.");
 
             var count = 0;

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -31,7 +31,7 @@ namespace MoreLinq
         static int CountUpTo<T>(this IEnumerable<T> source, int max)
         {
             Guard.IsNotNull(source);
-            if (max < 0) throw new ArgumentOutOfRangeException(nameof(max), "The maximum count argument cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(max, 0);
 
             var count = 0;
 

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -152,6 +152,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -51,9 +51,9 @@ namespace MoreLinq
         public static IEnumerable<T> Move<T>(this IEnumerable<T> source, int fromIndex, int count, int toIndex)
         {
             Guard.IsNotNull(source);
-            if (fromIndex < 0) throw new ArgumentOutOfRangeException(nameof(fromIndex), "The source index cannot be negative.");
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be negative.");
-            if (toIndex < 0) throw new ArgumentOutOfRangeException(nameof(toIndex), "Target index of range to move cannot be negative.");
+            Guard.IsGreaterThanOrEqualTo(fromIndex, 0);
+            Guard.IsGreaterThanOrEqualTo(count, 0);
+            Guard.IsGreaterThanOrEqualTo(toIndex, 0);
 
             if (toIndex == fromIndex || count == 0)
                 return source;

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -49,7 +50,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> Move<T>(this IEnumerable<T> source, int fromIndex, int count, int toIndex)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (fromIndex < 0) throw new ArgumentOutOfRangeException(nameof(fromIndex), "The source index cannot be negative.");
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Count cannot be negative.");
             if (toIndex < 0) throw new ArgumentOutOfRangeException(nameof(toIndex), "Target index of range to move cannot be negative.");

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -18,7 +18,6 @@
 namespace MoreLinq
 {
     using CommunityToolkit.Diagnostics;
-    using System;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -36,8 +37,8 @@ namespace MoreLinq
 
         static IEnumerable<Action> NestedLoops(this Action action, IEnumerable<ulong> loopCounts)
         {
-            if (action == null) throw new ArgumentNullException(nameof(action));
-            if (loopCounts == null) throw new ArgumentNullException(nameof(loopCounts));
+            Guard.IsNotNull(action);
+            Guard.IsNotNull(loopCounts);
 
             return _(); IEnumerable<Action> _()
             {

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/OrderBy.cs
+++ b/MoreLinq/OrderBy.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -51,8 +52,8 @@ namespace MoreLinq
 
         public static IOrderedEnumerable<T> OrderBy<T, TKey>(this IEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey>? comparer, OrderByDirection direction)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
             return direction == OrderByDirection.Ascending
                        ? source.OrderBy(keySelector, comparer)
                        : source.OrderByDescending(keySelector, comparer);
@@ -86,8 +87,8 @@ namespace MoreLinq
 
         public static IOrderedEnumerable<T> ThenBy<T, TKey>(this IOrderedEnumerable<T> source, Func<T, TKey> keySelector, IComparer<TKey>? comparer, OrderByDirection direction)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
             return direction == OrderByDirection.Ascending
                        ? source.ThenBy(keySelector, comparer)
                        : source.ThenByDescending(keySelector, comparer);

--- a/MoreLinq/OrderBy.cs
+++ b/MoreLinq/OrderBy.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -180,7 +181,7 @@ namespace MoreLinq
             Func<T, T, TResult> bothSelector,
             IComparer<TKey>? comparer)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector)); // Argument name changes to 'firstKeySelector'
+            Guard.IsNotNull(keySelector); // Argument name changes to 'firstKeySelector'
             return OrderedMerge(first, second, keySelector, keySelector, firstSelector, secondSelector, bothSelector, comparer);
         }
 
@@ -274,13 +275,13 @@ namespace MoreLinq
             Func<TFirst, TSecond, TResult> bothSelector,
             IComparer<TKey>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (firstKeySelector == null) throw new ArgumentNullException(nameof(firstKeySelector));
-            if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
-            if (firstSelector == null) throw new ArgumentNullException(nameof(firstSelector));
-            if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
-            if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(firstKeySelector);
+            Guard.IsNotNull(secondKeySelector);
+            Guard.IsNotNull(firstSelector);
+            Guard.IsNotNull(bothSelector);
+            Guard.IsNotNull(secondSelector);
 
             return _(comparer ?? Comparer<TKey>.Default);
 

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -76,7 +77,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Pad<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (width < 0) throw new ArgumentException(null, nameof(width));
             return PadImpl(source, width, padding, null);
         }
@@ -107,8 +108,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Pad<TSource>(this IEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(paddingSelector);
             if (width < 0) throw new ArgumentException(null, nameof(width));
             return PadImpl(source, width, default, paddingSelector);
         }

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -78,7 +78,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> Pad<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
             Guard.IsNotNull(source);
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            Guard.IsGreaterThanOrEqualTo(width, 0);
             return PadImpl(source, width, padding, null);
         }
 
@@ -110,7 +110,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(paddingSelector);
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            Guard.IsGreaterThanOrEqualTo(width, 0);
             return PadImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -77,7 +77,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> PadStart<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
             Guard.IsNotNull(source);
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            Guard.IsGreaterThanOrEqualTo(width, 0);
             return PadStartImpl(source, width, padding, null);
         }
 
@@ -111,7 +111,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(paddingSelector);
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            Guard.IsGreaterThanOrEqualTo(width, 0);
             return PadStartImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -75,7 +76,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> PadStart<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (width < 0) throw new ArgumentException(null, nameof(width));
             return PadStartImpl(source, width, padding, null);
         }
@@ -108,8 +109,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> PadStart<TSource>(this IEnumerable<TSource> source, int width, Func<int, TSource> paddingSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(paddingSelector);
             if (width < 0) throw new ArgumentException(null, nameof(width));
             return PadStartImpl(source, width, default, paddingSelector);
         }

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -50,8 +51,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> Pairwise<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TSource, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -83,7 +84,7 @@ namespace MoreLinq
         public static IEnumerable<T> PartialSort<T>(this IEnumerable<T> source,
             int count, IComparer<T>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return PartialSortByImpl<T, T>(source, count, null, null, comparer);
         }
 
@@ -182,8 +183,8 @@ namespace MoreLinq
             Func<TSource, TKey> keySelector,
             IComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
             return PartialSortByImpl(source, count, keySelector, comparer, null);
         }
 

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -83,9 +84,9 @@ namespace MoreLinq
         public static TResult Partition<T, TResult>(this IEnumerable<T> source,
             Func<T, bool> predicate, Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
+            Guard.IsNotNull(resultSelector);
 
             return source.GroupBy(predicate).Partition(resultSelector);
         }
@@ -112,7 +113,7 @@ namespace MoreLinq
         public static TResult Partition<T, TResult>(this IEnumerable<IGrouping<bool, T>> source,
             Func<IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
             return source.Partition(key1: true, key2: false, (t, f, _) => resultSelector(t, f));
         }
 
@@ -139,7 +140,7 @@ namespace MoreLinq
         public static TResult Partition<T, TResult>(this IEnumerable<IGrouping<bool?, T>> source,
             Func<IEnumerable<T>, IEnumerable<T>, IEnumerable<T>, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
             return source.Partition(key1: true, key2: false, key3: null, (t, f, n, _) => resultSelector(t, f, n));
         }
 
@@ -201,7 +202,7 @@ namespace MoreLinq
             TKey key, IEqualityComparer<TKey>? comparer,
             Func<IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return PartitionImpl(source, 1, key, key2: default, key3: default, comparer,
                                  (a, _, _, rest) => resultSelector(a, rest));
@@ -268,7 +269,7 @@ namespace MoreLinq
             TKey key1, TKey key2, IEqualityComparer<TKey>? comparer,
             Func<IEnumerable<TElement>, IEnumerable<TElement>, IEnumerable<IGrouping<TKey, TElement>>, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return PartitionImpl(source, 2, key1, key2, key3: default, comparer,
                                  (a, b, c, rest) => resultSelector(a, b, rest));
@@ -344,8 +345,8 @@ namespace MoreLinq
         {
             Debug.Assert(count is > 0 and <= 3);
 
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             comparer ??= EqualityComparer<TKey>.Default;
 

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/PendNode.cs
+++ b/MoreLinq/PendNode.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections;
     using System.Collections.Generic;
 
@@ -42,7 +42,7 @@ namespace MoreLinq
 
             public Item(T item, bool isPrepend, PendNode<T> next)
             {
-                if (next == null) throw new ArgumentNullException(nameof(next));
+                Guard.IsNotNull(next);
 
                 Value       = item;
                 IsPrepend   = isPrepend;

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -201,7 +202,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<T>> Permutations<T>(this IEnumerable<T> sequence)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
 
             return _(); IEnumerable<IList<T>> _()
             {

--- a/MoreLinq/Pipe.cs
+++ b/MoreLinq/Pipe.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Pipe.cs
+++ b/MoreLinq/Pipe.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -40,8 +41,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> Pipe<T>(this IEnumerable<T> source, Action<T> action)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (action == null) throw new ArgumentNullException(nameof(action));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(action);
 
             return _(); IEnumerable<T> _()
             {

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -56,8 +57,8 @@ namespace MoreLinq
             Func<TSource, TSource, TSource> transformation,
             TSource identity)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (transformation == null) throw new ArgumentNullException(nameof(transformation));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(transformation);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Prepend.cs
+++ b/MoreLinq/Prepend.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     static partial class MoreEnumerable
@@ -47,7 +47,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource value)
 #endif
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source is PendNode<TSource> node
                  ? node.Prepend(value)
                  : PendNode<TSource>.WithSource(source).Prepend(value);

--- a/MoreLinq/Random.cs
+++ b/MoreLinq/Random.cs
@@ -19,6 +19,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -63,7 +64,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Random(Random rand)
         {
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
+            Guard.IsNotNull(rand);
 
             return RandomImpl(rand, r => r.Next());
         }
@@ -111,7 +112,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Random(Random rand, int maxValue)
         {
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
+            Guard.IsNotNull(rand);
             if (maxValue < 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
 
             return RandomImpl(rand, r => r.Next(maxValue));
@@ -160,7 +161,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Random(Random rand, int minValue, int maxValue)
         {
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
+            Guard.IsNotNull(rand);
             if (minValue > maxValue) throw new ArgumentOutOfRangeException(nameof(minValue), $"The argument minValue ({minValue}) is greater than maxValue ({maxValue})");
 
             return RandomImpl(rand, r => r.Next(minValue, maxValue));
@@ -204,7 +205,7 @@ namespace MoreLinq
 
         public static IEnumerable<double> RandomDouble(Random rand)
         {
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
+            Guard.IsNotNull(rand);
 
             return RandomImpl(rand, r => r.NextDouble());
         }

--- a/MoreLinq/Random.cs
+++ b/MoreLinq/Random.cs
@@ -19,7 +19,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Random.cs
+++ b/MoreLinq/Random.cs
@@ -96,7 +96,7 @@ namespace MoreLinq
 
         public static IEnumerable<int> Random(int maxValue)
         {
-            if (maxValue < 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+            Guard.IsGreaterThanOrEqualTo(maxValue, 0);
 
             return Random(GlobalRandom.Instance, maxValue);
         }
@@ -113,7 +113,7 @@ namespace MoreLinq
         public static IEnumerable<int> Random(Random rand, int maxValue)
         {
             Guard.IsNotNull(rand);
-            if (maxValue < 0) throw new ArgumentOutOfRangeException(nameof(maxValue));
+            Guard.IsGreaterThanOrEqualTo(maxValue, 0);
 
             return RandomImpl(rand, r => r.Next(maxValue));
         }
@@ -162,7 +162,7 @@ namespace MoreLinq
         public static IEnumerable<int> Random(Random rand, int minValue, int maxValue)
         {
             Guard.IsNotNull(rand);
-            if (minValue > maxValue) throw new ArgumentOutOfRangeException(nameof(minValue), $"The argument minValue ({minValue}) is greater than maxValue ({maxValue})");
+            Guard.IsLessThan(minValue, maxValue);
 
             return RandomImpl(rand, r => r.Next(minValue, maxValue));
         }

--- a/MoreLinq/RandomSubset.cs
+++ b/MoreLinq/RandomSubset.cs
@@ -60,7 +60,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(rand);
             Guard.IsNotNull(source);
-            if (subsetSize < 0) throw new ArgumentOutOfRangeException(nameof(subsetSize));
+            Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
 
             return RandomSubsetImpl(source, rand, seq => (seq.ToArray(), subsetSize));
         }
@@ -77,7 +77,8 @@ namespace MoreLinq
 
             if (array.Length < subsetSize)
             {
-                throw new ArgumentOutOfRangeException(nameof(subsetSize),
+                ThrowHelper.ThrowArgumentOutOfRangeException(
+                    nameof(subsetSize),
                     "Subset size must be less than or equal to the source length.");
             }
 

--- a/MoreLinq/RandomSubset.cs
+++ b/MoreLinq/RandomSubset.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -57,8 +58,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> RandomSubset<T>(this IEnumerable<T> source, int subsetSize, Random rand)
         {
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(rand);
+            Guard.IsNotNull(source);
             if (subsetSize < 0) throw new ArgumentOutOfRangeException(nameof(subsetSize));
 
             return RandomSubsetImpl(source, rand, seq => (seq.ToArray(), subsetSize));

--- a/MoreLinq/RandomSubset.cs
+++ b/MoreLinq/RandomSubset.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -74,8 +75,8 @@ namespace MoreLinq
 
         public static IEnumerable<int> RankBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
 
             return _(comparer ?? Comparer<TKey>.Default);
 

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Reactive/Observable.cs
+++ b/MoreLinq/Reactive/Observable.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Reactive
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using Delegate = Delegating.Delegate;
 
@@ -42,9 +43,10 @@ namespace MoreLinq.Reactive
         /// <returns>The subscription, which when disposed, will unsubscribe
         /// from <paramref name="source"/>.</returns>
 
-        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception>? onError = null, Action? onCompleted = null) =>
-            source == null
-            ? throw new ArgumentNullException(nameof(source))
-            : source.Subscribe(Delegate.Observer(onNext, onError, onCompleted));
+        public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception>? onError = null, Action? onCompleted = null)
+        {
+            Guard.IsNotNull(source);
+            return source.Subscribe(Delegate.Observer(onNext, onError, onCompleted));
+        }
     }
 }

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Reactive
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Delegate = Delegating.Delegate;
@@ -34,7 +35,7 @@ namespace MoreLinq.Reactive
 
         public IDisposable Subscribe(IObserver<T> observer)
         {
-            if (observer == null) throw new ArgumentNullException(nameof(observer));
+            Guard.IsNotNull(observer);
 
             if (_error != null)
             {

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;
@@ -33,7 +34,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> Repeat<T>(this IEnumerable<T> sequence, int count)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Repeat count must be greater than or equal to zero.");
             return RepeatImpl(sequence, count);
         }
@@ -47,7 +48,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> Repeat<T>(this IEnumerable<T> sequence)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
             return RepeatImpl(sequence, null);
         }
 

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -35,7 +35,7 @@ namespace MoreLinq
         public static IEnumerable<T> Repeat<T>(this IEnumerable<T> sequence, int count)
         {
             Guard.IsNotNull(sequence);
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), "Repeat count must be greater than or equal to zero.");
+            Guard.IsGreaterThanOrEqualTo(count, 0);
             return RepeatImpl(sequence, count);
         }
 

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using Experimental;

--- a/MoreLinq/Return.cs
+++ b/MoreLinq/Return.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -43,7 +44,11 @@ namespace MoreLinq
 
             public T this[int index]
             {
-                get => index == 0 ? _item : throw new ArgumentOutOfRangeException(nameof(index));
+                get
+                {
+                    Guard.IsBetweenOrEqualTo(index, 0, 0);
+                    return _item;
+                }
                 set => throw ReadOnlyException();
             }
 

--- a/MoreLinq/RightJoin.cs
+++ b/MoreLinq/RightJoin.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/RightJoin.cs
+++ b/MoreLinq/RightJoin.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -58,7 +59,7 @@ namespace MoreLinq
             Func<TSource, TResult> secondSelector,
             Func<TSource, TSource, TResult> bothSelector)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.RightJoin(second, keySelector,
                                    secondSelector, bothSelector,
                                    null);
@@ -104,7 +105,7 @@ namespace MoreLinq
             Func<TSource, TSource, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
+            Guard.IsNotNull(keySelector);
             return first.RightJoin(second,
                                    keySelector, keySelector,
                                    secondSelector, bothSelector,
@@ -199,12 +200,12 @@ namespace MoreLinq
             Func<TFirst, TSecond, TResult> bothSelector,
             IEqualityComparer<TKey>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (firstKeySelector == null) throw new ArgumentNullException(nameof(firstKeySelector));
-            if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
-            if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
-            if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(firstKeySelector);
+            Guard.IsNotNull(secondKeySelector);
+            Guard.IsNotNull(secondSelector);
+            Guard.IsNotNull(bothSelector);
 
             return second.LeftJoin(first,
                                    secondKeySelector, firstKeySelector,

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
 
     public static partial class MoreEnumerable
@@ -47,7 +47,7 @@ namespace MoreLinq
 
         public static IEnumerable<KeyValuePair<T, int>> RunLengthEncode<T>(this IEnumerable<T> sequence, IEqualityComparer<T>? comparer)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
 
             return _(comparer ?? EqualityComparer<T>.Default);
 

--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -53,8 +54,8 @@ namespace MoreLinq
         public static IEnumerable<TSource> Scan<TSource>(this IEnumerable<TSource> source,
             Func<TSource, TSource, TSource> transformation)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (transformation == null) throw new ArgumentNullException(nameof(transformation));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(transformation);
 
             return ScanImpl(source, transformation, e => e.MoveNext() ? (true, e.Current) : default);
         }
@@ -83,8 +84,8 @@ namespace MoreLinq
         public static IEnumerable<TState> Scan<TSource, TState>(this IEnumerable<TSource> source,
             TState seed, Func<TState, TSource, TState> transformation)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (transformation == null) throw new ArgumentNullException(nameof(transformation));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(transformation);
 
             return ScanImpl(source, transformation, _ => (true, seed));
         }

--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -80,10 +81,10 @@ namespace MoreLinq
             Func<TState, TKey, TSource, TState> accumulator,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
-            if (seedSelector == null) throw new ArgumentNullException(nameof(seedSelector));
-            if (accumulator == null) throw new ArgumentNullException(nameof(accumulator));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(keySelector);
+            Guard.IsNotNull(seedSelector);
+            Guard.IsNotNull(accumulator);
 
             return _(comparer ?? EqualityComparer<TKey>.Default);
 

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ScanRight.cs
+++ b/MoreLinq/ScanRight.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -47,8 +48,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> ScanRight<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (func == null) throw new ArgumentNullException(nameof(func));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(func);
 
             return ScanRightImpl(source, func, list => list.Count > 0 ? (list[^1], list.Count - 1) : null);
         }
@@ -78,8 +79,8 @@ namespace MoreLinq
 
         public static IEnumerable<TAccumulate> ScanRight<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TSource, TAccumulate, TAccumulate> func)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (func == null) throw new ArgumentNullException(nameof(func));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(func);
 
             return ScanRightImpl(source, func, list => (seed, list.Count));
         }

--- a/MoreLinq/ScanRight.cs
+++ b/MoreLinq/ScanRight.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -35,7 +36,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, bool> newSegmentPredicate)
         {
-            if (newSegmentPredicate == null) throw new ArgumentNullException(nameof(newSegmentPredicate));
+            Guard.IsNotNull(newSegmentPredicate);
 
             return Segment(source, (curr, _, _) => newSegmentPredicate(curr));
         }
@@ -53,7 +54,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, int, bool> newSegmentPredicate)
         {
-            if (newSegmentPredicate == null) throw new ArgumentNullException(nameof(newSegmentPredicate));
+            Guard.IsNotNull(newSegmentPredicate);
 
             return Segment(source, (curr, _, index) => newSegmentPredicate(curr, index));
         }
@@ -71,8 +72,8 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<T>> Segment<T>(this IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (newSegmentPredicate == null) throw new ArgumentNullException(nameof(newSegmentPredicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(newSegmentPredicate);
 
             return _(); IEnumerable<IEnumerable<T>> _()
             {

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Shuffle.cs
+++ b/MoreLinq/Shuffle.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -67,8 +68,8 @@ namespace MoreLinq
 
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, Random rand)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (rand == null) throw new ArgumentNullException(nameof(rand));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(rand);
 
             return RandomSubsetImpl(source, rand, seq =>
             {

--- a/MoreLinq/Shuffle.cs
+++ b/MoreLinq/Shuffle.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -39,7 +39,7 @@ namespace MoreLinq
         public static IEnumerable<T> SkipLast<T>(this IEnumerable<T> source, int count)
 #endif
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             return count < 1 ? source
                  : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -54,8 +55,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> SkipUntil<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -49,7 +50,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> Slice<T>(this IEnumerable<T> sequence, int startIndex, int count)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
             if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
 

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -51,8 +51,8 @@ namespace MoreLinq
         public static IEnumerable<T> Slice<T>(this IEnumerable<T> sequence, int startIndex, int count)
         {
             Guard.IsNotNull(sequence);
-            if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
-            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+            Guard.IsGreaterThanOrEqualTo(startIndex, 0);
+            Guard.IsGreaterThanOrEqualTo(count, 0);
 
             return sequence switch
             {

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -80,8 +81,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> SortedMerge<TSource>(this IEnumerable<TSource> source, OrderByDirection direction, IComparer<TSource>? comparer, params IEnumerable<TSource>[] otherSequences)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (otherSequences == null) throw new ArgumentNullException(nameof(otherSequences));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(otherSequences);
 
             if (otherSequences.Length == 0)
                 return source; // optimization for when otherSequences is empty

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -178,9 +179,9 @@ namespace MoreLinq
             TSource separator, IEqualityComparer<TSource>? comparer, int count,
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             comparer ??= EqualityComparer<TSource>.Default;
             return Split(source, item => comparer.Equals(item, separator), count, resultSelector);
@@ -262,10 +263,10 @@ namespace MoreLinq
             Func<TSource, bool> separatorFunc, int count,
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (separatorFunc == null) throw new ArgumentNullException(nameof(separatorFunc));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(separatorFunc);
             if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -180,7 +180,7 @@ namespace MoreLinq
             Func<IEnumerable<TSource>, TResult> resultSelector)
         {
             Guard.IsNotNull(source);
-            if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
+            Guard.IsGreaterThan(count, 0);
             Guard.IsNotNull(resultSelector);
 
             comparer ??= EqualityComparer<TSource>.Default;
@@ -265,7 +265,7 @@ namespace MoreLinq
         {
             Guard.IsNotNull(source);
             Guard.IsNotNull(separatorFunc);
-            if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
+            Guard.IsGreaterThan(count, 0);
             Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -70,8 +70,8 @@ namespace MoreLinq
 
         public static bool StartsWith<T>(this IEnumerable<T> first, IEnumerable<T> second, IEqualityComparer<T>? comparer)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
 
             if (first.TryAsCollectionLike() is { Count: var firstCount } &&
                 second.TryAsCollectionLike() is { Count: var secondCount } &&

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -50,7 +51,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence)
         {
-            if (sequence == null) throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
 
             return _(); IEnumerable<IList<T>> _()
             {
@@ -97,8 +98,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence, int subsetSize)
         {
-            if (sequence == null)
-                throw new ArgumentNullException(nameof(sequence));
+            Guard.IsNotNull(sequence);
             if (subsetSize < 0)
                 throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be >= 0");
 
@@ -216,8 +216,7 @@ namespace MoreLinq
 
             public SubsetGenerator(IEnumerable<T> sequence, int subsetSize)
             {
-                if (sequence is null)
-                    throw new ArgumentNullException(nameof(sequence));
+                Guard.IsNotNull(sequence);
                 if (subsetSize < 0)
                     throw new ArgumentOutOfRangeException(nameof(subsetSize), "{subsetSize} must be between 0 and set.Count()");
                 _subsetSize = subsetSize;

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -99,8 +99,7 @@ namespace MoreLinq
         public static IEnumerable<IList<T>> Subsets<T>(this IEnumerable<T> sequence, int subsetSize)
         {
             Guard.IsNotNull(sequence);
-            if (subsetSize < 0)
-                throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be >= 0");
+            Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
 
             // NOTE: There's an interesting trade-off that we have to make in this operator.
             // Ideally, we would throw an exception here if the {subsetSize} parameter is
@@ -149,7 +148,11 @@ namespace MoreLinq
                 {
                     // precondition: subsetSize <= set.Count
                     if (subsetSize > set.Count)
-                        throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be <= sequence.Count()");
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException(
+                            nameof(subsetSize),
+                            "Subset size must be <= sequence.Count()");
+                    }
 
                     // initialize set arrays...
                     _set = set;
@@ -217,8 +220,7 @@ namespace MoreLinq
             public SubsetGenerator(IEnumerable<T> sequence, int subsetSize)
             {
                 Guard.IsNotNull(sequence);
-                if (subsetSize < 0)
-                    throw new ArgumentOutOfRangeException(nameof(subsetSize), "{subsetSize} must be between 0 and set.Count()");
+                Guard.IsGreaterThanOrEqualTo(subsetSize, 0);
                 _subsetSize = subsetSize;
                 _sequence = sequence;
             }

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -56,8 +57,8 @@ namespace MoreLinq
 
         public static IEnumerable<TResult> TagFirstLast<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(resultSelector);
 
             return _(); IEnumerable<TResult> _()
             {

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -47,7 +47,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> TakeEvery<TSource>(this IEnumerable<TSource> source, int step)
         {
             Guard.IsNotNull(source);
-            if (step <= 0) throw new ArgumentOutOfRangeException(nameof(step));
+            Guard.IsGreaterThan(step, 0);
             return source.Where((_, i) => i % step == 0);
         }
     }

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -45,7 +46,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> TakeEvery<TSource>(this IEnumerable<TSource> source, int step)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (step <= 0) throw new ArgumentOutOfRangeException(nameof(step));
             return source.Where((_, i) => i % step == 0);
         }

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Linq;
     using System.Collections.Generic;
@@ -52,7 +53,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
 #endif
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             return count < 1 ? Enumerable.Empty<TSource>()
                  : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -17,10 +17,9 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
-    using System.Linq;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
+    using System.Linq;
 
     static partial class MoreEnumerable
     {

--- a/MoreLinq/TakeUntil.cs
+++ b/MoreLinq/TakeUntil.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -54,8 +55,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> TakeUntil<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return _(); IEnumerable<TSource> _()
             {

--- a/MoreLinq/TakeUntil.cs
+++ b/MoreLinq/TakeUntil.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -243,7 +243,7 @@ namespace MoreLinq
             Func<T, int> indexSelector, Func<T, int, TResult> resultSelector)
         {
             Guard.IsNotNull(source);
-            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+            Guard.IsGreaterThanOrEqualTo(length, 0);
             Guard.IsNotNull(indexSelector);
             Guard.IsNotNull(resultSelector);
 

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -81,7 +82,7 @@ namespace MoreLinq
         public static TResult[] ToArrayByIndex<T, TResult>(this IEnumerable<T> source,
             Func<T, int> indexSelector, Func<T, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
             return source.ToArrayByIndex(indexSelector, (e, _) => resultSelector(e));
         }
 
@@ -116,9 +117,9 @@ namespace MoreLinq
         public static TResult[] ToArrayByIndex<T, TResult>(this IEnumerable<T> source,
             Func<T, int> indexSelector, Func<T, int, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (indexSelector == null) throw new ArgumentNullException(nameof(indexSelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(indexSelector);
+            Guard.IsNotNull(resultSelector);
 
             var lastIndex = -1;
             var indexed = (List<KeyValuePair<int, T>>?)null;
@@ -206,7 +207,7 @@ namespace MoreLinq
         public static TResult[] ToArrayByIndex<T, TResult>(this IEnumerable<T> source, int length,
             Func<T, int> indexSelector, Func<T, TResult> resultSelector)
         {
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(resultSelector);
             return source.ToArrayByIndex(length, indexSelector, (e, _) => resultSelector(e));
         }
 
@@ -241,10 +242,10 @@ namespace MoreLinq
         public static TResult[] ToArrayByIndex<T, TResult>(this IEnumerable<T> source, int length,
             Func<T, int> indexSelector, Func<T, int, TResult> resultSelector)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
-            if (indexSelector == null) throw new ArgumentNullException(nameof(indexSelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(indexSelector);
+            Guard.IsNotNull(resultSelector);
 
             var array = new TResult[length];
             foreach (var e in source)

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Data;

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -147,14 +147,16 @@ namespace MoreLinq
             //
 
             if (expressions.Any(e => e == null))
-                throw new ArgumentException("One of the supplied expressions was null.", nameof(expressions));
+                ThrowHelper.ThrowArgumentException(nameof(expressions), "One of the supplied expressions was null.");
+
             try
             {
                 return expressions.Select(GetAccessedMember);
             }
             catch (ArgumentException e)
             {
-                throw new ArgumentException("One of the supplied expressions is not allowed.", nameof(expressions), e);
+                ThrowHelper.ThrowArgumentException(nameof(expressions), "One of the supplied expressions is not allowed.", e);
+                return default!;
             }
 
             static MemberInfo GetAccessedMember(LambdaExpression lambda)
@@ -169,7 +171,7 @@ namespace MoreLinq
                 // member access e.g. not a.b.c
                 return body is MemberExpression { Expression.NodeType: ExpressionType.Parameter, Member: var member }
                      ? member
-                     : throw new ArgumentException($"Illegal expression: {lambda}", nameof(lambda));
+                     : ThrowHelper.ThrowArgumentException<MemberInfo>(nameof(lambda), $"Illegal expression: {lambda}");
             }
         }
 

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Data;
@@ -95,9 +96,9 @@ namespace MoreLinq
         public static TTable ToDataTable<T, TTable>(this IEnumerable<T> source, TTable table, params Expression<Func<T, object?>>[] expressions)
             where TTable : DataTable
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (table == null) throw new ArgumentNullException(nameof(table));
-            if (expressions == null) throw new ArgumentNullException(nameof(expressions));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(table);
+            Guard.IsNotNull(expressions);
 
             var members = PrepareMemberInfos(expressions).ToArray();
             var boundMembers = BuildOrBindSchema(table, members);
@@ -203,14 +204,14 @@ namespace MoreLinq
             var columnMembers = new MemberInfo[columns.Count];
 
             foreach (var member in members)
-            {
+                {
                 var column = columns[member.Name] ?? throw new ArgumentException($"Column named '{member.Name}' is missing.", nameof(table));
 
                 if (GetElementaryTypeOfPropertyOrField(member) is var type && type != column.DataType)
                     throw new ArgumentException($"Column named '{member.Name}' has wrong data type. It should be {type} when it is {column.DataType}.", nameof(table));
 
                 columnMembers[column.Ordinal] = member;
-            }
+                }
 
             return columnMembers;
 

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Text;

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Text;
@@ -45,8 +46,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString<TSource>(this IEnumerable<TSource> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, (sb, e) => sb.Append(e));
         }
 

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -37,6 +37,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -63,8 +64,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<bool> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -89,8 +90,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<byte> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -115,8 +116,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<char> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -141,8 +142,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<decimal> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -167,8 +168,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<double> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -193,8 +194,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<float> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -219,8 +220,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<int> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -245,8 +246,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<long> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -271,8 +272,8 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<sbyte> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -297,8 +298,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<short> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -323,8 +324,8 @@ namespace MoreLinq
 
         public static string ToDelimitedString(this IEnumerable<string> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -349,8 +350,8 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<uint> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -375,8 +376,8 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ulong> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
@@ -401,9 +402,9 @@ namespace MoreLinq
         [CLSCompliant(false)]
         public static string ToDelimitedString(this IEnumerable<ushort> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
+        }
     }
-}

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -37,7 +37,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -46,7 +46,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -46,6 +46,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -94,8 +95,8 @@ namespace MoreLinq
 <#= type.IsNotClsCompliant ? "        [CLSCompliant(false)]" : string.Empty #>
         public static string ToDelimitedString(this IEnumerable<<#= type.Name #>> source, string delimiter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(delimiter);
             return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 <#      } #>

--- a/MoreLinq/ToDictionary.cs
+++ b/MoreLinq/ToDictionary.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -57,7 +57,7 @@ namespace MoreLinq
             IEqualityComparer<TKey>? comparer)
             where TKey : notnull
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);
         }
 
@@ -96,7 +96,7 @@ namespace MoreLinq
             IEqualityComparer<TKey>? comparer)
             where TKey : notnull
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.ToDictionary(e => e.Key, e => e.Value, comparer);
         }
     }

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -63,7 +64,7 @@ namespace MoreLinq
         public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
 #endif
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return new HashSet<TSource>(source, comparer);
         }
     }

--- a/MoreLinq/ToLookup.cs
+++ b/MoreLinq/ToLookup.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -55,7 +55,7 @@ namespace MoreLinq
         public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.ToLookup(e => e.Key, e => e.Value, comparer);
         }
 
@@ -92,7 +92,7 @@ namespace MoreLinq
         public static ILookup<TKey, TValue> ToLookup<TKey, TValue>(this IEnumerable<(TKey Key, TValue Value)> source,
             IEqualityComparer<TKey>? comparer)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             return source.ToLookup(e => e.Key, e => e.Value, comparer);
         }
     }

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -60,7 +61,7 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source, string? format)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             return TraceImpl(source, string.IsNullOrEmpty(format)
                                      ? x => x?.ToString() ?? string.Empty
@@ -84,8 +85,8 @@ namespace MoreLinq
 
         public static IEnumerable<TSource> Trace<TSource>(this IEnumerable<TSource> source, Func<TSource, string> formatter)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(formatter);
             return TraceImpl(source, formatter);
         }
 

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Transpose.cs
+++ b/MoreLinq/Transpose.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -54,7 +55,7 @@ namespace MoreLinq
 
         public static IEnumerable<IEnumerable<T>> Transpose<T>(this IEnumerable<IEnumerable<T>> source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
 
             return _(); IEnumerable<IEnumerable<T>> _()
             {

--- a/MoreLinq/Transpose.cs
+++ b/MoreLinq/Transpose.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -46,7 +47,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> TraverseBreadthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
         {
-            if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
+            Guard.IsNotNull(childrenSelector);
 
             return _(); IEnumerable<T> _()
             {
@@ -86,7 +87,7 @@ namespace MoreLinq
 
         public static IEnumerable<T> TraverseDepthFirst<T>(T root, Func<T, IEnumerable<T>> childrenSelector)
         {
-            if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
+            Guard.IsNotNull(childrenSelector);
 
             return _(); IEnumerable<T> _()
             {

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/Unfold.cs
+++ b/MoreLinq/Unfold.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -56,10 +57,10 @@ namespace MoreLinq
             Func<T, TState> stateSelector,
             Func<T, TResult> resultSelector)
         {
-            if (generator == null) throw new ArgumentNullException(nameof(generator));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            if (stateSelector == null) throw new ArgumentNullException(nameof(stateSelector));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(generator);
+            Guard.IsNotNull(predicate);
+            Guard.IsNotNull(stateSelector);
+            Guard.IsNotNull(resultSelector);
 
             return _(state); IEnumerable<TResult> _(TState initialState)
             {

--- a/MoreLinq/Unfold.cs
+++ b/MoreLinq/Unfold.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -43,7 +43,7 @@ namespace MoreLinq
         public static IEnumerable<IList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
         {
             Guard.IsNotNull(source);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
 
             return _(); IEnumerable<IList<TSource>> _()
             {

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -41,7 +42,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<TSource>> Window<TSource>(this IEnumerable<TSource> source, int size)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
             return _(); IEnumerable<IList<TSource>> _()

--- a/MoreLinq/WindowLeft.cs
+++ b/MoreLinq/WindowLeft.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -60,7 +61,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
             return _(); IEnumerable<IList<TSource>> _()

--- a/MoreLinq/WindowLeft.cs
+++ b/MoreLinq/WindowLeft.cs
@@ -62,7 +62,7 @@ namespace MoreLinq
         public static IEnumerable<IList<TSource>> WindowLeft<TSource>(this IEnumerable<TSource> source, int size)
         {
             Guard.IsNotNull(source);
-            if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
 
             return _(); IEnumerable<IList<TSource>> _()
             {

--- a/MoreLinq/WindowLeft.cs
+++ b/MoreLinq/WindowLeft.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
-    using System;
+    using CommunityToolkit.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -60,7 +61,7 @@ namespace MoreLinq
 
         public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            Guard.IsNotNull(source);
             if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
 
             return source.WindowRightWhile((_, i) => i < size);
@@ -75,8 +76,8 @@ namespace MoreLinq
             this IEnumerable<TSource> source,
             Func<TSource, int, bool> predicate)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            Guard.IsNotNull(source);
+            Guard.IsNotNull(predicate);
 
             return _(); IEnumerable<IList<TSource>> _()
             {

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -62,7 +62,7 @@ namespace MoreLinq
         public static IEnumerable<IList<TSource>> WindowRight<TSource>(this IEnumerable<TSource> source, int size)
         {
             Guard.IsNotNull(source);
-            if (size < 0) throw new ArgumentOutOfRangeException(nameof(size));
+            Guard.IsGreaterThan(size, 0);
 
             return source.WindowRightWhile((_, i) => i < size);
         }

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -62,9 +63,9 @@ namespace MoreLinq
             IEnumerable<TSecond> second,
             Func<TFirst?, TSecond?, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl<TFirst, TSecond, object, object, TResult>(first, second, null, null, (a, b, _, _) => resultSelector(a, b), 1);
         }
@@ -114,10 +115,10 @@ namespace MoreLinq
             IEnumerable<T3> third,
             Func<T1?, T2?, T3?, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl<T1, T2, T3, object, TResult>(first, second, third, null, (a, b, c, _) => resultSelector(a, b, c), 2);
         }
@@ -171,11 +172,11 @@ namespace MoreLinq
             IEnumerable<T4> fourth,
             Func<T1?, T2?, T3?, T4?, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl(first, second, third, fourth, resultSelector, 3);
         }

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq
 {
+	using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 
@@ -64,9 +65,9 @@ namespace MoreLinq
             IEnumerable<TSecond> second,
             Func<TFirst, TSecond, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl<TFirst, TSecond, object, object, TResult>(first, second, null, null, (a, b, _, _) => resultSelector(a, b));
         }
@@ -119,10 +120,10 @@ namespace MoreLinq
             IEnumerable<T3> third,
             Func<T1, T2, T3, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl<T1, T2, T3, object, TResult>(first, second, third, null, (a, b, c, _) => resultSelector(a, b, c));
         }
@@ -179,11 +180,11 @@ namespace MoreLinq
             IEnumerable<T4> fourth,
             Func<T1, T2, T3, T4, TResult> resultSelector)
         {
-            if (first == null) throw new ArgumentNullException(nameof(first));
-            if (second == null) throw new ArgumentNullException(nameof(second));
-            if (third == null) throw new ArgumentNullException(nameof(third));
-            if (fourth == null) throw new ArgumentNullException(nameof(fourth));
-            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+            Guard.IsNotNull(first);
+            Guard.IsNotNull(second);
+            Guard.IsNotNull(third);
+            Guard.IsNotNull(fourth);
+            Guard.IsNotNull(resultSelector);
 
             return ZipImpl(first, second, third, fourth, resultSelector);
         }

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -17,7 +17,7 @@
 
 namespace MoreLinq
 {
-	using CommunityToolkit.Diagnostics;
+    using CommunityToolkit.Diagnostics;
     using System;
     using System.Collections.Generic;
 


### PR DESCRIPTION
This PR migrates code contracts for methods to `CommunityToolkit.Diagnostics` support methods. This has several advantages:
* Improves chance that error-checking host method will be inlined, possibly improving performance
* Reduces possibility human error by specifying parameter name only once
* Reduces boilerplate code.

Fixes #903 

Tasks:
* [x] `ArgumentNullException`
* [x] `ArgumentOutOfRangeException`
* [x] `ArgumentException`
* [x] `InvalidOperationException` (??)
