### PR TITLE
Revoke (obsolete) disabling of parallel builds

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -120,9 +120,6 @@
     <VersionPrefix>3.3.2</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
     <TargetFrameworks>net462;netstandard1.0;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <!-- Parallel build is disabled to avoid file locking issues during T4 code generation.
-         See also: https://github.com/dotnet/msbuild/issues/2781 -->
-    <BuildInParallel>false</BuildInParallel>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MoreLinq</AssemblyName>


### PR DESCRIPTION
Since `dotnet t4` is no longer invoked during a build via the project file (since #940), the disabling of parallel builds that was done as a specific workaround for T4 no longer applies and therefore this PR removes that disabling. It should have been done as part of PR #940.
