### PR TITLE
Add `Minima` & `Maxima` as successors to `MinBy` & `MaxBy`

### DIFF
--- a/MoreLinq.Test/MaximaTest.cs
+++ b/MoreLinq.Test/MaximaTest.cs
@@ -20,44 +20,44 @@ namespace MoreLinq.Test
     using NUnit.Framework;
 
     [TestFixture]
-    public class MaxByTest
+    public class MaximaTest
     {
         [Test]
-        public void MaxByIsLazy()
+        public void MaximaIsLazy()
         {
-            _ = new BreakingSequence<int>().MaxBy(BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().Maxima(BreakingFunc.Of<int, int>());
         }
 
         [Test]
-        public void MaxByReturnsMaxima()
+        public void MaximaReturnsMaxima()
         {
-            Assert.That(SampleData.Strings.MaxBy(x => x.Length),
+            Assert.That(SampleData.Strings.Maxima(x => x.Length),
                         Is.EqualTo(new[] { "hello", "world" }));
         }
 
         [Test]
-        public void MaxByNullComparer()
+        public void MaximaNullComparer()
         {
-            Assert.That(SampleData.Strings.MaxBy(x => x.Length, null),
-                        Is.EqualTo(SampleData.Strings.MaxBy(x => x.Length)));
+            Assert.That(SampleData.Strings.Maxima(x => x.Length, null),
+                        Is.EqualTo(SampleData.Strings.Maxima(x => x.Length)));
         }
 
         [Test]
-        public void MaxByEmptySequence()
+        public void MaximaEmptySequence()
         {
-            Assert.That(new string[0].MaxBy(x => x.Length), Is.Empty);
+            Assert.That(new string[0].Maxima(x => x.Length), Is.Empty);
         }
 
         [Test]
-        public void MaxByWithNaturalComparer()
+        public void MaximaWithNaturalComparer()
         {
-            Assert.That(SampleData.Strings.MaxBy(x => x[1]), Is.EqualTo(new[] { "az" }));
+            Assert.That(SampleData.Strings.Maxima(x => x[1]), Is.EqualTo(new[] { "az" }));
         }
 
         [Test]
-        public void MaxByWithComparer()
+        public void MaximaWithComparer()
         {
-            Assert.That(SampleData.Strings.MaxBy(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "aa" }));
+            Assert.That(SampleData.Strings.Maxima(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "aa" }));
         }
 
         public class First
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.First(maxima), Is.EqualTo("hello"));
             }
 
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.First(maxima), Is.EqualTo("ax"));
             }
 
@@ -83,7 +83,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.That(() =>
-                    MoreEnumerable.First(strings.MaxBy(s => s.Length)),
+                    MoreEnumerable.First(strings.Maxima(s => s.Length)),
                     Throws.InvalidOperationException);
             }
 
@@ -92,7 +92,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.That(() =>
-                    MoreEnumerable.First(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)),
+                    MoreEnumerable.First(strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer)),
                     Throws.InvalidOperationException);
             }
         }
@@ -103,7 +103,7 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.EqualTo("hello"));
             }
 
@@ -111,7 +111,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.EqualTo("ax"));
             }
 
@@ -119,7 +119,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.Null);
             }
 
@@ -127,7 +127,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.FirstOrDefault(maxima), Is.Null);
             }
         }
@@ -138,7 +138,7 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.Last(maxima), Is.EqualTo("world"));
             }
 
@@ -146,7 +146,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMaximumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.Last(maxima), Is.EqualTo("az"));
             }
 
@@ -155,7 +155,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.That(() =>
-                    MoreEnumerable.Last(strings.MaxBy(s => s.Length)),
+                    MoreEnumerable.Last(strings.Maxima(s => s.Length)),
                     Throws.InvalidOperationException);
             }
 
@@ -164,7 +164,7 @@ namespace MoreLinq.Test
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
                 Assert.That(() =>
-                    MoreEnumerable.Last(strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer)),
+                    MoreEnumerable.Last(strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer)),
                     Throws.InvalidOperationException);
             }
         }
