### PR TITLE
Add new `SourceKind`: `Collection` and `List` and use it for `EndsWith` tests.

### DIFF
--- a/MoreLinq.Test/Collection.cs
+++ b/MoreLinq.Test/Collection.cs
@@ -1,0 +1,50 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2023 Pierre Lando. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// This class is a wrapper around a <see cref="IList{T}"/> that only implement <see cref="ICollection{T}"/>.
+    /// </summary>
+    sealed class Collection<T> : ICollection<T>
+    {
+        readonly IList<T> _list;
+
+        public Collection(IList<T> list) => _list = list;
+
+        public int Count => _list.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(T item) => _list.Add(item);
+
+        public void Clear() => _list.Clear();
+
+        public bool Contains(T item) => _list.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_list).GetEnumerator();
+
+        public bool Remove(T item) => _list.Remove(item);
+    }
+}

--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -24,6 +24,9 @@ namespace MoreLinq.Test
     [TestFixture]
     public class EndsWithTest
     {
+        [TestCase(new int[0], new int[0], ExpectedResult = true)]
+        [TestCase(new int[0], new[] { 1, 2, 3 }, ExpectedResult = false)]
+        [TestCase(new[] { 1, 2, 3 }, new int[0], ExpectedResult = true)]
         [TestCase(new[] { 1, 2, 3 }, new[] { 2, 3 }, ExpectedResult = true)]
         [TestCase(new[] { 1, 2, 3 }, new[] { 1, 2, 3 }, ExpectedResult = true)]
         [TestCase(new[] { 1, 2, 3 }, new[] { 0, 1, 2, 3 }, ExpectedResult = false)]
@@ -40,30 +43,13 @@ namespace MoreLinq.Test
             return first.EndsWith(second);
         }
 
+        [TestCase("", "", ExpectedResult = true)]
+        [TestCase("", "1", ExpectedResult = false)]
+        [TestCase("1", "", ExpectedResult = true)]
         [TestCase("123", "23", ExpectedResult = true)]
         [TestCase("123", "123", ExpectedResult = true)]
         [TestCase("123", "0123", ExpectedResult = false)]
         public bool EndsWithWithStrings(string first, string second)
-        {
-            // Conflict with String.EndsWith(), which has precedence in this case
-            return MoreEnumerable.EndsWith(first, second);
-        }
-
-        [Test]
-        public void EndsWithReturnsTrueIfBothEmpty()
-        {
-            Assert.That(new int[0].EndsWith(new int[0]), Is.True);
-        }
-
-        [Test]
-        public void EndsWithReturnsFalseIfOnlyFirstIsEmpty()
-        {
-            Assert.That(new int[0].EndsWith(new[] { 1, 2, 3 }), Is.False);
-        }
-
-        [TestCase("", "", ExpectedResult = true)]
-        [TestCase("1", "", ExpectedResult = true)]
-        public bool EndsWithReturnsTrueIfSecondIsEmpty(string first, string second)
         {
             // Conflict with String.EndsWith(), which has precedence in this case
             return MoreEnumerable.EndsWith(first, second);

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -25,6 +25,8 @@ namespace MoreLinq.Test
     public enum SourceKind
     {
         Sequence,
+        Collection,
+        List,
         BreakingList,
         BreakingReadOnlyList,
         BreakingCollection,
@@ -91,6 +93,8 @@ namespace MoreLinq.Test
             sourceKind switch
             {
                 SourceKind.Sequence => input.Select(x => x),
+                SourceKind.Collection => new Collection<T>(input.ToList()),
+                SourceKind.List => input.ToList(),
                 SourceKind.BreakingList => new BreakingList<T>(input.ToList()),
                 SourceKind.BreakingReadOnlyList => new BreakingReadOnlyList<T>(input.ToList()),
                 SourceKind.BreakingCollection => new BreakingCollection<T>(input.ToList()),


### PR DESCRIPTION
Fix for #676/EndsWith.

This is WIP, I'm not happy on how all `Sequence`/`Collection`/`List` cases are built.  
I didn't find yet a nice way to mix `TestCase` and `Values` NUnit attributes.