### PR TITLE
Enable `ImplicitUsings`

### DIFF
--- a/MoreLinq/Acquire.cs
+++ b/MoreLinq/Acquire.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/AggregateRight.cs
+++ b/MoreLinq/AggregateRight.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Append.cs
+++ b/MoreLinq/Append.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/AssemblyInfo.cs
+++ b/MoreLinq/AssemblyInfo.cs
@@ -15,7 +15,6 @@
 // limitations under the License.
 #endregion
 
-using System;
 using System.Reflection;
 
 [assembly: AssemblyTitle("MoreLINQ")]

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Choose.cs
+++ b/MoreLinq/Choose.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Represents a union over list types implementing either <see
     /// cref="ICollection{T}"/> or <see cref="IReadOnlyCollection{T}"/>,

--- a/MoreLinq/Collections/Dictionary.cs
+++ b/MoreLinq/Collections/Dictionary.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq.Collections
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>

--- a/MoreLinq/Consume.cs
+++ b/MoreLinq/Consume.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/CountMethods.cs
+++ b/MoreLinq/CountMethods.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Delegating.cs
+++ b/MoreLinq/Delegating.cs
@@ -26,9 +26,6 @@
 
 namespace Delegating
 {
-    using System;
-    using System.Threading;
-
     static class Delegate
     {
         public static IDisposable Disposable(Action delegatee) =>

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/EquiZip.cs
+++ b/MoreLinq/EquiZip.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Evaluate.cs
+++ b/MoreLinq/Evaluate.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Experimental/Aggregate.cs
+++ b/MoreLinq/Experimental/Aggregate.cs
@@ -17,8 +17,7 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
-    using Reactive;
+    using MoreLinq.Reactive;
 
     static partial class ExperimentalEnumerable
     {

--- a/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
+++ b/MoreLinq/Experimental/Async/ExperimentalEnumerable.cs
@@ -2,8 +2,6 @@
 
 namespace MoreLinq.Experimental.Async
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// <para>
     /// Provides a set of static methods for querying objects that

--- a/MoreLinq/Experimental/Async/Merge.cs
+++ b/MoreLinq/Experimental/Async/Merge.cs
@@ -19,12 +19,7 @@
 
 namespace MoreLinq.Experimental.Async
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.CompilerServices;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     partial class ExperimentalEnumerable
     {

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -17,14 +17,9 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
     using System.Collections;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.ExceptionServices;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents options for a query whose results evaluate asynchronously.

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -19,11 +19,7 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
     using System.Buffers;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
 
     static partial class ExperimentalEnumerable
     {

--- a/MoreLinq/Experimental/CurrentBuffer.cs
+++ b/MoreLinq/Experimental/CurrentBuffer.cs
@@ -19,10 +19,7 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Represents a current buffered view of a larger result and which

--- a/MoreLinq/Experimental/ExperimentalEnumerable.cs
+++ b/MoreLinq/Experimental/ExperimentalEnumerable.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq.Experimental
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// <para>
     /// Provides a set of static methods for querying objects that

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -17,9 +17,7 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.Runtime.ExceptionServices;
 
     static partial class ExperimentalEnumerable

--- a/MoreLinq/Experimental/TrySingle.cs
+++ b/MoreLinq/Experimental/TrySingle.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq.Experimental
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     partial class ExperimentalEnumerable
     {
         /// <summary>

--- a/MoreLinq/Extensions.ToDataTable.g.cs
+++ b/MoreLinq/Extensions.ToDataTable.g.cs
@@ -31,9 +31,7 @@
 
 namespace MoreLinq.Extensions
 {
-    using System;
     using System.CodeDom.Compiler;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Data;
     using System.Linq.Expressions;

--- a/MoreLinq/Extensions.g.cs
+++ b/MoreLinq/Extensions.g.cs
@@ -31,9 +31,7 @@
 
 namespace MoreLinq.Extensions
 {
-    using System;
     using System.CodeDom.Compiler;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Collections;

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/FillBackward.cs
+++ b/MoreLinq/FillBackward.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/FillForward.cs
+++ b/MoreLinq/FillForward.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -19,9 +19,7 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
 
     static partial class MoreEnumerable
     {

--- a/MoreLinq/Fold.cs
+++ b/MoreLinq/Fold.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         static T[] Fold<T>(this IEnumerable<T> source, int count)

--- a/MoreLinq/ForEach.cs
+++ b/MoreLinq/ForEach.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     // Inspiration & credit: http://stackoverflow.com/a/13503860/6682
     static partial class MoreEnumerable
     {

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Generate.cs
+++ b/MoreLinq/Generate.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/GenerateByIndex.cs
+++ b/MoreLinq/GenerateByIndex.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/GlobalRandom.cs
+++ b/MoreLinq/GlobalRandom.cs
@@ -19,11 +19,6 @@
 
 namespace MoreLinq
 {
-    using System;
-#if !NET6_0_OR_GREATER
-    using System.Threading;
-#endif
-
     public static partial class MoreEnumerable
     {
         /// <remarks>

--- a/MoreLinq/GroupAdjacent.cs
+++ b/MoreLinq/GroupAdjacent.cs
@@ -17,11 +17,8 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Linq;
 
     static partial class MoreEnumerable
     {

--- a/MoreLinq/Index.cs
+++ b/MoreLinq/Index.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/IndexBy.cs
+++ b/MoreLinq/IndexBy.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Interleave.cs
+++ b/MoreLinq/Interleave.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/LeftJoin.cs
+++ b/MoreLinq/LeftJoin.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Represents a union over list types implementing either
     /// <see cref="IList{T}"/> or <see cref="IReadOnlyList{T}"/>, allowing

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -30,12 +30,9 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
 
     /// <summary>
     /// A <see cref="ILookup{TKey, TElement}"/> implementation that preserves insertion order

--- a/MoreLinq/MaxBy.cs
+++ b/MoreLinq/MaxBy.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     static partial class MoreEnumerable

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -17,10 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Exposes the enumerator, which supports iteration over a sequence of

--- a/MoreLinq/MinBy.cs
+++ b/MoreLinq/MinBy.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     static partial class MoreEnumerable

--- a/MoreLinq/Minima.cs
+++ b/MoreLinq/Minima.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/MoreEnumerable.cs
+++ b/MoreLinq/MoreEnumerable.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Provides a set of static methods for querying objects that
     /// implement <see cref="IEnumerable{T}" />.

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -145,6 +145,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+	<ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/NestedLoops.cs
+++ b/MoreLinq/NestedLoops.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         // This extension method was developed (primarily) to support the

--- a/MoreLinq/OrderBy.cs
+++ b/MoreLinq/OrderBy.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Pad.cs
+++ b/MoreLinq/Pad.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/PartialSort.cs
+++ b/MoreLinq/PartialSort.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/PendNode.cs
+++ b/MoreLinq/PendNode.cs
@@ -17,9 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Prepend-Append node is a single linked-list of the discriminated union

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -17,11 +17,8 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
 
     public static partial class MoreEnumerable
     {

--- a/MoreLinq/Pipe.cs
+++ b/MoreLinq/Pipe.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Prepend.cs
+++ b/MoreLinq/Prepend.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Random.cs
+++ b/MoreLinq/Random.cs
@@ -19,9 +19,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/RandomSubset.cs
+++ b/MoreLinq/RandomSubset.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Reactive/Observable.cs
+++ b/MoreLinq/Reactive/Observable.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq.Reactive
 {
-    using System;
     using Delegate = Delegating.Delegate;
 
     /// <summary>

--- a/MoreLinq/Repeat.cs
+++ b/MoreLinq/Repeat.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using Experimental;
 
     public static partial class MoreEnumerable

--- a/MoreLinq/Return.cs
+++ b/MoreLinq/Return.cs
@@ -17,9 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
 
     partial class MoreEnumerable
     {

--- a/MoreLinq/ReverseComparer.cs
+++ b/MoreLinq/ReverseComparer.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System.Collections.Generic;
-
     sealed class ReverseComparer<T>(IComparer<T>? underlying) : IComparer<T>
     {
         readonly IComparer<T> _underlying = underlying ?? Comparer<T>.Default;

--- a/MoreLinq/RightJoin.cs
+++ b/MoreLinq/RightJoin.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Scan.cs
+++ b/MoreLinq/Scan.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ScanRight.cs
+++ b/MoreLinq/ScanRight.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Sequence.cs
+++ b/MoreLinq/Sequence.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/SequenceException.cs
+++ b/MoreLinq/SequenceException.cs
@@ -17,7 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
 
     /// <summary>
     /// The exception that is thrown for a sequence that fails a condition.

--- a/MoreLinq/Shuffle.cs
+++ b/MoreLinq/Shuffle.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/SkipLast.cs
+++ b/MoreLinq/SkipLast.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
 

--- a/MoreLinq/StartsWith.cs
+++ b/MoreLinq/StartsWith.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -17,10 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
     using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
 
     public static partial class MoreEnumerable
     {

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/TakeEvery.cs
+++ b/MoreLinq/TakeEvery.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/TakeUntil.cs
+++ b/MoreLinq/TakeUntil.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ToArrayByIndex.cs
+++ b/MoreLinq/ToArrayByIndex.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -17,10 +17,7 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using System.Data;
-    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
 

--- a/MoreLinq/ToDelimitedString.cs
+++ b/MoreLinq/ToDelimitedString.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
 
     static partial class MoreEnumerable

--- a/MoreLinq/ToDictionary.cs
+++ b/MoreLinq/ToDictionary.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ToHashSet.cs
+++ b/MoreLinq/ToHashSet.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     // TODO: Tests! (The code is simple enough I trust it not to fail, mind you...)
     static partial class MoreEnumerable
     {

--- a/MoreLinq/ToLookup.cs
+++ b/MoreLinq/ToLookup.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Trace.cs
+++ b/MoreLinq/Trace.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Transpose.cs
+++ b/MoreLinq/Transpose.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/Unfold.cs
+++ b/MoreLinq/Unfold.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/UnreachableException.cs
+++ b/MoreLinq/UnreachableException.cs
@@ -32,8 +32,6 @@ global using UnreachableException = System.Diagnostics.UnreachableException;
 
 namespace MoreLinq
 {
-    using System;
-
     // Source: https://github.com/dotnet/runtime/blob/v7.0.2/src/libraries/System.Private.CoreLib/src/System/Diagnostics/UnreachableException.cs
 
     /// <summary>

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/WindowLeft.cs
+++ b/MoreLinq/WindowLeft.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -17,10 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     public static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ZipImpl.cs
+++ b/MoreLinq/ZipImpl.cs
@@ -17,8 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
     using System.Collections;
 
     static partial class MoreEnumerable

--- a/MoreLinq/ZipLongest.cs
+++ b/MoreLinq/ZipLongest.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/MoreLinq/ZipShortest.cs
+++ b/MoreLinq/ZipShortest.cs
@@ -17,9 +17,6 @@
 
 namespace MoreLinq
 {
-    using System;
-    using System.Collections.Generic;
-
     static partial class MoreEnumerable
     {
         /// <summary>

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -211,9 +211,7 @@ static void Run(ProgramArguments args)
 
     var baseImports = new[]
     {
-        "System",
         "System.CodeDom.Compiler",
-        "System.Collections.Generic",
         "System.Diagnostics.CodeAnalysis",
     };
 


### PR DESCRIPTION
This PR enables `ImplicitUsings` on the MoreLinq project and removes (now-)unnecessary `using`s on relevant files. This is a pre-requisite for #947 

Open questions:
* Should we enable `ImplicitUsings` on the other projects as well?
* Are there any non-default `using`s we should add to/remove from the implicit set? I could make the argument to remove `System.Linq` from the set, or to add `System.Collections` to the set of implicit usings, for example.
* Should we use a `GlobalUsings.cs` file instead of enabling `ImplicitUsings`? I prefer `ImplicitUsings`, because I don't like random files with no code, but `GlobalUsings.cs` would be more explicit.