@@ -175,7 +175,7 @@ namespace MoreLinq.Test
             public void ReturnsMaximum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.EqualTo("world"));
             }
 
@@ -183,7 +183,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMaximumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.EqualTo("az"));
             }
 
@@ -191,7 +191,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length);
+                var maxima = strings.Maxima(s => s.Length);
                 Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.Null);
             }
 
@@ -199,7 +199,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var maxima = strings.MaxBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var maxima = strings.Maxima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.LastOrDefault(maxima), Is.Null);
             }
         }
@@ -213,7 +213,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMaxima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MaxBy(s => s.Length).Take(count).ToArray();
+                return strings.Maxima(s => s.Length).Take(count).ToArray();
             }
 
             [TestCase(0, 0, ExpectedResult = new string[0]                         )]
@@ -227,7 +227,7 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMaximaPerComparer(int count, int index)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MaxBy(s => s[index], Comparable<char>.DescendingOrderComparer)
+                return strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
                               .Take(count)
                               .ToArray();
             }
@@ -242,7 +242,7 @@ namespace MoreLinq.Test
             public string[] TakeLastReturnsMaxima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MaxBy(s => s.Length).TakeLast(count).ToArray();
+                return strings.Maxima(s => s.Length).TakeLast(count).ToArray();
             }
 
             [TestCase(0, 0, ExpectedResult = new string[0]                         )]
@@ -256,7 +256,7 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMaximaPerComparer(int count, int index)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MaxBy(s => s[index], Comparable<char>.DescendingOrderComparer)
+                return strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
                               .TakeLast(count)
                               .ToArray();
             }

--- a/MoreLinq.Test/MinimaTest.cs
+++ b/MoreLinq.Test/MinimaTest.cs
@@ -20,44 +20,44 @@ namespace MoreLinq.Test
     using NUnit.Framework;
 
     [TestFixture]
-    public class MinByTest
+    public class MinimaTest
     {
         [Test]
-        public void MinByIsLazy()
+        public void MinimaIsLazy()
         {
-            _ = new BreakingSequence<int>().MinBy(BreakingFunc.Of<int, int>());
+            _ = new BreakingSequence<int>().Minima(BreakingFunc.Of<int, int>());
         }
 
         [Test]
-        public void MinByReturnsMinima()
+        public void MinimaReturnsMinima()
         {
-            Assert.That(SampleData.Strings.MinBy(x => x.Length),
+            Assert.That(SampleData.Strings.Minima(x => x.Length),
                         Is.EqualTo(new[] { "ax", "aa", "ab", "ay", "az" }));
         }
 
         [Test]
-        public void MinByNullComparer()
+        public void MinimaNullComparer()
         {
-            Assert.That(SampleData.Strings.MinBy(x => x.Length, null),
-                        Is.EqualTo(SampleData.Strings.MinBy(x => x.Length)));
+            Assert.That(SampleData.Strings.Minima(x => x.Length, null),
+                        Is.EqualTo(SampleData.Strings.Minima(x => x.Length)));
         }
 
         [Test]
-        public void MinByEmptySequence()
+        public void MinimaEmptySequence()
         {
-            Assert.That(new string[0].MinBy(x => x.Length), Is.Empty);
+            Assert.That(new string[0].Minima(x => x.Length), Is.Empty);
         }
 
         [Test]
-        public void MinByWithNaturalComparer()
+        public void MinimaWithNaturalComparer()
         {
-            Assert.That(SampleData.Strings.MinBy(x => x[1]), Is.EqualTo(new[] { "aa" }));
+            Assert.That(SampleData.Strings.Minima(x => x[1]), Is.EqualTo(new[] { "aa" }));
         }
 
         [Test]
-        public void MinByWithComparer()
+        public void MinimaWithComparer()
         {
-            Assert.That(SampleData.Strings.MinBy(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "az" }));
+            Assert.That(SampleData.Strings.Minima(x => x[1], Comparable<char>.DescendingOrderComparer), Is.EqualTo(new[] { "az" }));
         }
 
         public class First
@@ -66,7 +66,7 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = MoreEnumerable.First(strings.MinBy(s => s.Length));
+                var minima = MoreEnumerable.First(strings.Minima(s => s.Length));
                 Assert.That(minima, Is.EqualTo("ax"));
             }
 
