### PR TITLE
Fix exception thrown when `Pad`/`PadStart` width is invalid

### DIFF
--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -17,20 +17,31 @@
 
 namespace MoreLinq.Test
 {
-    using NUnit.Framework;
     using System;
     using System.Collections.Generic;
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
 
     [TestFixture]
     public class PadStartTest
     {
-        // PadStart(source, width)
+        static readonly IEnumerable<ITestCaseData> PadStartWithNegativeWidthCases =
+            from e in new (string Name, TestDelegate Delegate)[]
+            {
+                ("DefaultPadding" , static () => new object[0].PadStart(-1)),
+                ("Padding"        , static () => new object[0].PadStart(-1, -2)),
+                ("PaddingSelector", static () => new object[0].PadStart(-1, BreakingFunc.Of<int, int>())),
+            }
+            select new TestCaseData(e.Delegate).SetName(e.Name);
 
-        [Test]
-        public void PadStartWithNegativeWidth()
+        [TestCaseSource(nameof(PadStartWithNegativeWidthCases))]
+        public void PadStartWithNegativeWidth(TestDelegate @delegate)
         {
-            Assert.That(() => new int[0].PadStart(-1), Throws.ArgumentException("width"));
+            Assert.That(@delegate, Throws.ArgumentOutOfRangeException("width")
+                                         .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
         }
+
+        // PadStart(source, width)
 
         [Test]
         public void PadStartIsLazy()
@@ -62,12 +73,6 @@ namespace MoreLinq.Test
         // PadStart(source, width, padding)
 
         [Test]
-        public void PadStartWithPaddingWithNegativeWidth()
-        {
-            Assert.That(() => new int[0].PadStart(-1, 1), Throws.ArgumentException("width"));
-        }
-
-        [Test]
         public void PadStartWithPaddingIsLazy()
         {
             _ = new BreakingSequence<int>().PadStart(0, -1);
@@ -92,14 +97,6 @@ namespace MoreLinq.Test
             {
                 AssertEqual(source, x => x.PadStart(width, string.Empty), expected);
             }
-        }
-
-        // PadStart(source, width, paddingSelector)
-
-        [Test]
-        public void PadStartWithSelectorWithNegativeWidth()
-        {
-            Assert.That(() => new int[0].PadStart(-1, x => x), Throws.ArgumentException("width"));
         }
 
         [Test]

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -17,15 +17,44 @@
 
 namespace MoreLinq.Test
 {
+    using System;
+    using System.Collections.Generic;
     using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
 
     [TestFixture]
     public class PadTest
     {
-        [Test]
-        public void PadNegativeWidth()
+        static readonly IEnumerable<ITestCaseData> PadNegativeWidthCases =
+            from e in new (string Name, TestDelegate Delegate)[]
+            {
+                ("DefaultPadding" , static () => new object[0].Pad(-1)),
+                ("Padding"        , static () => new object[0].Pad(-1, -2)),
+                ("PaddingSelector", static () => new object[0].Pad(-1, BreakingFunc.Of<int, int>())),
+            }
+            select new TestCaseData(e.Delegate).SetName(e.Name);
+
+        [TestCaseSource(nameof(PadNegativeWidthCases))]
+        public void PadNegativeWidth(TestDelegate @delegate)
         {
-            Assert.That(() => new object[0].Pad(-1), Throws.ArgumentException("width"));
+            Assert.That(@delegate, Throws.ArgumentOutOfRangeException("width")
+                                         .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
+        }
+
+        [Test]
+        public void PadPaddingNegativeWidth()
+        {
+            Assert.That(() => new object[0].Pad(-1, -2),
+                        Throws.ArgumentOutOfRangeException("width")
+                              .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
+        }
+
+        [Test]
+        public void PadPaddingSelectorNegativeWidth()
+        {
+            Assert.That(() => new object[0].Pad(-1, BreakingFunc.Of<int, int>()),
+                        Throws.ArgumentOutOfRangeException("width")
+                              .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
         }
 
         [Test]

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -42,22 +42,6 @@ namespace MoreLinq.Test
         }
 
         [Test]
-        public void PadPaddingNegativeWidth()
-        {
-            Assert.That(() => new object[0].Pad(-1, -2),
-                        Throws.ArgumentOutOfRangeException("width")
-                              .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
-        }
-
-        [Test]
-        public void PadPaddingSelectorNegativeWidth()
-        {
-            Assert.That(() => new object[0].Pad(-1, BreakingFunc.Of<int, int>()),
-                        Throws.ArgumentOutOfRangeException("width")
-                              .And.Property(nameof(ArgumentOutOfRangeException.ActualValue)).EqualTo(-1));
-        }
-
-        [Test]
         public void PadIsLazy()
         {
             _ = new BreakingSequence<object>().Pad(0);

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -77,7 +77,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> Pad<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            if (width < 0) throw new ArgumentOutOfRangeException(nameof(width), width, null);
             return PadImpl(source, width, padding, null);
         }
 
@@ -109,7 +109,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            if (width < 0) throw new ArgumentOutOfRangeException(nameof(width), width, null);
             return PadImpl(source, width, default, paddingSelector);
         }
 

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -76,7 +76,7 @@ namespace MoreLinq
         public static IEnumerable<TSource> PadStart<TSource>(this IEnumerable<TSource> source, int width, TSource padding)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            if (width < 0) throw new ArgumentOutOfRangeException(nameof(width), width, null);
             return PadStartImpl(source, width, padding, null);
         }
 
@@ -110,7 +110,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (paddingSelector == null) throw new ArgumentNullException(nameof(paddingSelector));
-            if (width < 0) throw new ArgumentException(null, nameof(width));
+            if (width < 0) throw new ArgumentOutOfRangeException(nameof(width), width, null);
             return PadStartImpl(source, width, default, paddingSelector);
         }
 


### PR DESCRIPTION
This PR fixes #1027 and #1028.