### PR TITLE
Update package validation tool to v1.0.12

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "meziantou.framework.nugetpackagevalidation.tool": {
-      "version": "1.0.9",
+      "version": "1.0.12",
       "commands": [
         "meziantou.validate-nuget-package"
       ]


### PR DESCRIPTION
This PR updates [**Meziantou.Framework.NuGetPackageValidation.Tool**](https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool/) to its [latest version](https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool/1.0.12). See meziantou/Meziantou.Framework#539 for more background.
