### PR TITLE
Simplify `Fold` Implementation

### DIFF
--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -18,79 +18,9 @@
 namespace MoreLinq
 {
     using System;
-    using System.Collections.Generic;
 
     static partial class MoreEnumerable
     {
-        static TResult FoldImpl<T, TResult>(IEnumerable<T> source, int count,
-            Func<T, TResult>? folder1 = null,
-            Func<T, T, TResult>? folder2 = null,
-            Func<T, T, T, TResult>? folder3 = null,
-            Func<T, T, T, T, TResult>? folder4 = null,
-            Func<T, T, T, T, T, TResult>? folder5 = null,
-            Func<T, T, T, T, T, T, TResult>? folder6 = null,
-            Func<T, T, T, T, T, T, T, TResult>? folder7 = null,
-            Func<T, T, T, T, T, T, T, T, TResult>? folder8 = null,
-            Func<T, T, T, T, T, T, T, T, T, TResult>? folder9 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, TResult>? folder10 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, TResult>? folder11 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult>? folder12 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult>? folder13 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult>? folder14 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult>? folder15 = null,
-            Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult>? folder16 = null
-            )
-        {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (   count ==  1 && folder1  == null
-                || count ==  2 && folder2  == null
-                || count ==  3 && folder3  == null
-                || count ==  4 && folder4  == null
-                || count ==  5 && folder5  == null
-                || count ==  6 && folder6  == null
-                || count ==  7 && folder7  == null
-                || count ==  8 && folder8  == null
-                || count ==  9 && folder9  == null
-                || count == 10 && folder10 == null
-                || count == 11 && folder11 == null
-                || count == 12 && folder12 == null
-                || count == 13 && folder13 == null
-                || count == 14 && folder14 == null
-                || count == 15 && folder15 == null
-                || count == 16 && folder16 == null
-                )
-            {                                                // ReSharper disable NotResolvedInText
-#pragma warning disable CA2208 // Instantiate argument exceptions correctly
-                throw new ArgumentNullException("folder");   // ReSharper restore NotResolvedInText
-#pragma warning restore CA2208 // Instantiate argument exceptions correctly
-            }
-
-            var elements = new T[count];
-            foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
-            return count switch
-            {
-                 1 => Assume.NotNull(folder1 )(elements[0]),
-                 2 => Assume.NotNull(folder2 )(elements[0], elements[1]),
-                 3 => Assume.NotNull(folder3 )(elements[0], elements[1], elements[2]),
-                 4 => Assume.NotNull(folder4 )(elements[0], elements[1], elements[2], elements[3]),
-                 5 => Assume.NotNull(folder5 )(elements[0], elements[1], elements[2], elements[3], elements[4]),
-                 6 => Assume.NotNull(folder6 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]),
-                 7 => Assume.NotNull(folder7 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]),
-                 8 => Assume.NotNull(folder8 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]),
-                 9 => Assume.NotNull(folder9 )(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]),
-                10 => Assume.NotNull(folder10)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]),
-                11 => Assume.NotNull(folder11)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]),
-                12 => Assume.NotNull(folder12)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]),
-                13 => Assume.NotNull(folder13)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]),
-                14 => Assume.NotNull(folder14)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]),
-                15 => Assume.NotNull(folder15)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]),
-                16 => Assume.NotNull(folder16)(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]),
-                _ => throw new NotSupportedException()
-            };
-        }
-
         static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
 
         static Exception OnFolderSourceSizeError(int cmp, int count) =>

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,15 +25,10 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            foreach (var e in source.Index().AssertCount(count, OnFolderSourceSizeErrorSelector))
+            foreach (var e in source.Index().AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))))
                 elements[e.Key] = e.Value;
 
             return elements;
         }