@@ -74,7 +74,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.First(minima), Is.EqualTo("hello"));
             }
 
@@ -82,7 +82,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceThrows()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(() => MoreEnumerable.First(strings.MinBy(s => s.Length)),
+                Assert.That(() => MoreEnumerable.First(strings.Minima(s => s.Length)),
                             Throws.InvalidOperationException);
             }
 
@@ -90,7 +90,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerThrows()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(() => MoreEnumerable.First(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)),
+                Assert.That(() => MoreEnumerable.First(strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)),
                             Throws.InvalidOperationException);
             }
         }
@@ -101,7 +101,7 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length);
+                var minima = strings.Minima(s => s.Length);
                 Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.EqualTo("ax"));
             }
 
@@ -109,7 +109,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.EqualTo("hello"));
             }
 
@@ -117,7 +117,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length);
+                var minima = strings.Minima(s => s.Length);
                 Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.Null);
             }
 
@@ -125,7 +125,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.FirstOrDefault(minima), Is.Null);
             }
         }
@@ -136,7 +136,7 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length);
+                var minima = strings.Minima(s => s.Length);
                 Assert.That(MoreEnumerable.Last(minima), Is.EqualTo("az"));
             }
 
@@ -144,7 +144,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMinimumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.Last(minima), Is.EqualTo("world"));
             }
 
@@ -152,7 +152,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceThrows()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(() => MoreEnumerable.Last(strings.MinBy(s => s.Length)),
+                Assert.That(() => MoreEnumerable.Last(strings.Minima(s => s.Length)),
                             Throws.InvalidOperationException);
             }
 
@@ -160,7 +160,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerThrows()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                Assert.That(() => MoreEnumerable.Last(strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)),
+                Assert.That(() => MoreEnumerable.Last(strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)),
                             Throws.InvalidOperationException);
             }
         }
@@ -171,7 +171,7 @@ namespace MoreLinq.Test
             public void ReturnsMinimum()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length);
+                var minima = strings.Minima(s => s.Length);
                 Assert.That(MoreEnumerable.LastOrDefault(minima), Is.EqualTo("az"));
             }
 
@@ -179,7 +179,7 @@ namespace MoreLinq.Test
             public void WithComparerReturnsMinimumPerComparer()
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.LastOrDefault(minima), Is.EqualTo("world"));
             }
 
@@ -187,7 +187,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length);
+                var minima = strings.Minima(s => s.Length);
                 Assert.That(MoreEnumerable.LastOrDefault(minima), Is.Null);
             }
 
@@ -195,7 +195,7 @@ namespace MoreLinq.Test
             public void WithEmptySourceWithComparerReturnsDefault()
             {
                 using var strings = Enumerable.Empty<string>().AsTestingSequence();
-                var minima = strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer);
+                var minima = strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer);
                 Assert.That(MoreEnumerable.LastOrDefault(minima), Is.Null);
             }
         }
@@ -212,7 +212,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMinima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MinBy(s => s.Length).Take(count).ToArray();
+                return strings.Minima(s => s.Length).Take(count).ToArray();
             }
 
             [TestCase(0, ExpectedResult = new string[0]             )]
@@ -222,7 +222,7 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMinimaPerComparer(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
+                return strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
                               .Take(count)
                               .ToArray();
             }
@@ -240,7 +240,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMinima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MinBy(s => s.Length).TakeLast(count).ToArray();
+                return strings.Minima(s => s.Length).TakeLast(count).ToArray();
             }
 
             [TestCase(0, ExpectedResult = new string[0]             )]
