### PR TITLE
Add `CopyTo` operator

### DIFF
--- a/MoreLinq.Test/CopyToTest.cs
+++ b/MoreLinq.Test/CopyToTest.cs
@@ -1,0 +1,144 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2009 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CopyToTest
+    {
+        [Test]
+        public void ThrowsOnNegativeIndex()
+        {
+            Assert.That(
+                () => new BreakingSequence<int>().CopyTo(Array.Empty<int>(), -1),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void ThrowsOnTooMuchDataForArray()
+        {
+            Assert.That(
+                () => MoreEnumerable.From(() => 1).CopyTo(Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => Enumerable.Range(1, 1).CopyTo(Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => new List<int> { 1 }.AsEnumerable().CopyTo(Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => new List<int> { 1 }.AsReadOnly().AsEnumerable().CopyTo(Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void ThrowsOnTooMuchDataForIListArray()
+        {
+            Assert.That(
+                () => MoreEnumerable.From(() => 1).CopyTo((IList<int>)Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => Enumerable.Range(1, 1).CopyTo((IList<int>)Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => new List<int> { 1 }.AsEnumerable().CopyTo((IList<int>)Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+            Assert.That(
+                () => new List<int> { 1 }.AsReadOnly().AsEnumerable().CopyTo((IList<int>)Array.Empty<int>()),
+                Throws.TypeOf<ArgumentException>());
+        }
+
+        [Test]
+        public void CopiesDataToArray()
+        {
+            var array = new int[4];
+
+            using var xs = TestingSequence.Of(1);
+            var cnt = xs.CopyTo(array);
+            array.AssertSequenceEqual(1, 0, 0, 0);
+            Assert.That(cnt, Is.EqualTo(1));
+
+            cnt = new List<int> { 2 }.AsEnumerable().CopyTo(array, 1);
+            array.AssertSequenceEqual(1, 2, 0, 0);
+            Assert.That(cnt, Is.EqualTo(1));
+
+            cnt = Enumerable.Range(3, 1).CopyTo(array, 2);
+            array.AssertSequenceEqual(1, 2, 3, 0);
+            Assert.That(cnt, Is.EqualTo(1));
+
+            cnt = new[] { 4, }.AsEnumerable().CopyTo(array, 3);
+            array.AssertSequenceEqual(1, 2, 3, 4);
+            Assert.That(cnt, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CopiesDataToList()
+        {
+            var list = new List<int>();
+
+            var cnt = new[] { 1, }.AsEnumerable().CopyTo(list);
+            list.AssertSequenceEqual(1);
+            Assert.That(cnt, Is.EqualTo(1));
+
+            using (var xs = TestingSequence.Of(2))
+            {
+                cnt = xs.CopyTo(list, 1);
+                list.AssertSequenceEqual(1, 2);
+                Assert.That(cnt, Is.EqualTo(1));
+            }
+
+            using (var xs = TestingSequence.Of(3, 4))
+            {
+                cnt = xs.AsEnumerable().CopyTo(list, 1);
+                list.AssertSequenceEqual(1, 3, 4);
+                Assert.That(cnt, Is.EqualTo(2));
+            }
+        }
+
+        [Test]
+        public void CopiesDataToIList()
+        {
+            var list = new Collection<int>();
+
+            using (var xs = TestingSequence.Of(1))
+            {
+                var cnt = xs.CopyTo(list);
+                list.AssertSequenceEqual(1);
+                Assert.That(cnt, Is.EqualTo(1));
+            }
+
+            using (var xs = TestingSequence.Of(2))
+            {
+                var cnt = xs.CopyTo(list, 1);
+                list.AssertSequenceEqual(1, 2);
+                Assert.That(cnt, Is.EqualTo(1));
+            }
+
+            using (var xs = TestingSequence.Of(3, 4))
+            {
+                var cnt = xs.CopyTo(list, 1);
+                list.AssertSequenceEqual(1, 3, 4);
+                Assert.That(cnt, Is.EqualTo(2));
+            }
+        }
+    }
+}

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -223,6 +223,9 @@ namespace MoreLinq.Test
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes
 
+            public sealed class List<T> : System.Collections.Generic.List<T>
+            { }
+
             public sealed class OrderedEnumerable<T> : Enumerable<T>, System.Linq.IOrderedEnumerable<T?>
             {
                 public System.Linq.IOrderedEnumerable<T?> CreateOrderedEnumerable<TKey>(Func<T, TKey> keySelector, IComparer<TKey>? comparer, bool descending)

--- a/MoreLinq/CopyTo.cs
+++ b/MoreLinq/CopyTo.cs
@@ -1,0 +1,172 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2023 Turning Code, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Copies the contents of a sequence into a provided array.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="array">The array that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="array"/> is not long enough to hold the data from
+        /// sequence.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="array"/> if possible. If <paramref
+        /// name="source"/> is shorter than <paramref name="array"/>, then any remaining elements will be untouched. If
+        /// <paramref name="source"/> is longer than <paramref name="array"/>, then an exception will be thrown.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, TSource[] array)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (array == null) throw new ArgumentNullException(nameof(array));
+
+            return CopyTo(source, array, 0);
+        }
+
+        static int CopyTo<TSource>(IEnumerable<TSource> source, TSource[] array, int index)
+        {
+            if (source is TSource[] arr)
+            {
+                arr.CopyTo(array, index);
+                return arr.Length;
+            }
+            else if (source is ICollection<TSource> coll)
+            {
+                coll.CopyTo(array, index);
+                return coll.Count;
+            }
+            else if (source.TryAsCollectionLike() is CollectionLike<TSource> c)
+            {
+                if (c.Count + index > array.Length)
+                    throw new ArgumentException("Destination is not long enough.", nameof(array));
+
+                var i = index;
+                foreach (var el in source)
+                    array[i++] = el;
+
+                return i - index;
+            }
+            else
+            {
+                var i = index;
+                foreach (var el in source)
+                {
+                    if (i >= array.Length)
+                        throw new ArgumentException("Destination is not long enough.", nameof(array));
+
+                    array[i++] = el;
+                }
+
+                return i - index;
+            }
+        }
+
+        /// <summary>
+        /// Copies the contents of a sequence into a provided list.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="list">The list that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="list"/>, starting at position 0.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list)
+        {
+            return source.CopyTo(list, 0);
+        }
+
+        /// <summary>
+        /// Copies the contents of a sequence into a provided list.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="list">The list that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <param name="index">The position in <paramref name="list"/> at which to start copying data</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="list"/>, starting at position
+        /// <paramref name="index"/>.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list, int index)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (index < 0) throw new ArgumentOutOfRangeException(nameof(index));
+
+            if (list is TSource[] array)
+            {
+                return CopyTo(source, array, index);
+            }
+            else
+            {
+#if NET6_0_OR_GREATER
+                if (list is List<TSource> l
+                    && source.TryAsCollectionLike() is CollectionLike<TSource> c)
+                {
+                    l.EnsureCapacity(c.Count + index);
+                }
+#endif
+
+                var i = index;
+                foreach (var el in source)
+                {
+                    if (i < list.Count)
+                        list[i] = el;
+                    else
+                        list.Add(el);
+                    i++;
+                }
+
+                return i - index;
+            }
+        }
+    }
+}

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -1123,6 +1123,84 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>CopyTo</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class CopyToExtension
+    {
+
+        /// <summary>
+        /// Copies the contents of a sequence into a provided list.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="list">The list that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="list"/>, starting at position 0.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list)
+            => MoreEnumerable.CopyTo(source, list);
+        /// <summary>
+        /// Copies the contents of a sequence into a provided array.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="array">The array that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="array"/> is not long enough to hold the data from
+        /// sequence.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="array"/> if possible. If <paramref
+        /// name="source"/> is shorter than <paramref name="array"/>, then any remaining elements will be untouched. If
+        /// <paramref name="source"/> is longer than <paramref name="array"/>, then an exception will be thrown.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, TSource[] array)
+            => MoreEnumerable.CopyTo(source, array);
+
+        /// <summary>
+        /// Copies the contents of a sequence into a provided list.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of elements of <paramref name="source"/></typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="list">The list that is the destination of the elements copied from <paramref
+        /// name="source"/>.</param>
+        /// <param name="index">The position in <paramref name="list"/> at which to start copying data</param>
+        /// <returns>The number of elements actually copied.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// <para>
+        /// All data from <paramref name="source"/> will be copied to <paramref name="list"/>, starting at position
+        /// <paramref name="index"/>.
+        /// </para>
+        /// <para>
+        /// This operator executes immediately.
+        /// </para>
+        /// </remarks>
+        public static int CopyTo<TSource>(this IEnumerable<TSource> source, IList<TSource> list, int index)
+            => MoreEnumerable.CopyTo(source, list, index);
+
+    }
+
     /// <summary><c>CountBetween</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]


### PR DESCRIPTION
This PR adds a `CopyTo` operator, which operates similar to `Array.CopyTo` or `List.CopyTo`. This is useful for copying data from a stream to a pre-existing array or `IList<>`, such as an array rented from an `ArrayPool<>`. 

To match semantics with existing methods, this method will throw an exception if there is not enough room in the specified destination for the input data to be stored. If the consumer does not care about excess data, they can apply the `Take` operator before calling `CopyTo` to avoid the exception.

One difference between this operator and the collection methods is that this version returns an `int`. With the collection methods, it is easy to know pre or post how much data should be copied, because the `Count`/`Length` property is available. For `IEnumerable<>` this information is not as readily available, so `CopyTo` returns how many elements were stored in the destination.

Fixes #963 
