### PR TITLE
Discard unused expression value (IDE0058)

### DIFF
--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
 
                 try
                 {
-                    method.Invoke(null, args);
+                    _ = method.Invoke(null, args);
                 }
                 catch (TargetInvocationException tie)
                 {


### PR DESCRIPTION
This PR discards an unused expression value that should (and eventually would) have been triggered by [IDE0058](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058).