@@ -250,7 +250,7 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMinimaPerComparer(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.MinBy(s => s.Length, Comparable<int>.DescendingOrderComparer)
+                return strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
                               .TakeLast(count)
                               .ToArray();
             }

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -3396,6 +3396,58 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>MaxBy</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class MaxByExtension
+    {
+        /// <summary>
+        /// Returns the maximal elements of the given sequence, based on
+        /// the given projection.
+        /// </summary>
+        /// <remarks>
+        /// This overload uses the default comparer  for the projected type.
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <returns>The sequence of maximal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Maxima)} instead.")]
+        [ExcludeFromCodeCoverage]
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+            => MoreEnumerable.MaxBy(source, selector);
+
+        /// <summary>
+        /// Returns the maximal elements of the given sequence, based on
+        /// the given projection and the specified comparer for projected values.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <param name="comparer">Comparer to use to compare projected values</param>
+        /// <returns>The sequence of maximal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
+        /// or <paramref name="comparer"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Maxima)} instead.")]
+        [ExcludeFromCodeCoverage]
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+            => MoreEnumerable.MaxBy(source, selector, comparer);
+
+    }
+
     /// <summary><c>Maxima</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
@@ -3442,6 +3494,58 @@ namespace MoreLinq.Extensions
         public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
             => MoreEnumerable.Maxima(source, selector, comparer);
+
+    }
+
+    /// <summary><c>MinBy</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class MinByExtension
+    {
+        /// <summary>
+        /// Returns the minimal elements of the given sequence, based on
+        /// the given projection.
+        /// </summary>
+        /// <remarks>
+        /// This overload uses the default comparer for the projected type.
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <returns>The sequence of minimal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
+
+        [Obsolete($"Use {ExtremaMembers.Minima} instead.")]
+        [ExcludeFromCodeCoverage]
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+            => MoreEnumerable.MinBy(source, selector);
+
+        /// <summary>
+        /// Returns the minimal elements of the given sequence, based on
+        /// the given projection and the specified comparer for projected values.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <param name="comparer">Comparer to use to compare projected values</param>
+        /// <returns>The sequence of minimal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
+        /// or <paramref name="comparer"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Minima)} instead.")]
+        [ExcludeFromCodeCoverage]
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+            => MoreEnumerable.MinBy(source, selector, comparer);
 
     }
 

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -3396,10 +3396,10 @@ namespace MoreLinq.Extensions
 
     }
 
-    /// <summary><c>MaxBy</c> extension.</summary>
+    /// <summary><c>Maxima</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
-    public static partial class MaxByExtension
+    public static partial class MaximaExtension
     {
 
         /// <summary>
@@ -3418,9 +3418,9 @@ namespace MoreLinq.Extensions
         /// <returns>The sequence of maximal elements, according to the projection.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
-            => MoreEnumerable.MaxBy(source, selector);
+            => MoreEnumerable.Maxima(source, selector);
 
         /// <summary>
         /// Returns the maximal elements of the given sequence, based on
@@ -3439,16 +3439,16 @@ namespace MoreLinq.Extensions
         /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
         /// or <paramref name="comparer"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
-            => MoreEnumerable.MaxBy(source, selector, comparer);
+            => MoreEnumerable.Maxima(source, selector, comparer);
 
     }
 
-    /// <summary><c>MinBy</c> extension.</summary>
+    /// <summary><c>Minima</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
-    public static partial class MinByExtension
+    public static partial class MinimaExtension
     {
         /// <summary>
         /// Returns the minimal elements of the given sequence, based on
@@ -3466,9 +3466,9 @@ namespace MoreLinq.Extensions
         /// <returns>The sequence of minimal elements, according to the projection.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Minima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
-            => MoreEnumerable.MinBy(source, selector);
+            => MoreEnumerable.Minima(source, selector);
 
         /// <summary>
         /// Returns the minimal elements of the given sequence, based on
@@ -3487,9 +3487,9 @@ namespace MoreLinq.Extensions
         /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
         /// or <paramref name="comparer"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Minima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
-            => MoreEnumerable.MinBy(source, selector, comparer);
+            => MoreEnumerable.Minima(source, selector, comparer);
 
     }
 

