### PR TITLE
Enable nullable context for extensions generated via T4

### DIFF
--- a/MoreLinq/Aggregate.g.cs
+++ b/MoreLinq/Aggregate.g.cs
@@ -15,6 +15,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/Aggregate.g.tt
+++ b/MoreLinq/Aggregate.g.tt
@@ -19,6 +19,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #endregion
+
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
 <#
     var overloads =
         from args in new[]

--- a/MoreLinq/Cartesian.g.cs
+++ b/MoreLinq/Cartesian.g.cs
@@ -15,6 +15,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -20,6 +20,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/Fold.g.cs
+++ b/MoreLinq/Fold.g.cs
@@ -15,6 +15,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/Fold.g.tt
+++ b/MoreLinq/Fold.g.tt
@@ -20,6 +20,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 namespace MoreLinq
 {
     using System;

--- a/MoreLinq/ToDelimitedString.g.cs
+++ b/MoreLinq/ToDelimitedString.g.cs
@@ -15,6 +15,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 #if !MORELINQ
 //
 // For projects that may include/embed this source file directly, suppress the

--- a/MoreLinq/ToDelimitedString.g.tt
+++ b/MoreLinq/ToDelimitedString.g.tt
@@ -24,6 +24,16 @@
 // limitations under the License.
 #endregion
 
+#nullable enable // required for auto-generated sources (see below why)
+
+// > Older code generation strategies may not be nullable aware. Setting the
+// > project-level nullable context to "enable" could result in many
+// > warnings that a user is unable to fix. To support this scenario any syntax
+// > tree that is determined to be generated will have its nullable state
+// > implicitly set to "disable", regardless of the overall project state.
+//
+// Source: https://github.com/dotnet/roslyn/blob/70e158ba6c2c99bd3c3fc0754af0dbf82a6d353d/docs/features/nullable-reference-types.md#generated-code
+
 #if !MORELINQ
 //
 // For projects that may include/embed this source file directly, suppress the


### PR DESCRIPTION
This PR fixes #981 by enabling nullable context for the following extensions:

- `ToDelimitedString`
- `Aggregate`
- `Fold`
- `Cartesian`