-
-        static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
-
-        static Exception OnFolderSourceSizeError(int cmp, int count) =>
-            new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count));
     }
 }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -22,9 +22,13 @@ namespace MoreLinq
 
     static partial class MoreEnumerable
     {
-        static T[] Fold<T>(this IEnumerable<T> source, int count) =>
-            source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count)))
-                  .Index()
-                  .ToArrayByIndex(count, e => e.Key, e => e.Value);
+        static T[] Fold<T>(this IEnumerable<T> source, int count)
+        {
+            var elements = new T[count];
+            foreach (var e in source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))).Index())
+                elements[e.Key] = e.Value;
+
+            return elements;
+        }
     }
 }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,10 +25,20 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            foreach (var e in source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))).Index())
-                elements[e.Key] = e.Value;
+            var i = 0;
+
+            foreach (var item in source)
+            {
+                elements[i] = i < count ? item : throw LengthError(1);
+                i++;
+            }
+
+            if (i < elements.Length)
+                throw LengthError(-1);
 
             return elements;
+
+            InvalidOperationException LengthError(int cmp) => new(FormatSequenceLengthErrorMessage(cmp, count));
         }
     }
 }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -22,13 +22,9 @@ namespace MoreLinq
 
     static partial class MoreEnumerable
     {
-        static T[] Fold<T>(this IEnumerable<T> source, int count)
-        {
-            var elements = new T[count];
-            foreach (var e in source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))).Index())
-                elements[e.Key] = e.Value;
-
-            return elements;
-        }
+        static T[] Fold<T>(this IEnumerable<T> source, int count) =>
+            source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count)))
+                  .Index()
+                  .ToArrayByIndex(count, e => e.Key, e => e.Value);
     }
 }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,7 +25,7 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
+            foreach (var e in source.Index().AssertCount(count, OnFolderSourceSizeErrorSelector))
                 elements[e.Key] = e.Value;
 
             return elements;

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,20 +25,15 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            var i = 0;
-
-            foreach (var item in source)
-            {
-                elements[i] = i < count ? item : throw LengthError(1);
-                i++;
-            }
-
-            if (i < elements.Length)
-                throw LengthError(-1);
+            foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
 
             return elements;
-
-            InvalidOperationException LengthError(int cmp) => new(FormatSequenceLengthErrorMessage(cmp, count));
         }
