### PR TITLE
Add Extension Method for Enumerating all Pairs

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
@@ -65,6 +66,7 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+    <Content Include="PairsTest.cs" />
   </ItemGroup>
 
 </Project>

--- a/MoreLinq.Test/PairsTest.cs
+++ b/MoreLinq.Test/PairsTest.cs
@@ -1,0 +1,62 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2012 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PairsTest
+    {
+        [Test]
+        public void PairsNullArgument()
+        {
+            #pragma warning disable 8600, 8604 // need null enumeration for test
+            IEnumerable<int> source = null;
+            Assert.Throws<ArgumentNullException>(() => source.Pairs());
+            #pragma warning restore
+        }
+
+        [TestCase("[]", "[]")]
+        [TestCase("[A]", "[]")]
+        [TestCase("[A,B]", "[[A,B]]")]
+        [TestCase("[A,A]", "[[A,A]]")]
+        [TestCase("[A,B,C]", "[[A,B],[A,C],[B,C]]")]
+        [TestCase("[A,B,C,D]", "[[A,B],[A,C],[A,D],[B,C],[B,D],[C,D]]")]
+        [TestCase("[A,B,A,D]")]
+        public void PairwiseWithSequenceShorterThanTwo(in string input, in string expected)
+        {
+            var source = ParseStringArray(input);
+            var expectedPairs = ParseNestedStringArray(expected).Select(strs => (strs.First(), strs.Last()));
+            var actualPairs = source.Pairs();
+
+            actualPairs.AssertSequenceEquivalent(expectedPairs);
+        }
+
+        private static IEnumerable<IEnumerable<string>> ParseNestedStringArray(in string str)
+        {
+            return ParseStringArray(str).Select(strs => ParseStringArray(strs));
+        }        
+
+        private static IEnumerable<string> ParseStringArray(in string str)
+        {
+            return str.Substring(1, str.Length - 2).Split(',');
+        }
+    }
+}

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -61,6 +61,12 @@ namespace MoreLinq.Test
             Assert.That(actual, Is.EqualTo(expected));
 
         /// <summary>
+        /// Just to make our testing easier so we can chain the assertion call.
+        /// </summary>
+        internal static void AssertSequenceEquivalent<T>(this IEnumerable<T> actual, IEnumerable<T> expected) =>
+            Assert.That(actual, Is.EquivalentTo(expected));
+
+        /// <summary>
         /// Make testing even easier - a params array makes for readable tests :)
         /// The sequence should be evaluated exactly once.
         /// </summary>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -61,6 +61,7 @@
         - OrderedMerge
         - Pad
         - PadStart
+        - Pairs
         - Pairwise
         - PartialSort
         - PartialSortBy
@@ -241,6 +242,7 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+    <Content Include="Pairs.cs" />
   </ItemGroup>
 
   <Target Name="_CollectTextTemplates">

--- a/MoreLinq/Pairs.cs
+++ b/MoreLinq/Pairs.cs
@@ -1,0 +1,65 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2012 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Enumerates all positionally distinct pairs of items in an
+        /// enumeration. See examples for clarifications. Two of the
+        /// same values at different positions would appear in a pair.
+        /// The enumerated pairs are returned as <see cref="Tuple{T,T}"/>s.
+        /// The <see cref="Tuple{T,T}.Item1"/> will be the item appearing
+        /// positionally before the other in <paramref name="source"/>.
+        /// The pairs should not be assumed to be enumerated in any
+        /// particular order.
+        /// </summary>
+        /// <example>
+        /// [A, B, C, D] -> [(A, B), (A, C), (A, D), (B, C), (B, D), (C, D)]
+        /// </example>
+        /// <example>
+        /// [A, B, A, D] -> [(A, B), (A, A), (A, D), (B, A), (B, D), (A, D)]
+        /// </example>
+        /// <param name="source">The enumeration</param>
+        /// <typeparam name="T">The type of items in the enumeration</typeparam>
+        /// <exception cref="ArgumentNullException"/>
+        public static IEnumerable<(T, T)> Pairs<T>(this IEnumerable<T> source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            /*
+                We will return in order like
+
+                [A, B, C, D] -> [(A, B), (A, C), (B, C), (A, D), (B, D), (C, D)]
+
+                because it is ideal for minimizing both enumerations and space.
+
+                If it were needed to return in a more natural order like
+
+                [(A, B), (A, C), (A, D), (B, C), (B, D), (C, D)]
+
+                we would need Reverse or SkipWhile, each adding computations.
+            */
+            return source.SelectMany((t2, i2) => source.Take(i2).Select(t1 => (t1, t2)));
+        }
+    }
+}

