### PR TITLE
Use compiler-generated delegate caches in `ToDelimitedString`

### DIFF
--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -57,12 +57,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Boolean);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, bool, StringBuilder> Boolean = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -88,12 +83,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Byte);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, byte, StringBuilder> Byte = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -119,12 +109,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Char);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, char, StringBuilder> Char = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -150,12 +135,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Decimal);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, decimal, StringBuilder> Decimal = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -181,12 +161,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Double);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, double, StringBuilder> Double = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -212,12 +187,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Single);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, float, StringBuilder> Single = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -243,12 +213,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int32);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, int, StringBuilder> Int32 = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -274,12 +239,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int64);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, long, StringBuilder> Int64 = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -305,12 +265,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.SByte);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, sbyte, StringBuilder> SByte = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -336,12 +291,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.Int16);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, short, StringBuilder> Int16 = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -367,12 +317,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.String);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, string, StringBuilder> String = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -398,12 +343,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt32);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, uint, StringBuilder> UInt32 = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -429,12 +369,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt64);
-        }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, ulong, StringBuilder> UInt64 = (sb, e) => sb.Append(e);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
 
         /// <summary>
@@ -460,15 +395,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.UInt16);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, ushort, StringBuilder> UInt16 = (sb, e) => sb.Append(e);
-        }
-
-
-        static partial class StringBuilderAppenders {}
     }
 }

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -42,8 +42,8 @@ namespace MoreLinq
     using System.Text;
 
     partial class MoreEnumerable
-    {
-<#      var cscp = new CSharpCodeProvider();
+    {<#
+        var cscp = new CSharpCodeProvider();
         var types =
             from method in typeof(StringBuilder).GetMethods(BindingFlags.Public | BindingFlags.Instance)
             where "Append" == method.Name
@@ -73,6 +73,7 @@ namespace MoreLinq
                 break;
             }
         #>
+
         /// <summary>
         /// Creates a delimited string from a sequence of values and
         /// a given delimiter.
@@ -96,16 +97,8 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (delimiter == null) throw new ArgumentNullException(nameof(delimiter));
-            return ToDelimitedStringImpl(source, delimiter, StringBuilderAppenders.<#= type.Type.Name #>);
+            return ToDelimitedStringImpl(source, delimiter, static (sb, e) => sb.Append(e));
         }
-
-        static partial class StringBuilderAppenders
-        {
-            public static readonly Func<StringBuilder, <#= type.Name #>, StringBuilder> <#= type.Type.Name #> = (sb, e) => sb.Append(e);
-        }
-
 <#      } #>
-
-        static partial class StringBuilderAppenders {}
     }
 }


### PR DESCRIPTION
This PR removes all `StringBuilderAppenders` members that were designed to serve as static caches of delegates for use in `ToDelimitedString` implementations. This may have been significant in the past, but now using a simple static lambda seems to be simpler _and_ the compiler-generated cached delegate run faster. It does however come at the cost of an additional allocation because while the lambdas themselves are static, the delegate caching gets hosted into a non-static class (`<>c` below) generated by the C# compiler and the bodies converted into _regular instance-based_ methods:

```c#
[Serializable]
[CompilerGenerated]
private sealed class <>c
{
    [System.Runtime.CompilerServices.Nullable(0)]
    public static readonly <>c <>9 = new <>c();

    // ...omitted for brevity...

    public static Func<StringBuilder, bool, StringBuilder> <>9__281_0;
    public static Func<StringBuilder, byte, StringBuilder> <>9__282_0;
    public static Func<StringBuilder, char, StringBuilder> <>9__283_0;
    public static Func<StringBuilder, decimal, StringBuilder> <>9__284_0;
    public static Func<StringBuilder, double, StringBuilder> <>9__285_0;
    public static Func<StringBuilder, float, StringBuilder> <>9__286_0;
    public static Func<StringBuilder, int, StringBuilder> <>9__287_0;
    public static Func<StringBuilder, long, StringBuilder> <>9__288_0;
    public static Func<StringBuilder, sbyte, StringBuilder> <>9__289_0;
    public static Func<StringBuilder, short, StringBuilder> <>9__290_0;
    public static Func<StringBuilder, string, StringBuilder> <>9__291_0;
    public static Func<StringBuilder, uint, StringBuilder> <>9__292_0;
    public static Func<StringBuilder, ulong, StringBuilder> <>9__293_0;
    public static Func<StringBuilder, ushort, StringBuilder> <>9__294_0;

    // ...omitted for brevity...

    internal StringBuilder <ToDelimitedString>b__281_0(StringBuilder sb, bool e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__282_0(StringBuilder sb, byte e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__283_0(StringBuilder sb, char e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__284_0(StringBuilder sb, decimal e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__285_0(StringBuilder sb, double e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__286_0(StringBuilder sb, float e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__287_0(StringBuilder sb, int e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__288_0(StringBuilder sb, long e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__289_0(StringBuilder sb, sbyte e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__290_0(StringBuilder sb, short e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__291_0(StringBuilder sb, string e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__292_0(StringBuilder sb, uint e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__293_0(StringBuilder sb, ulong e) => sb.Append(e);
    internal StringBuilder <ToDelimitedString>b__294_0(StringBuilder sb, ushort e) => sb.Append(e);
}
```

Per dotnet/roslyn#51344, this is done so [because](https://github.com/dotnet/roslyn/discussions/51344#discussioncomment-386865):

> …the runtime is actually faster here in the non-static case than in the static case.

In the [StackOverflow] question “[Delegate caching behavior changes in Roslyn](https://stackoverflow.com/questions/30897647/delegate-caching-behavior-changes-in-roslyn)”, @Pilchie also [notes in a comment](https://stackoverflow.com/questions/30897647/delegate-caching-behavior-changes-in-roslyn#comment49837759_30897727):

> The reason it's faster is because delegate invokes are optimized for instance methods and have space on the stack for them. To call a static method they have to shift parameters around.

[Benchmarks](http://share.linqpad.net/59xa74.linq) seem to agree:

    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.1265)
    Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
    .NET SDK=7.0.103
      [Host] : .NET 7.0.3 (7.0.323.6910), X86 RyuJIT AVX2


|                 Method |     Mean |     Error |    StdDev | Allocated |
|----------------------- |---------:|----------:|----------:|----------:|
|         `StaticLambda` | 2.138 ns | 0.0208 ns | 0.0185 ns |         - |
|    `StaticMethodGroup` | 3.003 ns | 0.0296 ns | 0.0276 ns |         - |
|  `StaticLocalFunction` | 3.026 ns | 0.0607 ns | 0.0567 ns |         - |
| `CustomCachedDelegate` | 2.447 ns | 0.0383 ns | 0.0340 ns |         - |

---
- 📎 [`StringBuilderAppenders.zip`](https://github.com/morelinq/MoreLINQ/files/10774581/StringBuilderAppenders.zip)
- 📎 [`UserQuery-20230218-113452.log.txt`](https://github.com/morelinq/MoreLINQ/files/10774576/UserQuery-20230218-113452.log.txt)

[StackOverflow]: https://stackoverflow.com/