--- a/MoreLinq/ExtremaMembers.cs
+++ b/MoreLinq/ExtremaMembers.cs
@@ -1,0 +1,25 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2023 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    static class ExtremaMembers
+    {
+        public const string Minima = nameof(MoreEnumerable.Minima);
+        public const string Maxima = nameof(MoreEnumerable.Maxima);
+    }
+}

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -1,0 +1,85 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns the maximal elements of the given sequence, based on
+        /// the given projection.
+        /// </summary>
+        /// <remarks>
+        /// This overload uses the default comparer  for the projected type.
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <returns>The sequence of maximal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Maxima)} instead.")]
+        [ExcludeFromCodeCoverage]
+#if !NET6_0_OR_GREATER
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+#else
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+#endif
+        {
+            return MaxBy(source, selector, null);
+        }
+
+        /// <summary>
+        /// Returns the maximal elements of the given sequence, based on
+        /// the given projection and the specified comparer for projected values.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <param name="comparer">Comparer to use to compare projected values</param>
+        /// <returns>The sequence of maximal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
+        /// or <paramref name="comparer"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Maxima)} instead.")]
+        [ExcludeFromCodeCoverage]
+#if !NET6_0_OR_GREATER
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+#else
+        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+#endif
+        {
+            return source.Maxima(selector, comparer);
+        }
+    }
+}

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -185,10 +185,10 @@ namespace MoreLinq
         /// <returns>The sequence of maximal elements, according to the projection.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
-            return source.MaxBy(selector, null);
+            return source.Maxima(selector, null);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
         /// or <paramref name="comparer"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MaxBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Maxima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));

--- a/MoreLinq/MinBy.cs
+++ b/MoreLinq/MinBy.cs
@@ -1,0 +1,85 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns the minimal elements of the given sequence, based on
+        /// the given projection.
+        /// </summary>
+        /// <remarks>
+        /// This overload uses the default comparer for the projected type.
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <returns>The sequence of minimal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
+
+        [Obsolete($"Use {ExtremaMembers.Minima} instead.")]
+        [ExcludeFromCodeCoverage]
+#if !NET6_0_OR_GREATER
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+#else
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(IEnumerable<TSource> source,
+            Func<TSource, TKey> selector)
+#endif
+        {
+            return MinBy(source, selector, null);
+        }
+
+        /// <summary>
+        /// Returns the minimal elements of the given sequence, based on
+        /// the given projection and the specified comparer for projected values.
+        /// </summary>
+        /// <remarks>
+        /// This operator uses deferred execution. The results are evaluated
+        /// and cached on first use to returned sequence.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of the source sequence</typeparam>
+        /// <typeparam name="TKey">Type of the projected element</typeparam>
+        /// <param name="source">Source sequence</param>
+        /// <param name="selector">Selector to use to pick the results to compare</param>
+        /// <param name="comparer">Comparer to use to compare projected values</param>
+        /// <returns>The sequence of minimal elements, according to the projection.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
+        /// or <paramref name="comparer"/> is null</exception>
+
+        [Obsolete($"Use {nameof(ExtremaMembers.Minima)} instead.")]
+        [ExcludeFromCodeCoverage]
+#if !NET6_0_OR_GREATER
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+#else
+        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(IEnumerable<TSource> source,
+            Func<TSource, TKey> selector, IComparer<TKey>? comparer)
+#endif
+        {
+            return source.Minima(selector, comparer);
+        }
+    }
+}

