### PR TITLE
Fix collection-optimized paths for `Batch`

### DIFF
--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -137,32 +137,17 @@ namespace MoreLinq.Test
         [TestCase(SourceKind.BreakingList)]
         [TestCase(SourceKind.BreakingReadOnlyList)]
         [TestCase(SourceKind.BreakingCollection)]
-        public void BatchCollectionSmallerThanSizeUsesCollectionCountAtIterationTime(SourceKind kind)
-        {
-            var list = new List<int> { 1, 2 };
-            var result = list.ToSourceKind(kind, copy: false).Batch(3);
-            list.Add(3);
-
-            result.AssertSequenceEqual(new[] { 1, 2, 3 });
-        }
-
-        [TestCase(SourceKind.BreakingList)]
-        [TestCase(SourceKind.BreakingReadOnlyList)]
-        [TestCase(SourceKind.BreakingCollection)]
         public void BatchUsesCollectionCountAtIterationTime(SourceKind kind)
         {
-            var list = new List<int>(Enumerable.Range(1, 3));
-            var result = list.ToSourceKind(kind, copy: false).Batch(3);
+            var list = new List<int> { 1, 2 };
+            var result = list.AsSourceKind(kind).Batch(3);
 
-            // should use `CopyTo`
-            result.AssertCount(1).Consume();
+            list.Add(3);
+            result.AssertSequenceEqual(new[] { 1, 2, 3 });
 
             list.Add(4);
-
             // should fail trying to enumerate
-            Assert.That(
-                () => result.AssertCount(2).Consume(),
-                Throws.TypeOf<BreakException>());
+            Assert.That(result.Consume, Throws.TypeOf<BreakException>());
         }
     }
 }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -133,6 +133,16 @@ namespace MoreLinq.Test
             var batches = Enumerable.Empty<int>().ToSourceKind(kind).Batch(100);
             Assert.That(batches, Is.Empty);
         }
+
+        [Test]
+        public void BatchUsesCollectionCountAtIterationTime()
+        {
+            var stack = new List<int>(Enumerable.Range(1, 3));
+            var result = stack.Batch(3);
+            stack.Add(4);
+            result.AssertCount(2).Consume();
+            Assert.Pass();
+        }
     }
 }
 

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -137,9 +137,12 @@ namespace MoreLinq.Test
         [Test]
         public void BatchUsesCollectionCountAtIterationTime()
         {
-            var stack = new List<int>(Enumerable.Range(1, 3));
-            var result = stack.Batch(3);
-            stack.Add(4);
+            var list = new List<int>(Enumerable.Range(1, 3));
+
+            var result = list.Batch(3);
+            result.AssertCount(1).Consume();
+
+            list.Add(4);
             result.AssertCount(2).Consume();
             Assert.Pass();
         }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -146,7 +146,7 @@ namespace MoreLinq.Test
             result.AssertSequenceEqual(new[] { 1, 2, 3 });
 
             list.Add(4);
-            // should fail trying to enumerate
+            // should fail trying to enumerate because count is now greater than the batch size
             Assert.That(result.Consume, Throws.TypeOf<BreakException>());
         }
     }

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -87,15 +87,18 @@ namespace MoreLinq.Test
                 yield return split;
         }
 
-        internal static IEnumerable<T> ToSourceKind<T>(this IEnumerable<T> input, SourceKind sourceKind) =>
+        internal static IEnumerable<T> ToSourceKind<T>(this IEnumerable<T> input, SourceKind sourceKind, bool copy = true) =>
             sourceKind switch
             {
-                SourceKind.Sequence => input.Select(x => x),
-                SourceKind.BreakingList => new BreakingList<T>(input.ToList()),
-                SourceKind.BreakingReadOnlyList => new BreakingReadOnlyList<T>(input.ToList()),
-                SourceKind.BreakingCollection => new BreakingCollection<T>(input.ToList()),
-                SourceKind.BreakingReadOnlyCollection => new BreakingReadOnlyCollection<T>(input.ToList()),
+                SourceKind.Sequence => copy ? input.Select(x => x) : throw new InvalidOperationException("Invalid to keep original as sequence."),
+                SourceKind.BreakingList => new BreakingList<T>(copy ? input.ToList() : input.SafeCast<List<T>>()),
+                SourceKind.BreakingReadOnlyList => new BreakingReadOnlyList<T>(copy ? input.ToList() : input.SafeCast<List<T>>()),
+                SourceKind.BreakingCollection => new BreakingCollection<T>(copy ? input.ToList() : input.SafeCast<List<T>>()),
+                SourceKind.BreakingReadOnlyCollection => new BreakingReadOnlyCollection<T>(copy ? input.ToList() : input.SafeCast<List<T>>()),
                 _ => throw new ArgumentException(null, nameof(sourceKind))
             };
+
+        internal static T SafeCast<T>(this object obj) where T : class =>
+            obj is T t ? t : throw new InvalidOperationException($"Must pass an object of type `{typeof(T)}`.");
     }
 }

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -86,7 +86,7 @@ namespace MoreLinq.Test
             foreach (var split in str.Split(separators))
                 yield return split;
         }
