### PR TITLE
Rename read-only list/collection field of `ListLike`/`CollectionLike`

### DIFF
--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -30,23 +30,23 @@ namespace MoreLinq
     readonly struct CollectionLike<T>
     {
         readonly ICollection<T>? _rw;
-        readonly IReadOnlyCollection<T>? _rx;
+        readonly IReadOnlyCollection<T>? _ro;
 
         public CollectionLike(ICollection<T> collection)
         {
             _rw = collection ?? throw new ArgumentNullException(nameof(collection));
-            _rx = null;
+            _ro = null;
         }
 
         public CollectionLike(IReadOnlyCollection<T> collection)
         {
             _rw = null;
-            _rx = collection ?? throw new ArgumentNullException(nameof(collection));
+            _ro = collection ?? throw new ArgumentNullException(nameof(collection));
         }
 
-        public int Count => _rw?.Count ?? _rx?.Count ?? 0;
+        public int Count => _rw?.Count ?? _ro?.Count ?? 0;
 
         public IEnumerator<T> GetEnumerator() =>
-            _rw?.GetEnumerator() ?? _rx?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
+            _rw?.GetEnumerator() ?? _ro?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
     }
 }

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -30,24 +30,24 @@ namespace MoreLinq
     readonly struct ListLike<T>
     {
         readonly IList<T>? _rw;
-        readonly IReadOnlyList<T>? _rx;
+        readonly IReadOnlyList<T>? _ro;
 
         public ListLike(IList<T> list)
         {
             _rw = list ?? throw new ArgumentNullException(nameof(list));
-            _rx = null;
+            _ro = null;
         }
 
         public ListLike(IReadOnlyList<T> list)
         {
             _rw = null;
-            _rx = list ?? throw new ArgumentNullException(nameof(list));
+            _ro = list ?? throw new ArgumentNullException(nameof(list));
         }
 
-        public int Count => _rw?.Count ?? _rx?.Count ?? 0;
+        public int Count => _rw?.Count ?? _ro?.Count ?? 0;
 
         public T this[int index] => _rw is { } rw ? rw[index]
-                                  : _rx is { } rx ? rx[index]
+                                  : _ro is { } rx ? rx[index]
                                   : throw new ArgumentOutOfRangeException(nameof(index));
     }
 


### PR DESCRIPTION
This PR addresses the [feedback](https://github.com/morelinq/MoreLINQ/pull/472#discussion_r1085222239) from @fsateler on PR #472:

> `rx` means `read-execute` in the unix model. Perhaps `_ro` for `read-only` might be better?