### PR TITLE
Fix bug in `FillForward` when filler is `null`

### DIFF
--- a/MoreLinq.Test/FillForwardTest.cs
+++ b/MoreLinq.Test/FillForwardTest.cs
@@ -83,5 +83,18 @@ namespace MoreLinq.Test
                 new { Continent = "Africa", Country = "Kenya",   City = "Nairobi",    Value = 901 },
             }));
         }
+
+        /// <summary>
+        /// Exercises bug reported in <see
+        /// href="https://github.com/morelinq/MoreLINQ/issues/999">issue #999</see>.
+        /// </summary>
+
+        [Test]
+        public void FillForwardWithNullFiller()
+        {
+            var input = new int?[] { null, 1, null, 2, null, 3, null };
+            var result = input.FillForward(x => x is not null);
+            result.AssertSequenceEqual(Enumerable.Repeat((int?)null, input.Length));
+        }
     }
 }

--- a/MoreLinq/FillForward.cs
+++ b/MoreLinq/FillForward.cs
@@ -112,10 +112,10 @@ namespace MoreLinq
             {
                 if (predicate(item))
                 {
-                    yield return seed is (true, { } someSeed)
+                    yield return seed is (true, var theSeed)
                                ? fillSelector != null
-                                 ? fillSelector(item, someSeed)
-                                 : someSeed
+                                 ? fillSelector(item, theSeed)
+                                 : theSeed
                                : item;
                 }
                 else


### PR DESCRIPTION
This PR fixes #999.
