### PR TITLE
Run T4 templates if targets are out-of-date

### DIFF
--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -157,6 +157,7 @@
 
   <ItemGroup>
     <None Include="..\COPYING.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
+    <None Include="*.g.tt" />
     <None Update="Aggregate.g.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Aggregate.g.cs</LastGenOutput>
@@ -246,5 +247,32 @@
       <DependentUpon>ToDelimitedString.g.tt</DependentUpon>
     </Compile>
   </ItemGroup>
+
+  <Target Name="_CollectTextTemplates">
+    <ItemGroup>
+      <TextTemplate Include="%(None.Identity)" Condition="'%(None.Generator)' == 'TextTemplatingFileGenerator'">
+        <LastGenOutput>%(None.LastGenOutput)</LastGenOutput>
+      </TextTemplate>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_TransformTextTemplate" Inputs="$(TextTemplate)" Outputs="$(TextTemplateOutput)">
+    <Exec Command="dotnet t4 -h &gt; /dev/null" IgnoreExitCode="True" Condition="'$(WINDIR)' == ''">
+      <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
+    </Exec>
+    <Exec Command="dotnet t4 -h &gt; NUL" IgnoreExitCode="True" Condition="'$(WINDIR)' != ''">
+      <Output TaskParameter="ExitCode" PropertyName="_TestExitCode" />
+    </Exec>
+    <Exec Command="dotnet tool restore" Condition="$(_TestExitCode) != 0" />
+    <Message Text="dotnet t4 $(TextTemplate) -o $(TextTemplateOutput)" Importance="High" />
+    <Exec Command="dotnet t4 $(TextTemplate) -o $(TextTemplateOutput)" />
+  </Target>
+
+  <Target Name="TransformTextTemplates"
+          DependsOnTargets="_CollectTextTemplates">
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_TransformTextTemplate"
+             Properties="TextTemplate=%(TextTemplate.Identity);TextTemplateOutput=%(TextTemplate.LastGenOutput)"  />
+  </Target>
 
 </Project>

--- a/MoreLinq/tt.cmd
+++ b/MoreLinq/tt.cmd
@@ -1,8 +1,1 @@
-@echo off
-pushd "%~dp0"
-for /f "tokens=*" %%f in ('dir /s /b *.tt') do (
-    echo>&2 dotnet t4 "%%f"
-    dotnet t4 "%%f" || goto :end
-)
-:end
-popd
+@dotnet build "%~dp0MoreLinq.csproj" -t:TransformTextTemplates %*

--- a/MoreLinq/tt.sh
+++ b/MoreLinq/tt.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
-find . -name "*.tt" -print0 | xargs -0 -t -L 1 sh -c '(dotnet t4 "$0" || exit 255)'
+dotnet build -t:TransformTextTemplates "$@"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,8 @@ install:
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info
+# Touch T4 templates to force code generation & validation
+- touch MoreLinq/*.g.tt
 build_script:
 - pwsh: |
     grep --extended-regexp '^[[:space:]]*using[[:space:]]+System\.Linq;' (dir -Recurse -File -Filter *Test.cs MoreLinq.Test)


### PR DESCRIPTION
This PR restores some of PR #776 to re-integrate `dotnet t4` invocation from the project, but taking advantage of conditional execution of targets only if the outputs are out-of-date with respect to inputs.

During the CI builds, the templates are _touched_ to update their timestamps and force execution of the templates to later validate that generated code is fresh.
