### PR TITLE
Use docopt.net to parse extensions generator CLI args

### DIFF
--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="docopt.net" Version="0.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -45,8 +45,7 @@ try
     {
         Console.Error.WriteLine("Invalid argument or usage!");
         Console.Error.WriteLine();
-        var usage = ProgramArguments.Help.Replace("#BIN#", Path.GetFileName(Environment.ProcessPath), StringComparison.Ordinal);
-        Console.Error.WriteLine(usage);
+        Console.Error.WriteLine(ProgramArguments.Help);
     }
 
     return exitCode;
@@ -444,10 +443,10 @@ sealed class ArrayTypeKey : ParameterizedTypeKey
     }
 }
 
-[DocoptArguments]
+[DocoptArguments(HelpConstName = nameof(HelpText))]
 sealed partial class ProgramArguments
 {
-    public const string Help = """
+    const string HelpText = """
         Usage:
           #BIN# [options] [-u NAMESPACE]... [DIR]
 
@@ -458,4 +457,7 @@ sealed partial class ProgramArguments
           --no-class-lead        Skip generating class lead.
           -d, --debug            Produce output for debugging.
         """;
+
+    public static string Help =>
+        HelpText.Replace("#BIN#", Path.GetFileName(Environment.ProcessPath), StringComparison.Ordinal);
 }

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using DocoptNet;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -35,8 +36,20 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 try
 #pragma warning restore CA1852 // Seal internal types
 {
-    Run(args);
-    return 0;
+    var exitCode =
+        ProgramArguments.CreateParser()
+                        .Parse(args)
+                        .Match(args => { Run(args); return 0; }, _ => 1);
+
+    if (exitCode != 0)
+    {
+        Console.Error.WriteLine("Invalid argument or usage!");
+        Console.Error.WriteLine();
+        var usage = ProgramArguments.Help.Replace("#BIN#", Path.GetFileName(Environment.ProcessPath), StringComparison.Ordinal);
+        Console.Error.WriteLine(usage);
+    }
+
+    return exitCode;
 }
 #pragma warning disable CA1031 // Do not catch general exception types
 catch (Exception e)
@@ -46,54 +59,9 @@ catch (Exception e)
     return 0xbad;
 }
 
-static void Run(IEnumerable<string> args)
+static void Run(ProgramArguments args)
 {
-    var dir = Directory.GetCurrentDirectory();
-
-    string? includePattern = null;
-    string? excludePattern = null;
-    var debug = false;
-    var usings = new List<string>();
-    var noClassLead = false;
-
-    using (var arg = args.GetEnumerator())
-    {
-        while (arg.MoveNext())
-        {
-            switch (arg.Current)
-            {
-                case "-i":
-                case "--include":
-                    includePattern = Read(arg, MissingArgValue);
-                    break;
-                case "-x":
-                case "--exclude":
-                    excludePattern = Read(arg, MissingArgValue);
-                    break;
-                case "-u":
-                case "--using":
-                    usings.Add(Read(arg, MissingArgValue));
-                    break;
-                case "--no-class-lead":
-                    noClassLead = true;
-                    break;
-                case "-d":
-                case "--debug":
-                    debug = true;
-                    break;
-                case "":
-                    continue;
-                default:
-                    dir = arg.Current[0] != '-'
-                        ? arg.Current
-                        : throw new Exception("Invalid argument: " + arg.Current);
-                    break;
-            }
-        }
-
-        static Exception MissingArgValue() =>
-            new InvalidOperationException("Missing argument value.");
-    }
+    var dir = args.ArgDir ?? Directory.GetCurrentDirectory();
 
     static Func<string, bool>
         PredicateFromPattern(string? pattern, bool @default) =>
@@ -101,8 +69,8 @@ static void Run(IEnumerable<string> args)
             ? delegate { return @default; }
             : new Func<string, bool>(new Regex(pattern).IsMatch);
 
-    var includePredicate = PredicateFromPattern(includePattern, true);
-    var excludePredicate = PredicateFromPattern(excludePattern, false);
+    var includePredicate = PredicateFromPattern(args.OptInclude, true);
+    var excludePredicate = PredicateFromPattern(args.OptExclude, false);
 
     var thisAssemblyName = typeof(TypeKey).GetTypeInfo().Assembly.GetName();
 
@@ -198,7 +166,7 @@ static void Run(IEnumerable<string> args)
 
     q = q.ToArray();
 
-    if (debug)
+    if (args.OptDebug)
     {
         var ms =
             //
@@ -252,7 +220,7 @@ static void Run(IEnumerable<string> args)
     };
 
     var imports =
-        from ns in baseImports.Concat(usings)
+        from ns in baseImports.Concat(args.OptUsing)
         select indent + $"using {ns};";
 
     var classes =
@@ -290,7 +258,7 @@ static void Run(IEnumerable<string> args)
                         .WithSemicolonToken(ParseToken(";").WithTrailingTrivia(LineFeed))
         }
         into m
-        let classLead = !noClassLead
+        let classLead = !args.OptNoClassLead
             ? $$"""
 
                     /// <summary><c>{{m.Name}}</c> extension.</summary>
@@ -372,9 +340,6 @@ static TypeKey CreateTypeKey(TypeSyntax root, Func<string, TypeKey?> abbreviator
         _ => throw new NotSupportedException("Unhandled type: " + ts)
     };
 }
-
-static T Read<T>(IEnumerator<T> e, Func<Exception> errorFactory) =>
-    e.MoveNext() ? e.Current : throw errorFactory();
 
 //
 // Logical type nodes designed to be structurally sortable based on:
@@ -477,4 +442,20 @@ sealed class ArrayTypeKey : ParameterizedTypeKey
 
         return base.CompareParameters(other);
     }
+}
+
+[DocoptArguments]
+sealed partial class ProgramArguments
+{
+    public const string Help = """
+        Usage:
+          #BIN# [options] [-u NAMESPACE]... [DIR]
+
+        Options:
+          -i, --include REGEX    Include files matching pattern.
+          -x, --exclude REGEX    Exclude files matching pattern.
+          -u, --using NAMESPACE  Additional using imports to add.
+          --no-class-lead        Skip generating class lead.
+          -d, --debug            Produce output for debugging.
+        """;
 }


### PR DESCRIPTION
This PR uses [docopt.net](https://www.nuget.org/packages/docopt.net) to replace/reduce CLI argument handling code in the extensions generator program.