### PR TITLE
Remove redundant IsExternalInit package

### DIFF
--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -22,10 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Delegating" Version="1.3.1" />
-    <PackageReference Include="IsExternalInit" Version="1.0.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR removes the [**IsExternalInit**](https://www.nuget.org/packages/IsExternalInit) package reference from the test project that's redundant with [**PolySharp**](https://www.nuget.org/packages/PolySharp).