+
+        static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
+
+        static Exception OnFolderSourceSizeError(int cmp, int count) =>
+            new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count));
     }
 }

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -18,9 +18,19 @@
 namespace MoreLinq
 {
     using System;
+    using System.Collections.Generic;
 
     static partial class MoreEnumerable
     {
+        static T[] Fold<T>(this IEnumerable<T> source, int count)
+        {
+            var elements = new T[count];
+            foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return elements;
+        }
+
         static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
 
         static Exception OnFolderSourceSizeError(int cmp, int count) =>

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,7 +25,7 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            foreach (var e in source.Index().AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))))
+            foreach (var e in source.AssertCount(count, static (cmp, count) => new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count))).Index())
                 elements[e.Key] = e.Value;
 
             return elements;

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -44,10 +44,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[1];
-            foreach (var e in AssertCountImpl(source.Index(), 1, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(1);
             return folder(elements[0]);
         }
 
@@ -73,10 +70,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[2];
-            foreach (var e in AssertCountImpl(source.Index(), 2, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(2);
             return folder(elements[0], elements[1]);
         }
 
@@ -102,10 +96,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[3];
-            foreach (var e in AssertCountImpl(source.Index(), 3, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(3);
             return folder(elements[0], elements[1], elements[2]);
         }
 
@@ -131,10 +122,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[4];
-            foreach (var e in AssertCountImpl(source.Index(), 4, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(4);
             return folder(elements[0], elements[1], elements[2], elements[3]);
         }
 
@@ -160,10 +148,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[5];
-            foreach (var e in AssertCountImpl(source.Index(), 5, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(5);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4]);
         }
 
@@ -189,10 +174,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[6];
-            foreach (var e in AssertCountImpl(source.Index(), 6, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(6);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
         }
 
@@ -218,10 +200,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[7];
-            foreach (var e in AssertCountImpl(source.Index(), 7, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(7);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
         }
 
@@ -247,10 +226,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[8];
-            foreach (var e in AssertCountImpl(source.Index(), 8, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(8);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
         }
 
@@ -276,10 +252,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[9];
-            foreach (var e in AssertCountImpl(source.Index(), 9, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(9);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
         }
 
@@ -305,10 +278,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[10];
-            foreach (var e in AssertCountImpl(source.Index(), 10, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(10);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
         }
 
@@ -334,10 +304,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[11];
-            foreach (var e in AssertCountImpl(source.Index(), 11, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(11);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
         }
 
@@ -363,10 +330,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[12];
-            foreach (var e in AssertCountImpl(source.Index(), 12, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(12);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
         }
 
@@ -392,10 +356,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[13];
-            foreach (var e in AssertCountImpl(source.Index(), 13, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(13);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
         }
 
@@ -421,10 +382,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[14];
-            foreach (var e in AssertCountImpl(source.Index(), 14, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(14);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
         }
 
@@ -450,10 +408,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[15];
-            foreach (var e in AssertCountImpl(source.Index(), 15, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(15);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
         }
 
@@ -479,10 +434,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[16];
-            foreach (var e in AssertCountImpl(source.Index(), 16, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(16);
             return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
         }
 

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -41,7 +41,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
         {
-            return FoldImpl(source, 1, folder1: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[1];
+            foreach (var e in AssertCountImpl(source.Index(), 1, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0]);
         }
 
         /// <summary>
@@ -63,7 +70,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
         {
-            return FoldImpl(source, 2, folder2: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[2];
+            foreach (var e in AssertCountImpl(source.Index(), 2, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1]);
         }
 
         /// <summary>
@@ -85,7 +99,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 3, folder3: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[3];
+            foreach (var e in AssertCountImpl(source.Index(), 3, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2]);
         }
 
         /// <summary>
@@ -107,7 +128,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 4, folder4: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[4];
+            foreach (var e in AssertCountImpl(source.Index(), 4, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3]);
         }
 
         /// <summary>
@@ -129,7 +157,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 5, folder5: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[5];
+            foreach (var e in AssertCountImpl(source.Index(), 5, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4]);
         }
 
         /// <summary>
@@ -151,7 +186,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 6, folder6: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[6];
+            foreach (var e in AssertCountImpl(source.Index(), 6, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5]);
         }
 
         /// <summary>
@@ -173,7 +215,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 7, folder7: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[7];
+            foreach (var e in AssertCountImpl(source.Index(), 7, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6]);
         }
 
         /// <summary>
@@ -195,7 +244,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 8, folder8: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[8];
+            foreach (var e in AssertCountImpl(source.Index(), 8, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7]);
         }
 
         /// <summary>
@@ -217,7 +273,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 9, folder9: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[9];
+            foreach (var e in AssertCountImpl(source.Index(), 9, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8]);
         }
 
         /// <summary>
@@ -239,7 +302,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 10, folder10: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[10];
+            foreach (var e in AssertCountImpl(source.Index(), 10, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9]);
         }
 
         /// <summary>
@@ -261,7 +331,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 11, folder11: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[11];
+            foreach (var e in AssertCountImpl(source.Index(), 11, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10]);
         }
 
         /// <summary>
@@ -283,7 +360,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 12, folder12: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[12];
+            foreach (var e in AssertCountImpl(source.Index(), 12, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11]);
         }
 
         /// <summary>
@@ -305,7 +389,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 13, folder13: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[13];
+            foreach (var e in AssertCountImpl(source.Index(), 13, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12]);
         }
 
         /// <summary>
@@ -327,7 +418,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 14, folder14: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[14];
+            foreach (var e in AssertCountImpl(source.Index(), 14, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13]);
         }
 
         /// <summary>
@@ -349,7 +447,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 15, folder15: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[15];
+            foreach (var e in AssertCountImpl(source.Index(), 15, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14]);
         }
 
         /// <summary>
@@ -371,7 +476,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
-            return FoldImpl(source, 16, folder16: folder);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[16];
+            foreach (var e in AssertCountImpl(source.Index(), 16, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(elements[0], elements[1], elements[2], elements[3], elements[4], elements[5], elements[6], elements[7], elements[8], elements[9], elements[10], elements[11], elements[12], elements[13], elements[14], elements[15]);
         }
 
     }

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -34,7 +34,6 @@ namespace MoreLinq
             select new
             {
                 Ts            = string.Join(", ", Enumerable.Repeat("T", i)),
-                Count         = i,
                 CountElements = istr + " " + (i == 1 ? "element" : "elements"),
                 CountArg      = istr,
                 Elements      = string.Join(", ", from j in Enumerable.Range(0, i)
@@ -64,7 +63,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = source.Fold(<#= e.Count #>);
+            var elements = source.Fold(<#= e.CountArg #>);
             return folder(<#= e.Elements #>);
         }
 

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -64,10 +64,7 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (folder == null) throw new ArgumentNullException(nameof(folder));
 
-            var elements = new T[<#= e.Count #>];
-            foreach (var e in AssertCountImpl(source.Index(), <#= e.Count #>, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
-
+            var elements = source.Fold(<#= e.Count #>);
             return folder(<#= e.Elements #>);
         }
 

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -38,7 +38,7 @@ namespace MoreLinq
                 CountElements = istr + " " + (i == 1 ? "element" : "elements"),
                 CountArg      = istr,
                 FolderArgs    = "folder" + istr + ": folder",
-
+                Elements      = string.Join(", ", Enumerable.Range(0, i).Select(j => $"elements[{j}]")),
             };
 
         foreach (var e in overloads) { #>
@@ -61,7 +61,14 @@ namespace MoreLinq
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<<#= e.Ts #>, TResult> folder)
         {
-            return FoldImpl(source, <#= e.CountArg #>, <#= e.FolderArgs #>);
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (folder == null) throw new ArgumentNullException(nameof(folder));
+
+            var elements = new T[<#= e.Count #>];
+            foreach (var e in AssertCountImpl(source.Index(), <#= e.Count #>, OnFolderSourceSizeErrorSelector))
+                elements[e.Key] = e.Value;
+
+            return folder(<#= e.Elements #>);
         }
 
 <#      } #>

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -37,8 +37,8 @@ namespace MoreLinq
                 Count         = i,
                 CountElements = istr + " " + (i == 1 ? "element" : "elements"),
                 CountArg      = istr,
-                Elements      = string.Join(", ", Enumerable.Range(0, i)
-                                                            .Select(j => FormattableString.Invariant($"elements[{j}]"))),
+                Elements      = string.Join(", ", from j in Enumerable.Range(0, i)
+                                                  select FormattableString.Invariant($"elements[{j}]")),
             };
 
         foreach (var e in overloads) { #>

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -37,8 +37,8 @@ namespace MoreLinq
                 Count         = i,
                 CountElements = istr + " " + (i == 1 ? "element" : "elements"),
                 CountArg      = istr,
-                FolderArgs    = "folder" + istr + ": folder",
-                Elements      = string.Join(", ", Enumerable.Range(0, i).Select(j => $"elements[{j}]")),
+                Elements      = string.Join(", ", Enumerable.Range(0, i)
+                    .Select(j => FormattableString.Invariant($"elements[{j}]"))),
             };
 
         foreach (var e in overloads) { #>

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -38,7 +38,7 @@ namespace MoreLinq
                 CountElements = istr + " " + (i == 1 ? "element" : "elements"),
                 CountArg      = istr,
                 Elements      = string.Join(", ", Enumerable.Range(0, i)
-                    .Select(j => FormattableString.Invariant($"elements[{j}]"))),
+                                                            .Select(j => FormattableString.Invariant($"elements[{j}]"))),
             };
 
         foreach (var e in overloads) { #>


### PR DESCRIPTION
This PR simplifies the implementation of `Fold`. The existing `FoldImpl` is unnecessary and onerous to maintain. Since it receives 18 arguments, it must check which one should be non-`null` and then it must select that one for `Fold`ing. This a) creates additional branches and code bloat, and b) adds an additional method that must be maintained. 

It is better to have each overload of `Fold` do what it needs to do directly. This avoids branching and the `Assume.NotNull()` check, and simplifies the code significantly.