### PR TITLE
Fix inconsistencies in `Fold` doc

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -2032,14 +2032,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2052,14 +2052,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2072,14 +2072,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2092,14 +2092,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2112,14 +2112,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2132,14 +2132,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2152,14 +2152,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2172,14 +2172,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2192,14 +2192,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2212,14 +2212,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2232,14 +2232,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2252,14 +2252,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2272,14 +2272,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2292,14 +2292,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2312,14 +2312,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);
@@ -2332,14 +2332,14 @@ namespace MoreLinq.Extensions
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
             => MoreEnumerable.Fold(source, folder);

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -2037,8 +2037,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
@@ -2057,8 +2058,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
@@ -2077,8 +2079,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
@@ -2097,8 +2100,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
@@ -2117,8 +2121,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, TResult> folder)
@@ -2137,8 +2142,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, TResult> folder)
@@ -2157,8 +2163,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, TResult> folder)
@@ -2177,8 +2184,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, TResult> folder)
@@ -2197,8 +2205,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2217,8 +2226,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2237,8 +2247,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2257,8 +2268,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2277,8 +2289,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2297,8 +2310,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2317,8 +2331,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -2337,8 +2352,9 @@ namespace MoreLinq.Extensions
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -35,8 +35,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
@@ -61,8 +62,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
@@ -87,8 +89,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
@@ -113,8 +116,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
@@ -139,8 +143,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, TResult> folder)
@@ -165,8 +170,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, TResult> folder)
@@ -191,8 +197,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, TResult> folder)
@@ -217,8 +224,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, TResult> folder)
@@ -243,8 +251,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -269,8 +278,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -295,8 +305,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -321,8 +332,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -347,8 +359,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -373,8 +386,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -399,8 +413,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
@@ -425,8 +440,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -30,14 +30,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 1 element.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, TResult> folder)
         {
@@ -56,14 +56,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 2 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> folder)
         {
@@ -82,14 +82,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 3 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, TResult> folder)
         {
@@ -108,14 +108,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 4 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, TResult> folder)
         {
@@ -134,14 +134,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 5 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, TResult> folder)
         {
@@ -160,14 +160,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 6 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, TResult> folder)
         {
@@ -186,14 +186,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 7 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, TResult> folder)
         {
@@ -212,14 +212,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 8 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -238,14 +238,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 9 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -264,14 +264,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 10 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -290,14 +290,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 11 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -316,14 +316,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 12 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -342,14 +342,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 13 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -368,14 +368,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 14 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -394,14 +394,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 15 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {
@@ -420,14 +420,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly 16 elements.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, TResult> folder)
         {

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -47,14 +47,14 @@ namespace MoreLinq
         /// This operator uses immediate execution and effectively buffers
         /// as many items of the source sequence as necessary.
         /// </remarks>
-        /// <typeparam name="T">Type of element in the source sequence</typeparam>
-        /// <typeparam name="TResult">Type of the result</typeparam>
+        /// <typeparam name="T">Type of element in the source sequence.</typeparam>
+        /// <typeparam name="TResult">Type of the result.</typeparam>
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is null</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly <#= e.CountString #> <#= e.ElementNoun #></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly <#= e.CountString #> <#= e.ElementNoun #>.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<<#= string.Join(", ", Enumerable.Repeat("T", e.Count)) #>, TResult> folder)
         {

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -52,8 +52,9 @@ namespace MoreLinq
         /// <param name="source">The sequence of items to fold.</param>
         /// <param name="folder">Function to apply to the elements in the sequence.</param>
         /// <returns>The folded value returned by <paramref name="folder"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="folder"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Either <paramref name="source"/> or <paramref name="folder"/> is <see langword="null"/>.
+        /// </exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> does not contain exactly <#= e.CountString #> <#= e.ElementNoun #>.</exception>
 
         public static TResult Fold<T, TResult>(this IEnumerable<T> source, Func<<#= string.Join(", ", Enumerable.Repeat("T", e.Count)) #>, TResult> folder)


### PR DESCRIPTION
This PR fixes minor inconsistencies in doc comments of `Fold` overloads.
