### PR TITLE
Add `AggregateOrDefault`

### DIFF
--- a/MoreLinq.Test/AggregateOrDefaultTest.cs
+++ b/MoreLinq.Test/AggregateOrDefaultTest.cs
@@ -1,0 +1,70 @@
+﻿namespace MoreLinq.Test
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AggregateOrDefaultTest
+    {
+        [Test]
+        public void AggregateOrDefaultWhenCollectionIsNull()
+        {
+            string[]? collection = null;
+
+            var e1 = Assert.Throws<ArgumentNullException>(
+                () => collection!.AggregateOrDefault((curr, next) => curr + next));
+            var e2 = Assert.Throws<ArgumentNullException>(
+                () => collection!.AggregateOrDefault((curr, next) => curr + next, "<null>"));
+
+            Assert.That(e1?.ParamName, Is.EqualTo("source"));
+            Assert.That(e2?.ParamName, Is.EqualTo("source"));
+        }
+
+        [Test]
+        public void AggregateOrDefaultWhenFuncIsNull()
+        {
+            var collection = System.Linq.Enumerable.Empty<string>().ToList();
+
+            var e1 = Assert.Throws<ArgumentNullException>(
+                () => collection.AggregateOrDefault(null!));
+            var e2 = Assert.Throws<ArgumentNullException>(
+                () => collection.AggregateOrDefault(null!, "<null>"));
+
+            Assert.That(e1?.ParamName, Is.EqualTo("func"));
+            Assert.That(e2?.ParamName, Is.EqualTo("func"));
+        }
+
+        [Test]
+        public void AggregateOrDefaultWhenCollectionIsEmpty()
+        {
+            var collection = System.Linq.Enumerable.Empty<string>().ToList();
+            var result1 = collection.AggregateOrDefault((curr, next) => curr + next);
+            var result2 = collection.AggregateOrDefault((curr, next) => curr + next, "<null>");
+
+            Assert.That(result1, Is.Null);
+            Assert.That(result2, Is.EqualTo("<null>"));
+        }
+
+        [Test]
+        public void AggregateOrDefaultWhenCollectionHasOneElement()
+        {
+            var collection = new[] { "john" };
+            var result1 = collection.AggregateOrDefault((curr, next) => curr + next);
+            var result2 = collection.AggregateOrDefault((curr, next) => curr + next, "<null>");
+
+            Assert.That(result1, Is.EqualTo("john"));
+            Assert.That(result2, Is.EqualTo("john"));
+        }
+
+        [Test]
+        public void AggregateOrDefaultWhenCollectionHasManyElements()
+        {
+            var collection = new[] { "john", "jane", "alex" };
+            var result1 = collection.AggregateOrDefault((curr, next) => curr + next);
+            var result2 = collection.AggregateOrDefault((curr, next) => curr + next, "<null>");
+
+            Assert.That(result1, Is.EqualTo("johnjanealex"));
+            Assert.That(result2, Is.EqualTo("johnjanealex"));
+        }
+    }
+}

--- a/MoreLinq/AggregateOrDefault.cs
+++ b/MoreLinq/AggregateOrDefault.cs
@@ -1,0 +1,62 @@
+﻿namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>Applies an accumulator function over a sequence, or a default value if sequence contains no elements.</summary>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to aggregate over.</param>
+        /// <param name="func">An accumulator function to be invoked on each element.</param>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="func" /> is <see langword="null" />.</exception>
+        /// <returns><see langword="default" />(<typeparamref name="TSource" />) if <paramref name="source" /> is empty; otherwise, the final accumulator value.</returns>
+        public static TSource? AggregateOrDefault<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TSource, TSource> func)
+        {
+            return TryAggregate(source, func, out _);
+        }
+
+        /// <summary>Applies an accumulator function over a sequence, or a specified default value if sequence contains no elements.</summary>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to aggregate over.</param>
+        /// <param name="func">An accumulator function to be invoked on each element.</param>
+        /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="func" /> is <see langword="null" />.</exception>
+        /// <returns><paramref name="defaultValue"/> if <paramref name="source" /> is empty; otherwise, the final accumulator value.</returns>
+        public static TSource AggregateOrDefault<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TSource, TSource> func,
+            TSource defaultValue)
+        {
+            var value = TryAggregate(source, func, out var success);
+            return success ? value! : defaultValue;
+        }
+
+        static TSource? TryAggregate<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TSource, TSource> func,
+            out bool success)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (func == null) throw new ArgumentNullException(nameof(func));
+
+            using var e = source.GetEnumerator();
+            if (!e.MoveNext())
+            {
+                success = false;
+                return default;
+            }
+
+            var result = e.Current;
+            while (e.MoveNext())
+            {
+                result = func(result, e.Current);
+            }
+
+            success = true;
+            return result;
+        }
+    }
+}

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -346,6 +346,37 @@ namespace MoreLinq.Extensions
 
     }
 
