### PR TITLE
Fix error handling in Windows batch scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,8 +1,7 @@
 @echo off
 pushd "%~dp0"
 call :main %*
-popd
-goto :EOF
+popd & exit /b %ERRORLEVEL%
 
 :main
 setlocal
@@ -15,11 +14,11 @@ dotnet restore && dotnet tool restore ^
   && call :codegen MoreLinq\Extensions.ToDataTable.g.cs -i "[/\\]ToDataTable\.cs$" -u System.Data -u System.Linq.Expressions MoreLinq ^
   && call MoreLinq\tt ^
   && for %%i in (debug release) do dotnet build -c %%i --no-restore %* || exit /b 1
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :docs
 call :build && call msbuild.cmd MoreLinq.shfbproj %1 %2 %3 %4 %5 %6 %7 %8 %9
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :nodotnet
 echo>&2 dotnet executable not found in PATH
@@ -31,4 +30,4 @@ echo | set /p=Generating extensions wrappers (%1)...
 dotnet run --project bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- %2 %3 %4 %5 %6 %7 %8 %9 > "%temp%\%~nx1" ^
   && move "%temp%\%~nx1" "%~dp1" > nul ^
   && echo Done.
-goto :EOF
+exit /b %ERRORLEVEL%

--- a/builddocs.cmd
+++ b/builddocs.cmd
@@ -1,1 +1,1 @@
-@"%~dp0build" docs
+@call "%~dp0build" docs

--- a/msbuild.cmd
+++ b/msbuild.cmd
@@ -18,7 +18,7 @@ if not defined MSBUILD_VERSION_MAJOR goto :nomsbuild
 if %MSBUILD_VERSION_MAJOR% lss 17    goto :nomsbuild
 :build
 "%MSBUILD%" %*
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :nomsbuild
 echo>&2 Microsoft Build Engine 17.0 or a later version is required to build
@@ -27,4 +27,4 @@ echo>&2 https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-p
 echo>&2 At the very least, you will want to install the MSBuilt Tool workload
 echo>&2 that has the identifier "Microsoft.VisualStudio.Workload.MSBuildTools":
 echo>&2 https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools#msbuild-tools
-exit /b s
+exit /b 1

--- a/pack.cmd
+++ b/pack.cmd
@@ -1,15 +1,14 @@
 @echo off
 pushd "%~dp0"
 call :main %*
-popd
-goto :EOF
+popd & exit /b %ERRORLEVEL%
 
 :main
 setlocal
 if not exist dist md dist
-if not %errorlevel%==0 exit /b %errorlevel%
+if not %ERRORLEVEL%==0 exit /b %ERRORLEVEL%
 set VERSION_SUFFIX=
 if not "%~1"=="" set VERSION_SUFFIX=/p:VersionSuffix=%1
 call build ^
   && dotnet pack --no-build -c Release %VERSION_SUFFIX%
-goto :EOF
+exit /b %ERRORLEVEL%

--- a/test.cmd
+++ b/test.cmd
@@ -1,8 +1,7 @@
 @echo off
 pushd "%~dp0"
 call :main %*
-popd
-goto :EOF
+popd & exit /b %ERRORLEVEL%
 
 :main
 setlocal
@@ -15,14 +14,14 @@ call build ^
   && call :test net462 Debug ^
   && call :test net462 Release ^
   && call :report-cover
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :clean
 setlocal
 cd MoreLinq.Test
 if exist TestResults rd /s /q TestResults || exit /b 1
 if exist TestResult.xml del TestResult.xml || exit /b 1
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :test
 setlocal
@@ -41,7 +40,7 @@ if not defined TEST_RESULTS_DIR (
     exit /b 1
 )
 copy "%TEST_RESULTS_DIR%\coverage.opencover.xml" coverage-%1-%2.opencover.xml > nul
-goto :EOF
+exit /b %ERRORLEVEL%
 
 :report-cover
 setlocal
@@ -50,4 +49,4 @@ dotnet reportgenerator -reports:coverage-*.opencover.xml ^
                        -reporttypes:Html;TextSummary ^
                        -targetdir:reports ^
   && type reports\Summary.txt
-goto :EOF
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
This PR fixes error handling in Windows batch script and removes use of some quirks (e.g. `goto :EOF` and `popd` do not reset the `ERRORLEVEL` on success) to ensure more robust propagation of errors/failures.
