### PR TITLE
Implement `Fold` entirely in its own terms

### DIFF
--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -22,8 +22,6 @@ namespace MoreLinq
 
     static partial class MoreEnumerable
     {
-#if MORELINQ
-
         static readonly Func<int, int, Exception> DefaultErrorSelector = OnAssertCountFailure;
 
         /// <summary>
@@ -42,7 +40,7 @@ namespace MoreLinq
         /// </remarks>
 
         public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source, int count) =>
-            AssertCountImpl(source, count, DefaultErrorSelector);
+            AssertCount(source, count, DefaultErrorSelector);
 
         /// <summary>
         /// Asserts that a source sequence contains a given count of elements.
@@ -68,18 +66,6 @@ namespace MoreLinq
         /// </remarks>
 
         public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source,
-            int count, Func<int, int, Exception> errorSelector) =>
-            AssertCountImpl(source, count, errorSelector);
-
-        static Exception OnAssertCountFailure(int cmp, int count) =>
-            new SequenceException(FormatSequenceLengthErrorMessage(cmp, count));
-
-        internal static string FormatSequenceLengthErrorMessage(int cmp, int count) =>
-            $"Sequence contains too {(cmp < 0 ? "few" : "many")} elements when exactly {count:N0} {(count == 1 ? "was" : "were")} expected.";
-
-#endif
-
-        static IEnumerable<TSource> AssertCountImpl<TSource>(IEnumerable<TSource> source,
             int count, Func<int, int, Exception> errorSelector)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
@@ -106,5 +92,11 @@ namespace MoreLinq
                     throw errorSelector(-1, count);
             }
         }
+
+        static Exception OnAssertCountFailure(int cmp, int count) =>
+            new SequenceException(FormatSequenceLengthErrorMessage(cmp, count));
+
+        internal static string FormatSequenceLengthErrorMessage(int cmp, int count) =>
+            $"Sequence contains too {(cmp < 0 ? "few" : "many")} elements when exactly {count:N0} {(count == 1 ? "was" : "were")} expected.";
     }
 }

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -540,7 +540,8 @@ namespace MoreLinq.Extensions
         /// </remarks>
 
         public static IEnumerable<TSource> AssertCount<TSource>(this IEnumerable<TSource> source,
-            int count, Func<int, int, Exception> errorSelector)             => MoreEnumerable.AssertCount(source, count, errorSelector);
+            int count, Func<int, int, Exception> errorSelector)
+            => MoreEnumerable.AssertCount(source, count, errorSelector);
 
     }
 

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -25,15 +25,20 @@ namespace MoreLinq
         static T[] Fold<T>(this IEnumerable<T> source, int count)
         {
             var elements = new T[count];
-            foreach (var e in AssertCountImpl(source.Index(), count, OnFolderSourceSizeErrorSelector))
-                elements[e.Key] = e.Value;
+            var i = 0;
+
+            foreach (var item in source)
+            {
+                elements[i] = i < count ? item : throw LengthError(1);
+                i++;
+            }
+
+            if (i < count)
+                throw LengthError(-1);
 
             return elements;
+
+            InvalidOperationException LengthError(int cmp) => new(FormatSequenceLengthErrorMessage(cmp, count));
         }
-
-        static readonly Func<int, int, Exception> OnFolderSourceSizeErrorSelector = OnFolderSourceSizeError;
-
-        static Exception OnFolderSourceSizeError(int cmp, int count) =>
-            new InvalidOperationException(FormatSequenceLengthErrorMessage(cmp, count));
     }
 }


### PR DESCRIPTION
This PR implements `Fold` entirely in its own terms; that is, without any dependency on or composing on top of `AsserCount` and `Index`. `Fold` is expected to be used for short sequences (up to a maximum length of 16 elements), so this has the positive effect of avoiding extra enumerator allocations and virtual dispatches.