+    /// <summary><c>AggregateOrDefault</c> extension.</summary>
+
+    [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]
+    public static partial class AggregateOrDefaultExtension
+    {
+        /// <summary>Applies an accumulator function over a sequence, or a default value if sequence contains no elements.</summary>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to aggregate over.</param>
+        /// <param name="func">An accumulator function to be invoked on each element.</param>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="func" /> is <see langword="null" />.</exception>
+        /// <returns><see langword="default" />(<typeparamref name="TSource" />) if <paramref name="source" /> is empty; otherwise, the final accumulator value.</returns>
+        public static TSource? AggregateOrDefault<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TSource, TSource> func)
+            => MoreEnumerable.AggregateOrDefault(source, func);
+
+        /// <summary>Applies an accumulator function over a sequence, or a specified default value if sequence contains no elements.</summary>
+        /// <param name="source">An <see cref="IEnumerable{T}" /> to aggregate over.</param>
+        /// <param name="func">An accumulator function to be invoked on each element.</param>
+        /// <param name="defaultValue">The default value to return if the sequence is empty.</param>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+        /// <exception cref="ArgumentNullException"><paramref name="source" /> or <paramref name="func" /> is <see langword="null" />.</exception>
+        /// <returns><paramref name="defaultValue"/> if <paramref name="source" /> is empty; otherwise, the final accumulator value.</returns>
+        public static TSource AggregateOrDefault<TSource>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TSource, TSource> func,
+            TSource defaultValue)
+            => MoreEnumerable.AggregateOrDefault(source, func, defaultValue);
+
+    }
+
     /// <summary><c>AggregateRight</c> extension.</summary>
 
     [GeneratedCode("MoreLinq.ExtensionsGenerator", "1.0.0.0")]

--- a/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -17,14 +17,19 @@
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Collections.Generic.IEqualityComparer<TSource>? comparer) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.AggregateOrDefaultExtension
 MoreLinq.Extensions.MaximaExtension
 MoreLinq.Extensions.MinimaExtension
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!

--- a/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,14 +7,19 @@
 *REMOVED*static MoreLinq.MoreEnumerable.Concat<T>(this System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 *REMOVED*static MoreLinq.MoreEnumerable.Prepend<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, TSource value) -> System.Collections.Generic.IEnumerable<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.AggregateOrDefaultExtension
 MoreLinq.Extensions.MaximaExtension
 MoreLinq.Extensions.MinimaExtension
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!

--- a/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MoreLinq/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -11,14 +11,19 @@
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.ToHashSet<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Collections.Generic.IEqualityComparer<TSource>? comparer) -> System.Collections.Generic.HashSet<TSource>!
 *REMOVED*static MoreLinq.MoreEnumerable.Windowed<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<TSource>!>!
+MoreLinq.Extensions.AggregateOrDefaultExtension
 MoreLinq.Extensions.MaximaExtension
 MoreLinq.Extensions.MinimaExtension
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.Extensions.AggregateOrDefaultExtension.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.Extensions.BatchExtension.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.Extensions.BatchExtension.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MaximaExtension.Maxima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector) -> MoreLinq.IExtremaEnumerable<TSource>!
 static MoreLinq.Extensions.MinimaExtension.Minima<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TKey>! selector, System.Collections.Generic.IComparer<TKey>? comparer) -> MoreLinq.IExtremaEnumerable<TSource>!
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func) -> TSource?
+static MoreLinq.MoreEnumerable.AggregateOrDefault<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, System.Func<TSource, TSource, TSource>! func, TSource defaultValue) -> TSource
 static MoreLinq.MoreEnumerable.Append<T>(System.Collections.Generic.IEnumerable<T>! head, T tail) -> System.Collections.Generic.IEnumerable<T>!
 static MoreLinq.MoreEnumerable.Batch<TSource, TResult>(this System.Collections.Generic.IEnumerable<TSource>! source, int size, System.Func<TSource[]!, TResult>! resultSelector) -> System.Collections.Generic.IEnumerable<TResult>!
 static MoreLinq.MoreEnumerable.Batch<TSource>(this System.Collections.Generic.IEnumerable<TSource>! source, int size) -> System.Collections.Generic.IEnumerable<TSource[]!>!

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Applies multiple accumulators sequentially in a single pass over a sequence.
 
 This method has 7 overloads.
 
+### AggregateOrDefault
+
+Applies an accumulator function over a sequence, or a default value if sequence contains no elements.
+
+This method has 2 overloads.
+
 ### AggregateRight
 
 Applies a right-associative accumulator function over a sequence.


### PR DESCRIPTION
Add the extension method `AggregateOrDefault` allowing to aggregate over empty collections by returning a default value.