### PR TITLE
Don't validate content of `otherSequences` argument of `Interleave`

### DIFF
--- a/MoreLinq.Test/InterleaveTest.cs
+++ b/MoreLinq.Test/InterleaveTest.cs
@@ -51,20 +51,6 @@ namespace MoreLinq.Test
         }
 
         /// <summary>
-        /// Verify that Interleave early throw ArgumentNullException when an element
-        /// of otherSequences is null.
-        /// </summary>
-        [Test]
-        public void TestInterleaveEarlyThrowOnNullElementInOtherSequences()
-        {
-            var sequenceA = Enumerable.Range(1, 1);
-            var otherSequences = new IEnumerable<int>[] { null! };
-
-            Assert.That(() => sequenceA.Interleave(otherSequences),
-                        Throws.ArgumentNullException("otherSequences"));
-        }
-
-        /// <summary>
         /// Verify that interleaving disposes those enumerators that it managed
         /// to open successfully
         /// </summary>

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -54,8 +54,6 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
             if (otherSequences == null) throw new ArgumentNullException(nameof(otherSequences));
-            if (otherSequences.Any(s => s == null))
-                throw new ArgumentNullException(nameof(otherSequences), "One or more sequences passed to Interleave was null.");
 
             return Impl(otherSequences.Prepend(sequence));
 


### PR DESCRIPTION
This PR fixes #1029.
