### PR TITLE
Fix `Permutations` for when source length is >12

### DIFF
--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -4511,6 +4511,9 @@ namespace MoreLinq.Extensions
         /// <param name="sequence">The original sequence to permute.</param>
         /// <returns>
         /// A sequence of lists representing permutations of the original sequence.</returns>
+        /// <exception cref="OverflowException">
+        /// Too many permutations (limited by <see cref="ulong.MaxValue"/>); thrown during iteration
+        /// of the resulting sequence.</exception>
         /// <remarks>
         /// <para>
         /// A permutation is a unique re-ordering of the elements of the sequence.</para>

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -34,19 +34,17 @@ namespace MoreLinq
         /// <param name="loopCounts">A sequence of loop repetition counts</param>
         /// <returns>A sequence of Action representing the expansion of a set of nested loops</returns>
 
-        static IEnumerable<Action> NestedLoops(this Action action, IEnumerable<int> loopCounts)
+        static IEnumerable<Action> NestedLoops(this Action action, IEnumerable<ulong> loopCounts)
         {
             if (action == null) throw new ArgumentNullException(nameof(action));
             if (loopCounts == null) throw new ArgumentNullException(nameof(loopCounts));
 
             return _(); IEnumerable<Action> _()
             {
-                var count = loopCounts.Assert(n => n >= 0,
-                                              _ => new InvalidOperationException("Invalid loop count (must be greater than or equal to zero)."))
-                                      .DefaultIfEmpty()
-                                      .Aggregate((acc, x) => acc * x);
+                var count = loopCounts.DefaultIfEmpty()
+                                      .Aggregate((acc, x) => checked(acc * x));
 
-                for (var i = 0; i < count; i++)
+                for (var i = 0UL; i < count; i++)
                     yield return action;
             }
         }

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -83,7 +83,7 @@ namespace MoreLinq
                 // The nested loop construction below takes into account the fact that:
                 // 1) for empty sets and sets of cardinality 1, there exists only a single permutation.
                 // 2) for sets larger than 1 element, the number of nested loops needed is: set.Count-1
-                _generator = NestedLoops(NextPermutation, Enumerable.Range(2, Math.Max(0, _valueSet.Count - 1)));
+                _generator = NestedLoops(NextPermutation, Generate(2UL, n => n + 1).Take(Math.Max(0, _valueSet.Count - 1)));
                 Reset();
             }
 
@@ -184,6 +184,9 @@ namespace MoreLinq
         /// <param name="sequence">The original sequence to permute.</param>
         /// <returns>
         /// A sequence of lists representing permutations of the original sequence.</returns>
+        /// <exception cref="OverflowException">
+        /// Too many permutations (limited by <see cref="ulong.MaxValue"/>); thrown during iteration
+        /// of the resulting sequence.</exception>
         /// <remarks>
         /// <para>
         /// A permutation is a unique re-ordering of the elements of the sequence.</para>


### PR DESCRIPTION
This PR fixes #978, by using `ulong` internally instead of `int` and adding checked arithmetic. This limits to 18,446,744,073,709,551,615 permutations and will overflow thereafter. A document comment has also been added to call out this limitation.

Due to the computationally expensive nature of enumerating permutations of a source with more than 12 elements, no unit test has been added to exercise the fix. However, the [following LINQPad query](http://share.linqpad.net/73ibc7.linq) was used as an eyeball test: [`MoreLinqPermutations.zip`](https://github.com/morelinq/MoreLINQ/files/10876399/MoreLinqPermutations.zip). At the time of opening this PR, it will use [latest NuGet package version (3.4.0)](https://www.nuget.org/packages/morelinq/3.4.0) and will exercise the bug. If the package reference is changed to an assembly reference that's the output of this PR, then it will exercise the fix.