--- a/MoreLinq/Minima.cs
+++ b/MoreLinq/Minima.cs
@@ -38,10 +38,10 @@ namespace MoreLinq
         /// <returns>The sequence of minimal elements, according to the projection.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="selector"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Minima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector)
         {
-            return source.MinBy(selector, null);
+            return source.Minima(selector, null);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace MoreLinq
         /// <exception cref="ArgumentNullException"><paramref name="source"/>, <paramref name="selector"/>
         /// or <paramref name="comparer"/> is null</exception>
 
-        public static IExtremaEnumerable<TSource> MinBy<TSource, TKey>(this IEnumerable<TSource> source,
+        public static IExtremaEnumerable<TSource> Minima<TSource, TKey>(this IEnumerable<TSource> source,
             Func<TSource, TKey> selector, IComparer<TKey>? comparer)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -52,10 +52,10 @@
         - Lag
         - Lead
         - LeftJoin
-        - MaxBy
+        - Maxima
         - Memoize (EXPERIMENTAL)
         - Merge (EXPERIMENTAL)
-        - MinBy
+        - Minima
         - Move
         - OrderBy
         - OrderedMerge

--- a/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 #nullable enable
+*REMOVED*MoreLinq.Extensions.MaxByExtension
+*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
@@ -8,18 +14,32 @@
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) -> System.Collections.Generic.IEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.SkipLast<T>(this System.Collections.Generic.IEnumerable<T>! source, int count) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.TakeLast<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int count) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Collections.Generic.IEqualityComparer<TSource>? comparer) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.MaximaExtension
+MoreLinq.Extensions.MinimaExtension
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
 static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) -> System.Collections.Generic.IEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Prepend<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.SkipLast<T>(System.Collections.Generic.IEnumerable<T>! source, int count) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.TakeLast<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, int count) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,12 +1,6 @@
 #nullable enable
-*REMOVED*MoreLinq.Extensions.MaxByExtension
-*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
@@ -36,8 +30,12 @@ static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.G
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
 static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.DistinctBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! keySelector, System.Collections.Generic.IEqualityComparer<TKey>? comparer) -> System.Collections.Generic.IEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Prepend<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,15 +1,35 @@
 #nullable enable
+*REMOVED*MoreLinq.Extensions.MaxByExtension
+*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
 *REMOVED*static MoreLinq.MoreEnumerable.Concat<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.MaximaExtension
+MoreLinq.Extensions.MinimaExtension
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Prepend<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,20 +1,10 @@
 #nullable enable
-*REMOVED*MoreLinq.Extensions.MaxByExtension
-*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
 *REMOVED*static MoreLinq.MoreEnumerable.Concat<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
-*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
 MoreLinq.Extensions.MaximaExtension

--- a/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,21 +1,41 @@
 #nullable enable
+*REMOVED*MoreLinq.Extensions.MaxByExtension
+*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
 *REMOVED*static MoreLinq.MoreEnumerable.Concat<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.SkipLast<T>(this System.Collections.Generic.IEnumerable<T>! source, int count) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.TakeLast<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int count) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Collections.Generic.IEqualityComparer<TSource>? comparer) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.MaximaExtension
+MoreLinq.Extensions.MinimaExtension
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.Prepend<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 static MoreLinq.MoreEnumerable.SkipLast<T>(System.Collections.Generic.IEnumerable<T>! source, int count) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.TakeLast<TSource>(System.Collections.Generic.IEnumerable<TSource>! source, int count) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,20 +1,10 @@
 #nullable enable
-*REMOVED*MoreLinq.Extensions.MaxByExtension
-*REMOVED*MoreLinq.Extensions.MinByExtension
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MaxByExtension.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.Extensions.MinByExtension.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Append<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<System.Collections.Generic.IEnumerable<TSource>!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 *REMOVED*static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
 *REMOVED*static MoreLinq.MoreEnumerable.Concat<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
-*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MaxBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
-*REMOVED*static MoreLinq.MoreEnumerable.MinBy<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.SkipLast<T>(this System.Collections.Generic.IEnumerable<T>! source, int count) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.TakeLast<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int count) -> System.Collections.Generic.IEnumerable<TSource>!

--- a/README.md
+++ b/README.md
@@ -363,17 +363,21 @@ This method has 4 overloads.
 
 ### ~~MaxBy~~
 
