### PR TITLE
Set package validation baseline to version 4.0

### DIFF
--- a/MoreLinq/CompatibilitySuppressions.xml
+++ b/MoreLinq/CompatibilitySuppressions.xml
@@ -2,231 +2,63 @@
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.AppendExtension</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.PrependExtension</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.AppendExtension</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.PrependExtension</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.AppendExtension</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.SkipLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
     <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.PrependExtension</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.TakeLast``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
     <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.AppendExtension</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0001</DiagnosticId>
-    <Target>T:MoreLinq.Extensions.PrependExtension</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.ToHashSet``1(System.Collections.Generic.IEnumerable{``0},System.Collections.Generic.IEqualityComparer{``0})</Target>
+    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
     <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.Extensions.BatchExtension.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
+    <Target>M:MoreLinq.MoreEnumerable.ToHashSet``1(System.Collections.Generic.IEnumerable{``0})</Target>
+    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Append``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Concat``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Prepend``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Windowed``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
-    <Left>lib/net462/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.Extensions.BatchExtension.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Append``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Concat``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Prepend``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Windowed``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net6.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.Extensions.BatchExtension.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Append``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Concat``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Prepend``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Windowed``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
-    <Left>lib/netstandard2.0/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.0/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.Extensions.BatchExtension.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Append``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Batch``2(System.Collections.Generic.IEnumerable{``0},System.Int32,System.Func{System.Collections.Generic.IEnumerable{``0},``1})</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Concat``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Prepend``1(System.Collections.Generic.IEnumerable{``0},``0)</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:MoreLinq.MoreEnumerable.Windowed``1(System.Collections.Generic.IEnumerable{``0},System.Int32)</Target>
-    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
-    <IsBaselineSuppression>true</IsBaselineSuppression>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>PKV006</DiagnosticId>
-    <Target>.NETStandard,Version=v1.0</Target>
   </Suppression>
 </Suppressions>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -135,7 +135,7 @@
     <PackageOutputPath>..\dist</PackageOutputPath>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>3.4.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
This PR sets the package validation baseline to the [latest release, 4.0](https://github.com/morelinq/MoreLINQ/releases/tag/v4.0.0) and updates the `CompatibilitySuppressions.xml` file accordingly.