### PR TITLE
Skip build when testing on CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ image:
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  SKIP_TEST_BUILD: true
 for:
 -
   matrix:

--- a/test.cmd
+++ b/test.cmd
@@ -5,8 +5,9 @@ popd & exit /b %ERRORLEVEL%
 
 :main
 setlocal
-call build ^
-  && call :clean ^
+if not defined SKIP_TEST_BUILD set SKIP_TEST_BUILD=false
+if %SKIP_TEST_BUILD%==false call build || exit /b 1
+call :clean ^
   && call :test net7.0 Debug ^
   && call :test net7.0 Release ^
   && call :test net6.0 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
-./build.sh $c
+if [[ "${SKIP_TEST_BUILD:=false}" == "false" ]]; then
+    ./build.sh $c
+fi
 if [[ -d "MoreLinq.Test/TestResults" ]]; then
     rm -rf MoreLinq.Test/TestResults
 fi


### PR DESCRIPTION
This PR fixes #95 by skipping the build step in `test.cmd` and `test.sh` when an environment variable named `SKIP_TEST_BUILD` is defined and its value is anything but `false`. During a CI build `SKIP_TEST_BUILD` is set to `true`.