-This method was renamed to [`Maxima`](#maxima) in version 4.0 to avoid conflict
-with the [`MaxBy`][linq-maxby] method introduced in .NET 6.0.
+:warning: **This method is obsolete. Use [`Maxima`](#maxima) instead.**
 
-[linq-maxby]: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby
+Returns the maxima (maximal elements) of the given sequence, based on the
+given projection.
+
+This method has 2 overloads.
 
 ### ~~MinBy~~
 
-This method was renamed to [`Minima`](#minima) in version 4.0 to avoid conflict
-with the [`MinBy`][linq-minby] method introduced in .NET 6.0.
+:warning: **This method is obsolete. Use [`Maxima`](#maxima) instead.**
 
-[linq-minby]: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby
+Returns the minima (minimal elements) of the given sequence, based on the
+given projection.
+
+This method has 2 overloads.
 
 ### Maxima
 

--- a/README.md
+++ b/README.md
@@ -361,14 +361,28 @@ Performs a left outer join between two sequences.
 
 This method has 4 overloads.
 
-### MaxBy
+### ~~MaxBy~~
+
+This method was renamed to [`Maxima`](#maxima) in version 4.0 to avoid conflict
+with the [`MaxBy`][linq-maxby] method introduced in .NET 6.0.
+
+[linq-maxby]: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby
+
+### ~~MinBy~~
+
+This method was renamed to [`Minima`](#minima) in version 4.0 to avoid conflict
+with the [`MinBy`][linq-minby] method introduced in .NET 6.0.
+
+[linq-minby]: https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.maxby
+
+### Maxima
 
 Returns the maxima (maximal elements) of the given sequence, based on the
 given projection.
 
 This method has 2 overloads.
 
-### MinBy
+### Minima
 
 Returns the minima (minimal elements) of the given sequence, based on the
 given projection.

--- a/README.md
+++ b/README.md
@@ -370,18 +370,18 @@ given projection.
 
 This method has 2 overloads.
 
+### Maxima
+
+Returns the maxima (maximal elements) of the given sequence, based on the
+given projection.
+
+This method has 2 overloads.
+
 ### ~~MinBy~~
 
 :warning: **This method is obsolete. Use [`Maxima`](#maxima) instead.**
 
 Returns the minima (minimal elements) of the given sequence, based on the
-given projection.
-
-This method has 2 overloads.
-
-### Maxima
-
-Returns the maxima (maximal elements) of the given sequence, based on the
 given projection.
 
 This method has 2 overloads.

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -120,7 +120,6 @@ static void Run(ProgramArguments args)
             where md.ParameterList.Parameters.Count > 0
                && md.ParameterList.Parameters.First().Modifiers.Any(m => m.Value is "this")
                && md.Modifiers.Any(m => m.Value is "public")
-               && md.AttributeLists.SelectMany(al => al.Attributes).All(a => a.Name.ToString() != "Obsolete")
             //
             // Build a dictionary of type abbreviations (e.g. TSource -> a,
             // TResult -> b, etc.) for the method's type parameters. If the


### PR DESCRIPTION
This PR closes #1018.

It introduces `Minima` as a replacement for `MinBy` and `Maxima` as a replacement for `MaxBy`.

`MinBy` and `MaxBy` are still there for compatibility, but marked obsolete. In .NET 6+, they are demoted from being extension methods to regular static ones, which should avoid conflicts with identically named methods introduced with .NET 6. Both methods are, however, exposed as extensions when statically imported via `MoreEnumerable.Extensions.MinByExtension` and `MoreEnumerable.Extensions.MaxByExtension`. These can conflict when a project migrates to .NET 6, but that would have happened anyway. These extensions are also marked as being superseded by their successors and so the developer should be guided to make the required change by using either `MoreEnumerable.Extensions.MinimaExtension`/`MoreEnumerable.Extensions.MaximaExtension` or simply reverting to importing `MoreLinq`.