--- a/MoreLinq/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/MoreLinq/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -63,6 +63,7 @@ MoreLinq.Extensions.OrderByExtension
 MoreLinq.Extensions.OrderedMergeExtension
 MoreLinq.Extensions.PadExtension
 MoreLinq.Extensions.PadStartExtension
+MoreLinq.Extensions.PairsExtension
 MoreLinq.Extensions.PairwiseExtension
 MoreLinq.Extensions.PartialSortByExtension
 MoreLinq.Extensions.PartialSortExtension
@@ -274,6 +275,7 @@ static MoreLinq.Extensions.PadExtension.Pad<TSource>(this System.Collections.Gen
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width) -> System.Collections.Generic.IEnumerable<TSource?>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, System.Func<int, TSource>! paddingSelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, TSource padding) -> System.Collections.Generic.IEnumerable<TSource>!
+static MoreLinq.Extensions.PairsExtension.Pairs<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<(T,T)>!
 static MoreLinq.Extensions.PairwiseExtension.Pairwise<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector, MoreLinq.OrderByDirection direction) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -61,6 +61,7 @@ MoreLinq.Extensions.OrderByExtension
 MoreLinq.Extensions.OrderedMergeExtension
 MoreLinq.Extensions.PadExtension
 MoreLinq.Extensions.PadStartExtension
+MoreLinq.Extensions.PairsExtension
 MoreLinq.Extensions.PairwiseExtension
 MoreLinq.Extensions.PartialSortByExtension
 MoreLinq.Extensions.PartialSortExtension
@@ -268,6 +269,7 @@ static MoreLinq.Extensions.PadExtension.Pad<TSource>(this System.Collections.Gen
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width) -> System.Collections.Generic.IEnumerable<TSource?>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, System.Func<int, TSource>! paddingSelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, TSource padding) -> System.Collections.Generic.IEnumerable<TSource>!
+static MoreLinq.Extensions.PairsExtension.Pairs<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<(T,T)>!
 static MoreLinq.Extensions.PairwiseExtension.Pairwise<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector, MoreLinq.OrderByDirection direction) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -63,6 +63,7 @@ MoreLinq.Extensions.OrderByExtension
 MoreLinq.Extensions.OrderedMergeExtension
 MoreLinq.Extensions.PadExtension
 MoreLinq.Extensions.PadStartExtension
+MoreLinq.Extensions.PairsExtension
 MoreLinq.Extensions.PairwiseExtension
 MoreLinq.Extensions.PartialSortByExtension
 MoreLinq.Extensions.PartialSortExtension
@@ -274,6 +275,7 @@ static MoreLinq.Extensions.PadExtension.Pad<TSource>(this System.Collections.Gen
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width) -> System.Collections.Generic.IEnumerable<TSource?>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, System.Func<int, TSource>! paddingSelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PadStartExtension.PadStart<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int width, TSource padding) -> System.Collections.Generic.IEnumerable<TSource>!
+static MoreLinq.Extensions.PairsExtension.Pairs<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<(T,T)>!
 static MoreLinq.Extensions.PairwiseExtension.Pairwise<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.Extensions.PartialSortByExtension.PartialSortBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, int count, System.Func<TSource, TKey>! keySelector, MoreLinq.OrderByDirection direction) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ Pads a sequence with default values in the beginning if it is narrower
 
 This method has 3 overloads.
 
+### Pairs
+
+Enumerates all positionally distinct pairs of items in an
+enumeration. Two of the same values at different positions
+would appear in a pair.
+
 ### Pairwise
 
 Returns a sequence resulting from applying a function to each element in the


### PR DESCRIPTION
- [x] New extension method for enumerating all pairs
- [x] Unit test
- [x] Add to public, shipped list
- [ ] Need to generate the public method in the `Extensions.g.cs`. I assume this is done by the **ExtensionsGenerator**, and I tried to no avail. Is there developer documentation on how to do the code generation?