### PR TITLE
Remove testing on .NET Core 3.1 that's no longer supported

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType Condition="'$(TargetFramework)' == 'net462'">Exe</OutputType>

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
 
                 try
                 {
-                    method.Invoke(null, args);
+                    _ = method.Invoke(null, args);
                 }
                 catch (TargetInvocationException tie)
                 {
@@ -57,12 +57,6 @@ namespace MoreLinq.Test
                 Debug.Assert(e is not null);
                 var stackTrace = new StackTrace(e, false);
                 var stackFrame = stackTrace.GetFrames().First();
-#if NETCOREAPP3_1
-                // Under .NET Core 3.1, "StackTrace.GetFrames()" was defined to return an array
-                // of nullable frame elements. See:
-                // https://github.com/dotnet/corefx/blob/v3.1.32/src/Common/src/CoreLib/System/Diagnostics/StackTrace.cs#L162
-                Debug.Assert(stackFrame is not null);
-#endif
                 var actualType = stackFrame.GetMethod()?.DeclaringType;
                 Assert.That(actualType, Is.SameAs(typeof(MoreEnumerable)));
             });

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,10 +53,8 @@ install:
 - eclint check -w "**/*.{cs,tt,cmd,sh,md,txt,yml,json,sln,csproj,shfbproj}"
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
-- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 3.1.10 -SkipNonVersionedFiles }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 6.0.11 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
-- sh: ./tools/dotnet-install.sh --runtime dotnet --version 3.1.10 --skip-non-versioned-files
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 6.0.11 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:

--- a/test.cmd
+++ b/test.cmd
@@ -12,8 +12,6 @@ call build ^
   && call :test net7.0 Release ^
   && call :test net6.0 Debug ^
   && call :test net6.0 Release ^
-  && call :test netcoreapp3.1 Debug ^
-  && call :test netcoreapp3.1 Release ^
   && call :test net462 Debug ^
   && call :test net462 Release ^
   && call :report-cover

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in netcoreapp3.1 net6.0 net7.0; do
+for f in net6.0 net7.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"


### PR DESCRIPTION
This PR removes testing on [.NET Core 3.1](https://dotnet.microsoft.com/en-us/download/dotnet/3.1) that's no longer supported since last month (December 13, 2022).
