### PR TITLE
Simplify `Slice` operator

### DIFF
--- a/MoreLinq.Test/SliceTest.cs
+++ b/MoreLinq.Test/SliceTest.cs
@@ -127,23 +127,5 @@ namespace MoreLinq.Test
             Assert.That(resultA, Is.EqualTo(sequenceA.Skip(count / 2).Take(count)));
             Assert.That(resultB, Is.EqualTo(sequenceB.Skip(count / 2).Take(count)));
         }
-
-        /// <summary>
-        /// Verify that slice is optimized for <see cref="IList{T}"/> and <see cref="IReadOnlyList{T}"/> implementations and does not
-        /// unnecessarily traverse items outside of the slice region.
-        /// </summary>
-        [TestCase(SourceKind.BreakingList)]
-        [TestCase(SourceKind.BreakingReadOnlyList)]
-        public void TestSliceOptimization(SourceKind sourceKind)
-        {
-            const int sliceStart = 4;
-            const int sliceCount = 3;
-            var sequence = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }.ToSourceKind(sourceKind);
-
-            var result = sequence.Slice(sliceStart, sliceCount);
-
-            Assert.That(result.Count(), Is.EqualTo(sliceCount));
-            Assert.That(Enumerable.Range(5, sliceCount), Is.EqualTo(result));
-        }
     }
 }

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     public static partial class MoreEnumerable
     {
@@ -53,19 +52,21 @@ namespace MoreLinq
             if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex));
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
 
-            return sequence switch
-            {
-                IList<T> list => SliceList(list.Count, i => list[i]),
-                IReadOnlyList<T> list => SliceList(list.Count, i => list[i]),
-                var seq => seq.Skip(startIndex).Take(count)
-            };
+            return Core();
 
-            IEnumerable<T> SliceList(int listCount, Func<int, T> indexer)
+            IEnumerable<T> Core()
             {
-                var countdown = count;
-                var index = startIndex;
-                while (index < listCount && countdown-- > 0)
-                    yield return indexer(index++);
+                using var e = sequence.GetEnumerator();
+
+                var index = 0;
+                while (index < startIndex && e.MoveNext())
+                    index++;
+
+                while (count > 0 && e.MoveNext())
+                {
+                    count--;
+                    yield return e.Current;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR simplifies the `Slice` operator. It no longer uses information from `IList<>`, and operates efficiently on all enumerators. 