### PR TITLE
Suppress `EnableGenerateDocumentationFile` warning as workaround for IDE0005

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,5 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AnalysisLevel>7.0-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Workaround for IDE0005 (Remove unnecessary usings/imports); see https://github.com/dotnet/roslyn/issues/41640 -->
+    <NoWarn>EnableGenerateDocumentationFile</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR is a workaround for dotnet/roslyn#41640.
