### PR TITLE
Consolidate structural differences in `*Like` types

### DIFF
--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -49,4 +49,16 @@ namespace MoreLinq
         public IEnumerator<T> GetEnumerator() =>
             _rw?.GetEnumerator() ?? _rx?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
     }
+
+    static class CollectionLike
+    {
+        public static CollectionLike<T>? TryAsCollectionLike<T>(this IEnumerable<T> source) =>
+            source switch
+            {
+                null => throw new ArgumentNullException(nameof(source)),
+                ICollection<T> collection => new(collection),
+                IReadOnlyCollection<T> collection => new(collection),
+                _ => null
+            };
+    }
 }

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -54,8 +54,6 @@ namespace MoreLinq
     static class ListLike
     {
         public static ListLike<T> AsListLike<T>(this List<T> list) => new((IList<T>)list);
-        public static ListLike<T> AsListLike<T>(this IList<T> list) => new(list);
-        public static ListLike<T> AsListLike<T>(this IReadOnlyList<T> list) => new(list);
 
         public static ListLike<T> ToListLike<T>(this IEnumerable<T> source)
             => source.TryAsListLike() ?? source.ToList().AsListLike();
@@ -64,8 +62,8 @@ namespace MoreLinq
             source switch
             {
                 null => throw new ArgumentNullException(nameof(source)),
-                IList<T> list => list.AsListLike(),
-                IReadOnlyList<T> list => list.AsListLike(),
+                IList<T> list => new(list),
+                IReadOnlyList<T> list => new(list),
                 _ => null
             };
     }

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -27,15 +27,6 @@ namespace MoreLinq
 
     public static partial class MoreEnumerable
     {
-        internal static CollectionLike<T>? TryAsCollectionLike<T>(this IEnumerable<T> source) =>
-            source switch
-            {
-                null => throw new ArgumentNullException(nameof(source)),
-                ICollection<T> collection => new CollectionLike<T>(collection),
-                IReadOnlyCollection<T> collection => new CollectionLike<T>(collection),
-                _ => null
-            };
-
         static int CountUpTo<T>(this IEnumerable<T> source, int max)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));


### PR DESCRIPTION
This PR consolidate structural differences between `CollectionLike<T>` and `ListLike<T>`:

- The `TryAsCollectionLike` as extension is moved to `CollectionLike`.
- Type construction helpers for `ListLike<T>` are in-lined due to single use.