- 
+
         internal static IEnumerable<T> ToSourceKind<T>(this IEnumerable<T> input, SourceKind sourceKind) =>
 #pragma warning disable IDE0072 // Add missing cases
             sourceKind switch

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -92,18 +92,18 @@ namespace MoreLinq
                 {
                     case ICollection<TSource> { Count: 0 }:
                     {
-                        yield break;
+                        break;
                     }
                     case ICollection<TSource> collection when collection.Count <= size:
                     {
                         var bucket = new TSource[collection.Count];
                         collection.CopyTo(bucket, 0);
                         yield return resultSelector(bucket);
-                        yield break;
+                        break;
                     }
                     case IReadOnlyCollection<TSource> { Count: 0 }:
                     {
-                        yield break;
+                        break;
                     }
                     case IReadOnlyList<TSource> list when list.Count <= size:
                     {
@@ -111,7 +111,7 @@ namespace MoreLinq
                         for (var i = 0; i < list.Count; i++)
                             bucket[i] = list[i];
                         yield return resultSelector(bucket);
-                        yield break;
+                        break;
                     }
                     case IReadOnlyCollection<TSource> collection when collection.Count <= size:
                     {
@@ -144,6 +144,7 @@ namespace MoreLinq
                             Array.Resize(ref bucket, count);
                             yield return resultSelector(bucket);
                         }
+
                         break;
                     }
                 }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     static partial class MoreEnumerable
     {
@@ -87,69 +86,65 @@ namespace MoreLinq
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            switch (source)
+            return Impl(); IEnumerable<TResult> Impl()
             {
-                case ICollection<TSource> { Count: 0 }:
+                switch (source)
                 {
-                    return Enumerable.Empty<TResult>();
-                }
-                case ICollection<TSource> collection when collection.Count <= size:
-                {
-                    return _(); IEnumerable<TResult> _()
+                    case ICollection<TSource> { Count: 0 }:
+                    {
+                        yield break;
+                    }
+                    case ICollection<TSource> collection when collection.Count <= size:
                     {
                         var bucket = new TSource[collection.Count];
                         collection.CopyTo(bucket, 0);
                         yield return resultSelector(bucket);
+                        yield break;
                     }
-                }
-                case IReadOnlyCollection<TSource> { Count: 0 }:
-                {
-                    return Enumerable.Empty<TResult>();
-                }
-                case IReadOnlyList<TSource> list when list.Count <= size:
-                {
-                    return _(); IEnumerable<TResult> _()
+                    case IReadOnlyCollection<TSource> { Count: 0 }:
+                    {
+                        yield break;
+                    }
+                    case IReadOnlyList<TSource> list when list.Count <= size:
                     {
                         var bucket = new TSource[list.Count];
                         for (var i = 0; i < list.Count; i++)
                             bucket[i] = list[i];
                         yield return resultSelector(bucket);
+                        yield break;
                     }
-                }
-                case IReadOnlyCollection<TSource> collection when collection.Count <= size:
-                {
-                    return Batch(collection.Count);
-                }
-                default:
-                {
-                    return Batch(size);
-                }
-
-                IEnumerable<TResult> Batch(int size)
-                {
-                    TSource[]? bucket = null;
-                    var count = 0;
-
-                    foreach (var item in source)
+                    case IReadOnlyCollection<TSource> collection when collection.Count <= size:
                     {
-                        bucket ??= new TSource[size];
-                        bucket[count++] = item;
-
-                        // The bucket is fully buffered before it's yielded
-                        if (count != size)
-                            continue;
-
-                        yield return resultSelector(bucket);
-
-                        bucket = null;
-                        count = 0;
+                        size = collection.Count;
+                        goto default;
                     }
-
-                    // Return the last bucket with all remaining elements
-                    if (count > 0)
+                    default:
                     {
-                        Array.Resize(ref bucket, count);
-                        yield return resultSelector(bucket);
+                        TSource[]? bucket = null;
+                        var count = 0;
+
+                        foreach (var item in source)
+                        {
+                            bucket ??= new TSource[size];
+                            bucket[count++] = item;
+
+                            // The bucket is fully buffered before it's yielded
+                            if (count != size)
+                                continue;
+
+                            yield return resultSelector(bucket);
+
+                            bucket = null;
+                            count = 0;
+                        }
+
+                        // Return the last bucket with all remaining elements
+                        if (count > 0)
+                        {
+                            Array.Resize(ref bucket, count);
+                            yield return resultSelector(bucket);
+                        }
+                        break;
                     }
                 }
             }

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -86,7 +86,7 @@ namespace MoreLinq
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return Impl(); IEnumerable<TResult> Impl()
+            return _(); IEnumerable<TResult> _()
             {
                 switch (source)
                 {


### PR DESCRIPTION
The `Batch` operator contains similar problems to those addressed in issue #943/PR #946. This PR removes all collection optimizations, since they are all based on caching the collection count at initial call instead of run-time. 