### PR TITLE
Set simple field naming rules with `this` qualifier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,42 @@ dotnet_analyzer_diagnostic.category-Style.severity = warning
 # IDE0022: Use expression/block body for methods
 dotnet_diagnostic.IDE0022.severity = suggestion
 
+# IDE1006: Naming rule violation
+dotnet_diagnostic.IDE1006.severity = warning
+
+# Naming capitalization styles
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# Naming rule that private instance fields must use camel case
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_rule.camel_case_private_fields.severity = warning
+dotnet_naming_rule.camel_case_private_fields.symbols = private_fields
+dotnet_naming_rule.camel_case_private_fields.style = camel_case_style
+
+# Naming rule that static read-only fields must use Pascal case
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = readonly, static
+dotnet_naming_rule.pascal_case_static_readonly_fields.severity = warning
+dotnet_naming_rule.pascal_case_static_readonly_fields.symbols = static_readonly_fields
+dotnet_naming_rule.pascal_case_static_readonly_fields.style = pascal_case_style
+
+# Naming rule that const fields must use Pascal case
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.applicable_accessibilities = *
+dotnet_naming_symbols.const_fields.required_modifiers = const
+dotnet_naming_rule.pascal_case_const_fields.severity = warning
+dotnet_naming_rule.pascal_case_const_fields.symbols = const_fields
+dotnet_naming_rule.pascal_case_const_fields.style = pascal_case_style
+
+# this. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true
 csharp_style_var_when_type_is_apparent = true

--- a/MoreLinq.Test/Async/MergeTest.cs
+++ b/MoreLinq.Test/Async/MergeTest.cs
@@ -86,22 +86,22 @@ namespace MoreLinq.Test.Async
         {
             sealed record State(TaskCompletionSource<T> TaskCompletionSource, T Result);
 
-            State? _state;
+            State? state;
 
             public Task<T> Result(T result)
             {
-                if (_state is not null)
+                if (this.state is not null)
                     throw new InvalidOperationException();
-                _state = new State(new TaskCompletionSource<T>(), result);
-                return _state.TaskCompletionSource.Task;
+                this.state = new State(new TaskCompletionSource<T>(), result);
+                return this.state.TaskCompletionSource.Task;
             }
 
             public void Complete()
             {
-                if (_state is not { } state)
+                if (this.state is not { } someState)
                     throw new InvalidOperationException();
-                _state = null;
-                state.TaskCompletionSource.SetResult(state.Result);
+                this.state = null;
+                someState.TaskCompletionSource.SetResult(someState.Result);
             }
         }
 

--- a/MoreLinq.Test/Async/TestingAsyncSequence.cs
+++ b/MoreLinq.Test/Async/TestingAsyncSequence.cs
@@ -43,14 +43,14 @@ namespace MoreLinq.Test.Async
 
     sealed class TestingAsyncSequence<T> : IAsyncEnumerable<T>, IDisposable
     {
-        bool? _disposed;
-        IAsyncEnumerable<T>? _source;
-        ExceptionDispatchInfo? _disposeErrorInfo;
+        bool? disposed;
+        IAsyncEnumerable<T>? source;
+        ExceptionDispatchInfo? disposeErrorInfo;
 
         internal TestingAsyncSequence(IAsyncEnumerable<T> sequence) =>
-            _source = sequence;
+            this.source = sequence;
 
-        public bool IsDisposed => _disposed == true;
+        public bool IsDisposed => this.disposed == true;
         public int MoveNextCallCount { get; private set; }
 
         void IDisposable.Dispose() =>
@@ -62,24 +62,24 @@ namespace MoreLinq.Test.Async
 
         void AssertDisposed()
         {
-            _disposeErrorInfo?.Throw();
+            this.disposeErrorInfo?.Throw();
 
-            if (_disposed is null)
+            if (this.disposed is null)
                 return;
 
-            Assert.IsTrue(_disposed, "Expected sequence to be disposed.");
-            _disposed = null;
+            Assert.IsTrue(this.disposed, "Expected sequence to be disposed.");
+            this.disposed = null;
         }
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
-            Assert.That(_source, Is.Not.Null,
+            Assert.That(this.source, Is.Not.Null,
                         "LINQ operators should not enumerate a sequence more than once.");
 
             // Dammit (!) below is okay since we assert above it's not null.
-            var enumerator = _source!.GetAsyncEnumerator(cancellationToken).AsWatchable();
+            var enumerator = this.source!.GetAsyncEnumerator(cancellationToken).AsWatchable();
 
-            _disposed = false;
+            this.disposed = false;
             enumerator.Disposed += delegate
             {
                 // If the following assertion fails the capture the error
@@ -90,14 +90,14 @@ namespace MoreLinq.Test.Async
 
                 try
                 {
-                    Assert.That(_disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
+                    Assert.That(this.disposed, Is.False, "LINQ operators should not dispose a sequence more than once.");
                 }
                 catch (AssertionException e)
                 {
-                    _disposeErrorInfo = ExceptionDispatchInfo.Capture(e);
+                    this.disposeErrorInfo = ExceptionDispatchInfo.Capture(e);
                 }
 
-                _disposed = true;
+                this.disposed = true;
             };
 
             var ended = false;
@@ -108,7 +108,7 @@ namespace MoreLinq.Test.Async
                 MoveNextCallCount++;
             };
 
-            _source = null;
+            this.source = null;
             return enumerator;
         }
     }

--- a/MoreLinq.Test/Async/WatchableEnumerator.cs
+++ b/MoreLinq.Test/Async/WatchableEnumerator.cs
@@ -29,23 +29,23 @@ namespace MoreLinq.Test.Async
     sealed class WatchableEnumerator<T>(IAsyncEnumerator<T> source) :
         IAsyncEnumerator<T>
     {
-        readonly IAsyncEnumerator<T> _source = source ?? throw new ArgumentNullException(nameof(source));
+        readonly IAsyncEnumerator<T> source = source ?? throw new ArgumentNullException(nameof(source));
 
         public event EventHandler? Disposed;
         public event EventHandler<bool>? MoveNextCalled;
 
-        public T Current => _source.Current;
+        public T Current => this.source.Current;
 
         public async ValueTask<bool> MoveNextAsync()
         {
-            var moved = await _source.MoveNextAsync();
+            var moved = await this.source.MoveNextAsync();
             MoveNextCalled?.Invoke(this, moved);
             return moved;
         }
 
         public async ValueTask DisposeAsync()
         {
-            await _source.DisposeAsync();
+            await this.source.DisposeAsync();
             Disposed?.Invoke(this, EventArgs.Empty);
         }
     }

--- a/MoreLinq.Test/BatchTest.cs
+++ b/MoreLinq.Test/BatchTest.cs
@@ -375,34 +375,34 @@ namespace MoreLinq.Test
 
         sealed class TestArrayPool<T> : ArrayPool<T>, IDisposable
         {
-            T[]? _pooledArray;
-            T[]? _rentedArray;
+            T[]? pooledArray;
+            T[]? rentedArray;
 
             public override T[] Rent(int minimumLength)
             {
-                if (_pooledArray is null && _rentedArray is null)
-                    _pooledArray = new T[minimumLength * 2];
+                if (this.pooledArray is null && this.rentedArray is null)
+                    this.pooledArray = new T[minimumLength * 2];
 
-                (_pooledArray, _rentedArray) =
-                    (null, _pooledArray ?? throw new InvalidOperationException("The pool is exhausted."));
+                (this.pooledArray, this.rentedArray) =
+                    (null, this.pooledArray ?? throw new InvalidOperationException("The pool is exhausted."));
 
-                return _rentedArray;
+                return this.rentedArray;
             }
 
             public override void Return(T[] array, bool clearArray = false)
             {
-                if (_rentedArray is null)
+                if (this.rentedArray is null)
                     throw new InvalidOperationException("Cannot return when nothing has been rented from this pool.");
 
-                if (array != _rentedArray)
+                if (array != this.rentedArray)
                     throw new InvalidOperationException("Cannot return what has not been rented from this pool.");
 
-                _pooledArray = array;
-                _rentedArray = null;
+                this.pooledArray = array;
+                this.rentedArray = null;
             }
 
             public void Dispose() =>
-                Assert.That(_rentedArray, Is.Null);
+                Assert.That(this.rentedArray, Is.Null);
         }
     }
 }

--- a/MoreLinq.Test/BreakingCollection.cs
+++ b/MoreLinq.Test/BreakingCollection.cs
@@ -23,9 +23,9 @@ namespace MoreLinq.Test
     class BreakingCollection<T>(IList<T> list) :
         BreakingSequence<T>, ICollection<T>
     {
-        protected readonly IList<T> List = list;
-
         public BreakingCollection(params T[] values) : this((IList<T>)values) { }
+
+        protected IList<T> List { get; } = list;
 
         public int Count => List.Count;
 

--- a/MoreLinq.Test/BreakingReadOnlyCollection.cs
+++ b/MoreLinq.Test/BreakingReadOnlyCollection.cs
@@ -22,10 +22,10 @@ namespace MoreLinq.Test
     class BreakingReadOnlyCollection<T>(IReadOnlyCollection<T> collection) :
         BreakingSequence<T>, IReadOnlyCollection<T>
     {
-        readonly IReadOnlyCollection<T> _collection = collection;
+        readonly IReadOnlyCollection<T> collection = collection;
 
         public BreakingReadOnlyCollection(params T[] values) : this((IReadOnlyCollection<T>)values) { }
 
-        public int Count => _collection.Count;
+        public int Count => this.collection.Count;
     }
 }

--- a/MoreLinq.Test/BreakingReadOnlyList.cs
+++ b/MoreLinq.Test/BreakingReadOnlyList.cs
@@ -31,10 +31,10 @@ namespace MoreLinq.Test
         BreakingReadOnlyCollection<T>(list),
         IReadOnlyList<T>
     {
-        readonly IReadOnlyList<T> _list = list;
+        readonly IReadOnlyList<T> list = list;
 
         public BreakingReadOnlyList(params T[] values) : this((IReadOnlyList<T>)values) { }
 
-        public T this[int index] => _list[index];
+        public T this[int index] => this.list[index];
     }
 }

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -152,13 +152,13 @@ namespace MoreLinq.Test
 
             abstract class Sequence<T> : IEnumerable<T>
             {
-                readonly Func<IEnumerator<T>, IEnumerator<T>> _em;
+                readonly Func<IEnumerator<T>, IEnumerator<T>> em;
 
                 protected Sequence(Func<IEnumerator<T>, IEnumerator<T>>? em) =>
-                    _em = em ?? (e => e);
+                    this.em = em ?? (e => e);
 
                 public IEnumerator<T> GetEnumerator() =>
-                    _em(Items.GetEnumerator());
+                    this.em(Items.GetEnumerator());
 
                 IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -174,15 +174,15 @@ namespace MoreLinq.Test
                                        Func<IEnumerator<T>, IEnumerator<T>>? em = null) :
                 Sequence<T>(em), ICollection<T>
             {
-                readonly ICollection<T> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+                readonly ICollection<T> collection = collection ?? throw new ArgumentNullException(nameof(collection));
 
-                public int Count => _collection.Count;
-                public bool IsReadOnly => _collection.IsReadOnly;
+                public int Count => this.collection.Count;
+                public bool IsReadOnly => this.collection.IsReadOnly;
 
-                protected override IEnumerable<T> Items => _collection;
+                protected override IEnumerable<T> Items => this.collection;
 
-                public bool Contains(T item) => _collection.Contains(item);
-                public void CopyTo(T[] array, int arrayIndex) => _collection.CopyTo(array, arrayIndex);
+                public bool Contains(T item) => this.collection.Contains(item);
+                public void CopyTo(T[] array, int arrayIndex) => this.collection.CopyTo(array, arrayIndex);
 
                 public void Add(T item) => throw new NotImplementedException();
                 public void Clear() => throw new NotImplementedException();
@@ -198,11 +198,11 @@ namespace MoreLinq.Test
                                                Func<IEnumerator<T>, IEnumerator<T>>? em = null) :
                 Sequence<T>(em), IReadOnlyCollection<T>
             {
-                readonly ICollection<T> _collection = collection ?? throw new ArgumentNullException(nameof(collection));
+                readonly ICollection<T> collection = collection ?? throw new ArgumentNullException(nameof(collection));
 
-                public int Count => _collection.Count;
+                public int Count => this.collection.Count;
 
-                protected override IEnumerable<T> Items => _collection;
+                protected override IEnumerable<T> Items => this.collection;
             }
         }
 

--- a/MoreLinq.Test/EqualityComparer.cs
+++ b/MoreLinq.Test/EqualityComparer.cs
@@ -32,20 +32,20 @@ namespace MoreLinq.Test
 
         sealed class DelegatingComparer<T> : IEqualityComparer<T>
         {
-            readonly Func<T?, T?, bool> _comparer;
-            readonly Func<T, int> _hasher;
+            readonly Func<T?, T?, bool> comparer;
+            readonly Func<T, int> hasher;
 
             public DelegatingComparer(Func<T?, T?, bool> comparer)
                 : this(comparer, x => x == null ? 0 : x.GetHashCode()) { }
 
             DelegatingComparer(Func<T?, T?, bool> comparer, Func<T, int> hasher)
             {
-                _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-                _hasher = hasher ?? throw new ArgumentNullException(nameof(hasher));
+                this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+                this.hasher = hasher ?? throw new ArgumentNullException(nameof(hasher));
             }
 
-            public bool Equals(T? x, T? y) => _comparer(x, y);
-            public int GetHashCode(T obj) => _hasher(obj);
+            public bool Equals(T? x, T? y) => this.comparer(x, y);
+            public int GetHashCode(T obj) => this.hasher(obj);
         }
     }
 }

--- a/MoreLinq.Test/ReadOnlyCollection.cs
+++ b/MoreLinq.Test/ReadOnlyCollection.cs
@@ -29,12 +29,12 @@ namespace MoreLinq.Test
             IReadOnlyCollection<T>
             where TList : IList<T>
         {
-            readonly TList _list = list;
+            readonly TList list = list;
 
-            public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+            public IEnumerator<T> GetEnumerator() => this.list.GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-            public int Count => _list.Count;
+            public int Count => this.list.Count;
         }
     }
 }

--- a/MoreLinq.Test/Scope.cs
+++ b/MoreLinq.Test/Scope.cs
@@ -21,10 +21,10 @@ namespace MoreLinq.Test
 
     abstract class Scope<T> : IDisposable
     {
-        readonly T _old;
+        readonly T old;
 
-        protected Scope(T current) => _old = current;
-        public virtual void Dispose() => Restore(_old);
+        protected Scope(T current) => this.old = current;
+        public virtual void Dispose() => Restore(this.old);
         protected abstract void Restore(T old);
     }
 }

--- a/MoreLinq.Test/SequenceReader.cs
+++ b/MoreLinq.Test/SequenceReader.cs
@@ -42,7 +42,7 @@ namespace MoreLinq.Test
     /// <param name="enumerator">Source enumerator.</param>
     sealed class SequenceReader<T>(IEnumerator<T> enumerator) : IDisposable
     {
-        IEnumerator<T>? _enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
+        IEnumerator<T>? enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
 
         /// <summary>
         /// Initializes a <see cref="SequenceReader{T}" /> instance
@@ -60,7 +60,7 @@ namespace MoreLinq.Test
         }
 
         IEnumerator<T> Enumerator =>
-            _enumerator ?? throw new ObjectDisposedException(GetType().FullName);
+            this.enumerator ?? throw new ObjectDisposedException(GetType().FullName);
 
         /// <summary>
         /// Reads a value otherwise throws <see cref="InvalidOperationException"/>
@@ -100,9 +100,9 @@ namespace MoreLinq.Test
 
         public void Dispose()
         {
-            var e = _enumerator;
+            var e = this.enumerator;
             if (e == null) return;
-            _enumerator = null;
+            this.enumerator = null;
             e.Dispose();
         }
     }

--- a/MoreLinq.Test/TestingSequence.cs
+++ b/MoreLinq.Test/TestingSequence.cs
@@ -64,45 +64,45 @@ namespace MoreLinq.Test
     /// </summary>
     sealed class TestingSequence<T> : IEnumerable<T>, IDisposable
     {
-        readonly IEnumerable<T> _sequence;
-        readonly Options _options;
-        readonly int _maxEnumerations;
+        readonly IEnumerable<T> sequence;
+        readonly Options options;
+        readonly int maxEnumerations;
 
-        int _disposedCount;
-        int _enumerationCount;
+        int disposedCount;
+        int enumerationCount;
 
         internal TestingSequence(IEnumerable<T> sequence, Options options, int maxEnumerations)
         {
-            _sequence = sequence;
-            _maxEnumerations = maxEnumerations;
-            _options = options;
+            this.sequence = sequence;
+            this.maxEnumerations = maxEnumerations;
+            this.options = options;
         }
 
         public int MoveNextCallCount { get; private set; }
-        public bool IsDisposed => _enumerationCount > 0 && _disposedCount == _enumerationCount;
+        public bool IsDisposed => this.enumerationCount > 0 && this.disposedCount == this.enumerationCount;
 
         void IDisposable.Dispose()
         {
-            if (_enumerationCount > 0)
-                Assert.That(_disposedCount, Is.EqualTo(_enumerationCount), ExpectedDisposal);
+            if (this.enumerationCount > 0)
+                Assert.That(this.disposedCount, Is.EqualTo(this.enumerationCount), ExpectedDisposal);
         }
 
         public IEnumerator<T> GetEnumerator()
         {
-            Assert.That(_enumerationCount, Is.LessThan(_maxEnumerations), TooManyEnumerations);
-            Assert.That(_enumerationCount, Is.EqualTo(_disposedCount), SimultaneousEnumerations);
-            _enumerationCount++;
+            Assert.That(this.enumerationCount, Is.LessThan(this.maxEnumerations), TooManyEnumerations);
+            Assert.That(this.enumerationCount, Is.EqualTo(this.disposedCount), SimultaneousEnumerations);
+            this.enumerationCount++;
 
-            var enumerator = _sequence.GetEnumerator().AsWatchable();
+            var enumerator = this.sequence.GetEnumerator().AsWatchable();
             var disposed = false;
             enumerator.Disposed += delegate
             {
                 if (!disposed)
                 {
-                    _disposedCount++;
+                    this.disposedCount++;
                     disposed = true;
                 }
-                else if (!_options.HasFlag(Options.AllowRepeatedDisposals))
+                else if (!this.options.HasFlag(Options.AllowRepeatedDisposals))
                 {
                     Assert.Fail(TooManyDisposals);
                 }
@@ -112,7 +112,7 @@ namespace MoreLinq.Test
             enumerator.MoveNextCalled += (_, moved) =>
             {
                 Assert.That(disposed, Is.False, MoveNextPostDisposal);
-                if (!_options.HasFlag(Options.AllowRepeatedMoveNexts))
+                if (!this.options.HasFlag(Options.AllowRepeatedMoveNexts))
                     Assert.That(ended, Is.False, MoveNextPostEnumeration);
 
                 ended = !moved;

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -42,20 +42,20 @@ namespace MoreLinq.Test
         }
 
 
-        readonly IReadOnlyCollection<TestObject> _testObjects;
+        readonly IReadOnlyCollection<TestObject> testObjects;
 
 
         public ToDataTableTest() =>
-            _testObjects = Enumerable.Range(0, 3)
-                                     .Select(i => new TestObject(i))
-                                     .ToArray();
+            this.testObjects = Enumerable.Range(0, 3)
+                                         .Select(i => new TestObject(i))
+                                         .ToArray();
 
         [Test]
         public void ToDataTableNullMemberExpressionMethod()
         {
             Expression<Func<TestObject, object?>>? expression = null;
 
-            Assert.That(() => _testObjects.ToDataTable(expression!),
+            Assert.That(() => this.testObjects.ToDataTable(expression!),
                         Throws.ArgumentException("expressions"));
         }
 
@@ -65,7 +65,7 @@ namespace MoreLinq.Test
             using var dt = new DataTable();
             _ = dt.Columns.Add("Test");
 
-            Assert.That(() => _testObjects.ToDataTable(dt),
+            Assert.That(() => this.testObjects.ToDataTable(dt),
                         Throws.ArgumentException("table"));
         }
 
@@ -75,14 +75,14 @@ namespace MoreLinq.Test
             using var dt = new DataTable();
             _ = dt.Columns.Add("AString", typeof(int));
 
-            Assert.That(() => _testObjects.ToDataTable(dt, t => t.AString),
+            Assert.That(() => this.testObjects.ToDataTable(dt, t => t.AString),
                         Throws.ArgumentException("table"));
         }
 
         [Test]
         public void ToDataTableMemberExpressionMethod()
         {
-            Assert.That(() => _testObjects.ToDataTable(t => t.ToString()),
+            Assert.That(() => this.testObjects.ToDataTable(t => t.ToString()),
                         Throws.ArgumentException("lambda"));
         }
 
@@ -90,28 +90,28 @@ namespace MoreLinq.Test
         [Test]
         public void ToDataTableMemberExpressionNonMember()
         {
-            Assert.That(() => _testObjects.ToDataTable(t => t.ToString().Length),
+            Assert.That(() => this.testObjects.ToDataTable(t => t.ToString().Length),
                         Throws.ArgumentException("lambda"));
         }
 
         [Test]
         public void ToDataTableMemberExpressionIndexer()
         {
-            Assert.That(() => _testObjects.ToDataTable(t => t[0]),
+            Assert.That(() => this.testObjects.ToDataTable(t => t[0]),
                         Throws.ArgumentException("lambda"));
         }
 
         [Test]
         public void ToDataTableMemberExpressionStatic()
         {
-            Assert.That(() => _ = _testObjects.ToDataTable(_ => DateTime.Now),
+            Assert.That(() => _ = this.testObjects.ToDataTable(_ => DateTime.Now),
                         Throws.ArgumentException("lambda"));
         }
 
         [Test]
         public void ToDataTableSchemaInDeclarationOrder()
         {
-            var dt = _testObjects.ToDataTable();
+            var dt = this.testObjects.ToDataTable();
 
             // Assert properties first, then fields, then in declaration order
 
@@ -134,14 +134,14 @@ namespace MoreLinq.Test
         [Test]
         public void ToDataTableContainsAllElements()
         {
-            var dt = _testObjects.ToDataTable();
-            Assert.That(dt.Rows.Count, Is.EqualTo(_testObjects.Count));
+            var dt = this.testObjects.ToDataTable();
+            Assert.That(dt.Rows.Count, Is.EqualTo(this.testObjects.Count));
         }
 
         [Test]
         public void ToDataTableWithExpression()
         {
-            var dt = _testObjects.ToDataTable(t => t.AString);
+            var dt = this.testObjects.ToDataTable(t => t.AString);
 
             Assert.That(dt.Columns[0].Caption, Is.EqualTo("AString"));
             Assert.That(dt.Columns[0].DataType, Is.EqualTo(typeof(string)));

--- a/MoreLinq.Test/TrySingleTest.cs
+++ b/MoreLinq.Test/TrySingleTest.cs
@@ -72,9 +72,9 @@ namespace MoreLinq.Test
 
         class BreakingSingleElementCollectionBase<T> : IEnumerable<T>
         {
-            readonly T _element;
+            readonly T element;
 
-            protected BreakingSingleElementCollectionBase(T element) => _element = element;
+            protected BreakingSingleElementCollectionBase(T element) => this.element = element;
 
 #pragma warning disable CA1822 // Mark members as static
             public int Count => 1;
@@ -82,7 +82,7 @@ namespace MoreLinq.Test
 
             public IEnumerator<T> GetEnumerator()
             {
-                yield return _element;
+                yield return this.element;
                 Assert.Fail($"{nameof(ExperimentalEnumerable.TrySingle)} should not have attempted to consume a second element.");
             }
 

--- a/MoreLinq.Test/WatchableEnumerator.cs
+++ b/MoreLinq.Test/WatchableEnumerator.cs
@@ -29,7 +29,7 @@ namespace MoreLinq.Test
     sealed class WatchableEnumerator<T>(IEnumerator<T> source) :
         IEnumerator<T>
     {
-        readonly IEnumerator<T> _source = source ?? throw new ArgumentNullException(nameof(source));
+        readonly IEnumerator<T> source = source ?? throw new ArgumentNullException(nameof(source));
 
         public event EventHandler? Disposed;
         public event EventHandler? GetCurrentCalled;
@@ -40,24 +40,24 @@ namespace MoreLinq.Test
             get
             {
                 GetCurrentCalled?.Invoke(this, EventArgs.Empty);
-                return _source.Current;
+                return this.source.Current;
             }
         }
 
         object? IEnumerator.Current => this.Current;
 
-        public void Reset() => _source.Reset();
+        public void Reset() => this.source.Reset();
 
         public bool MoveNext()
         {
-            var moved = _source.MoveNext();
+            var moved = this.source.MoveNext();
             MoveNextCalled?.Invoke(this, moved);
             return moved;
         }
 
         public void Dispose()
         {
-            _source.Dispose();
+            this.source.Dispose();
             Disposed?.Invoke(this, EventArgs.Empty);
         }
     }

--- a/MoreLinq/CollectionLike.cs
+++ b/MoreLinq/CollectionLike.cs
@@ -29,25 +29,25 @@ namespace MoreLinq
 
     readonly struct CollectionLike<T>
     {
-        readonly ICollection<T>? _rw;
-        readonly IReadOnlyCollection<T>? _ro;
+        readonly ICollection<T>? rw;
+        readonly IReadOnlyCollection<T>? ro;
 
         public CollectionLike(ICollection<T> collection)
         {
-            _rw = collection ?? throw new ArgumentNullException(nameof(collection));
-            _ro = null;
+            this.rw = collection ?? throw new ArgumentNullException(nameof(collection));
+            this.ro = null;
         }
 
         public CollectionLike(IReadOnlyCollection<T> collection)
         {
-            _rw = null;
-            _ro = collection ?? throw new ArgumentNullException(nameof(collection));
+            this.rw = null;
+            this.ro = collection ?? throw new ArgumentNullException(nameof(collection));
         }
 
-        public int Count => _rw?.Count ?? _ro?.Count ?? 0;
+        public int Count => this.rw?.Count ?? this.ro?.Count ?? 0;
 
         public IEnumerator<T> GetEnumerator() =>
-            _rw?.GetEnumerator() ?? _ro?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
+            this.rw?.GetEnumerator() ?? this.ro?.GetEnumerator() ?? Enumerable.Empty<T>().GetEnumerator();
     }
 
     static class CollectionLike

--- a/MoreLinq/Collections/Dictionary.cs
+++ b/MoreLinq/Collections/Dictionary.cs
@@ -30,24 +30,24 @@ namespace MoreLinq.Collections
 
     sealed class Dictionary<TKey, TValue>
     {
-        readonly System.Collections.Generic.Dictionary<ValueTuple<TKey>, TValue> _dict;
+        readonly System.Collections.Generic.Dictionary<ValueTuple<TKey>, TValue> dict;
 
         public Dictionary(IEqualityComparer<TKey> comparer)
         {
             var keyComparer = ReferenceEquals(comparer, EqualityComparer<TKey>.Default)
                             ? null
                             : new ValueTupleItemComparer<TKey>(comparer);
-            _dict = new System.Collections.Generic.Dictionary<ValueTuple<TKey>, TValue>(keyComparer);
+            this.dict = new System.Collections.Generic.Dictionary<ValueTuple<TKey>, TValue>(keyComparer);
         }
 
         public TValue this[TKey key]
         {
-            get => _dict[ValueTuple.Create(key)];
-            set => _dict[ValueTuple.Create(key)] = value;
+            get => this.dict[ValueTuple.Create(key)];
+            set => this.dict[ValueTuple.Create(key)] = value;
         }
 
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) =>
-            _dict.TryGetValue(ValueTuple.Create(key), out value);
+            this.dict.TryGetValue(ValueTuple.Create(key), out value);
 
         sealed class ValueTupleItemComparer<T>(IEqualityComparer<T> comparer) :
             IEqualityComparer<ValueTuple<T>>

--- a/MoreLinq/Delegating.cs
+++ b/MoreLinq/Delegating.cs
@@ -42,12 +42,12 @@ namespace Delegating
 
     sealed class DelegatingDisposable(Action delegatee) : IDisposable
     {
-        Action? _delegatee = delegatee ?? throw new ArgumentNullException(nameof(delegatee));
+        Action? delegatee = delegatee ?? throw new ArgumentNullException(nameof(delegatee));
 
         public void Dispose()
         {
-            var delegatee = _delegatee;
-            if (delegatee == null || Interlocked.CompareExchange(ref _delegatee, null, delegatee) != delegatee)
+            var delegatee = this.delegatee;
+            if (delegatee == null || Interlocked.CompareExchange(ref this.delegatee, null, delegatee) != delegatee)
                 return;
             delegatee();
         }
@@ -58,10 +58,10 @@ namespace Delegating
                                        Action? onCompleted = null) :
         IObserver<T>
     {
-        readonly Action<T> _onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
+        readonly Action<T> onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
 
         public void OnCompleted() => onCompleted?.Invoke();
         public void OnError(Exception error) => onError?.Invoke(error);
-        public void OnNext(T value) => _onNext(value);
+        public void OnNext(T value) => this.onNext(value);
     }
 }

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -756,27 +756,27 @@ namespace MoreLinq.Experimental
         {
             public static readonly ConcurrencyGate Unbounded = new();
 
-            readonly SemaphoreSlim? _semaphore;
+            readonly SemaphoreSlim? semaphore;
 
             ConcurrencyGate(SemaphoreSlim? semaphore = null) =>
-                _semaphore = semaphore;
+                this.semaphore = semaphore;
 
             public ConcurrencyGate(int max) :
                 this(new SemaphoreSlim(max, max)) { }
 
             public Task EnterAsync(CancellationToken token)
             {
-                if (_semaphore == null)
+                if (this.semaphore == null)
                 {
                     token.ThrowIfCancellationRequested();
                     return CompletedTask.Instance;
                 }
 
-                return _semaphore.WaitAsync(token);
+                return this.semaphore.WaitAsync(token);
             }
 
             public void Exit() =>
-                _semaphore?.Release();
+                this.semaphore?.Release();
         }
     }
 }

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -228,26 +228,26 @@ namespace MoreLinq.Experimental
 
         sealed class CurrentPoolArrayProvider<T> : CurrentBuffer<T>, ICurrentBufferProvider<T>
         {
-            bool _rented;
-            T[] _array = [];
-            int _count;
-            IEnumerator<(T[], int)>? _rental;
-            ArrayPool<T>? _pool;
+            bool rented;
+            T[] array = [];
+            int count;
+            IEnumerator<(T[], int)>? rental;
+            ArrayPool<T>? pool;
 
             public CurrentPoolArrayProvider(IEnumerator<(T[], int)> rental, ArrayPool<T> pool) =>
-                (_rental, _pool) = (rental, pool);
+                (this.rental, this.pool) = (rental, pool);
 
             ICurrentBuffer<T> ICurrentBufferProvider<T>.CurrentBuffer => this;
 
             public bool UpdateWithNext()
             {
-                if (_rental is { Current: var (array, _) } rental)
+                if (this.rental is { Current: var (array, _) } rental)
                 {
-                    Debug.Assert(_pool is not null);
-                    if (_rented)
+                    Debug.Assert(this.pool is not null);
+                    if (this.rented)
                     {
-                        _pool.Return(array);
-                        _rented = false;
+                        this.pool.Return(array);
+                        this.rented = false;
                     }
 
                     if (!rental.MoveNext())
@@ -256,34 +256,34 @@ namespace MoreLinq.Experimental
                         return false;
                     }
 
-                    _rented = true;
-                    (_array, _count) = rental.Current;
+                    this.rented = true;
+                    (this.array, this.count) = rental.Current;
                     return true;
                 }
 
                 return false;
             }
 
-            public override int Count => _count;
+            public override int Count => this.count;
 
             public override T this[int index]
             {
-                get => index >= 0 && index < Count ? _array[index] : throw new ArgumentOutOfRangeException(nameof(index));
+                get => index >= 0 && index < Count ? this.array[index] : throw new ArgumentOutOfRangeException(nameof(index));
                 set => throw new NotSupportedException();
             }
 
             public void Dispose()
             {
-                if (_rental is { Current: var (array, _) } enumerator)
+                if (this.rental is { Current: var (array, _) } enumerator)
                 {
-                    Debug.Assert(_pool is not null);
-                    if (_rented)
-                        _pool.Return(array);
+                    Debug.Assert(this.pool is not null);
+                    if (this.rented)
+                        this.pool.Return(array);
                     enumerator.Dispose();
-                    _array = [];
-                    _count = 0;
-                    _rental = null;
-                    _pool = null;
+                    this.array = [];
+                    this.count = 0;
+                    this.rental = null;
+                    this.pool = null;
                 }
             }
         }

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -64,32 +64,32 @@ namespace MoreLinq.Experimental
 
     sealed class MemoizedEnumerable<T>(IEnumerable<T> sequence) : IEnumerable<T>, IDisposable
     {
-        List<T>? _cache;
-        readonly object _locker = new();
-        readonly IEnumerable<T> _source = sequence ?? throw new ArgumentNullException(nameof(sequence));
-        IEnumerator<T>? _sourceEnumerator;
-        int? _errorIndex;
-        ExceptionDispatchInfo? _error;
+        List<T>? cache;
+        readonly object locker = new();
+        readonly IEnumerable<T> source = sequence ?? throw new ArgumentNullException(nameof(sequence));
+        IEnumerator<T>? sourceEnumerator;
+        int? errorIndex;
+        ExceptionDispatchInfo? error;
 
         public IEnumerator<T> GetEnumerator()
         {
-            if (_cache == null)
+            if (this.cache == null)
             {
-                lock (_locker)
+                lock (this.locker)
                 {
-                    if (_cache == null)
+                    if (this.cache == null)
                     {
-                        _error?.Throw();
+                        this.error?.Throw();
 
                         try
                         {
                             var cache = new List<T>(); // for exception safety, allocate then...
-                            _sourceEnumerator = _source.GetEnumerator(); // (because this can fail)
-                            _cache = cache; // ...commit to state
+                            this.sourceEnumerator = this.source.GetEnumerator(); // (because this can fail)
+                            this.cache = cache; // ...commit to state
                         }
                         catch (Exception ex)
                         {
-                            _error = ExceptionDispatchInfo.Capture(ex);
+                            this.error = ExceptionDispatchInfo.Capture(ex);
                             throw;
                         }
                     }
@@ -103,46 +103,46 @@ namespace MoreLinq.Experimental
                 while (true)
                 {
                     T current;
-                    lock (_locker)
+                    lock (this.locker)
                     {
-                        if (_cache == null) // Cache disposed during iteration?
+                        if (this.cache == null) // Cache disposed during iteration?
                             throw new ObjectDisposedException(nameof(MemoizedEnumerable<T>));
 
-                        if (index >= _cache.Count)
+                        if (index >= this.cache.Count)
                         {
-                            if (index == _errorIndex)
-                                Assume.NotNull(_error).Throw();
+                            if (index == this.errorIndex)
+                                Assume.NotNull(this.error).Throw();
 
-                            if (_sourceEnumerator == null)
+                            if (this.sourceEnumerator == null)
                                 break;
 
                             bool moved;
                             try
                             {
-                                moved = _sourceEnumerator.MoveNext();
+                                moved = this.sourceEnumerator.MoveNext();
                             }
                             catch (Exception ex)
                             {
-                                _error = ExceptionDispatchInfo.Capture(ex);
-                                _errorIndex = index;
-                                _sourceEnumerator.Dispose();
-                                _sourceEnumerator = null;
+                                this.error = ExceptionDispatchInfo.Capture(ex);
+                                this.errorIndex = index;
+                                this.sourceEnumerator.Dispose();
+                                this.sourceEnumerator = null;
                                 throw;
                             }
 
                             if (moved)
                             {
-                                _cache.Add(_sourceEnumerator.Current);
+                                this.cache.Add(this.sourceEnumerator.Current);
                             }
                             else
                             {
-                                _sourceEnumerator.Dispose();
-                                _sourceEnumerator = null;
+                                this.sourceEnumerator.Dispose();
+                                this.sourceEnumerator = null;
                                 break;
                             }
                         }
 
-                        current = _cache[index];
+                        current = this.cache[index];
                     }
 
                     yield return current;
@@ -155,13 +155,13 @@ namespace MoreLinq.Experimental
 
         public void Dispose()
         {
-            lock (_locker)
+            lock (this.locker)
             {
-                _error = null;
-                _cache = null;
-                _errorIndex = null;
-                _sourceEnumerator?.Dispose();
-                _sourceEnumerator = null;
+                this.error = null;
+                this.cache = null;
+                this.errorIndex = null;
+                this.sourceEnumerator?.Dispose();
+                this.sourceEnumerator = null;
             }
         }
     }

--- a/MoreLinq/GlobalRandom.cs
+++ b/MoreLinq/GlobalRandom.cs
@@ -48,9 +48,9 @@ namespace MoreLinq
         {
             public static Random Instance { get; } = new GlobalRandom();
 
-            static int _seed = Environment.TickCount;
-            [ThreadStatic] static Random? _threadRandom;
-            static Random ThreadRandom => _threadRandom ??= new Random(Interlocked.Increment(ref _seed));
+            static int seed = Environment.TickCount;
+            [ThreadStatic] static Random? threadRandom;
+            static Random ThreadRandom => threadRandom ??= new Random(Interlocked.Increment(ref seed));
 
             GlobalRandom() { }
 

--- a/MoreLinq/ListLike.cs
+++ b/MoreLinq/ListLike.cs
@@ -29,25 +29,25 @@ namespace MoreLinq
 
     readonly struct ListLike<T>
     {
-        readonly IList<T>? _rw;
-        readonly IReadOnlyList<T>? _ro;
+        readonly IList<T>? rw;
+        readonly IReadOnlyList<T>? ro;
 
         public ListLike(IList<T> list)
         {
-            _rw = list ?? throw new ArgumentNullException(nameof(list));
-            _ro = null;
+            this.rw = list ?? throw new ArgumentNullException(nameof(list));
+            this.ro = null;
         }
 
         public ListLike(IReadOnlyList<T> list)
         {
-            _rw = null;
-            _ro = list ?? throw new ArgumentNullException(nameof(list));
+            this.rw = null;
+            this.ro = list ?? throw new ArgumentNullException(nameof(list));
         }
 
-        public int Count => _rw?.Count ?? _ro?.Count ?? 0;
+        public int Count => this.rw?.Count ?? this.ro?.Count ?? 0;
 
-        public T this[int index] => _rw is { } rw ? rw[index]
-                                  : _ro is { } rx ? rx[index]
+        public T this[int index] => this.rw is { } rw ? rw[index]
+                                  : this.ro is { } rx ? rx[index]
                                   : throw new ArgumentOutOfRangeException(nameof(index));
     }
 

--- a/MoreLinq/Lookup.cs
+++ b/MoreLinq/Lookup.cs
@@ -27,6 +27,8 @@
 #pragma warning disable IDE0040 // Add accessibility modifiers
 #pragma warning disable IDE0032 // Use auto property
 #pragma warning disable IDE0017 // Simplify object initialization
+#pragma warning disable IDE0009 // Member access should be qualified
+#pragma warning disable IDE1006 // Naming rule violation
 
 namespace MoreLinq
 {

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -283,8 +283,8 @@ namespace MoreLinq
                 public static readonly Extrema<(bool, T), T> First = new Extremum(false);
                 public static readonly Extrema<(bool, T), T> Last  = new Extremum(true);
 
-                readonly bool _poppable;
-                Extremum(bool poppable) => _poppable = poppable;
+                readonly bool poppable;
+                Extremum(bool poppable) => this.poppable = poppable;
 
                 public override (bool, T) New() => default;
                 public override void Restart(ref (bool, T) store) => store = default;
@@ -294,7 +294,7 @@ namespace MoreLinq
 
                 public override void Add(ref (bool, T) store, int? limit, T item)
                 {
-                    if (!_poppable && store is (true, _))
+                    if (!this.poppable && store is (true, _))
                         return;
                     store = (true, item);
                 }

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -67,48 +67,48 @@ namespace MoreLinq
             //                               for( int j = 0; j < 8; j++ )
             //                                   DoSomething();
 
-            readonly IList<T> _valueSet;
-            readonly int[] _permutation;
-            readonly IEnumerable<Action> _generator;
+            readonly IList<T> valueSet;
+            readonly int[] permutation;
+            readonly IEnumerable<Action> generator;
 
-            IEnumerator<Action> _generatorIterator;
-            bool _hasMoreResults;
+            IEnumerator<Action> generatorIterator;
+            bool hasMoreResults;
 
-            IList<T>? _current;
+            IList<T>? current;
 
             public PermutationEnumerator(IEnumerable<T> valueSet)
             {
-                _valueSet = valueSet.ToArray();
-                _permutation = new int[_valueSet.Count];
+                this.valueSet = valueSet.ToArray();
+                this.permutation = new int[this.valueSet.Count];
                 // The nested loop construction below takes into account the fact that:
                 // 1) for empty sets and sets of cardinality 1, there exists only a single permutation.
                 // 2) for sets larger than 1 element, the number of nested loops needed is: set.Count-1
-                _generator = NestedLoops(NextPermutation, Generate(2UL, n => n + 1).Take(Math.Max(0, _valueSet.Count - 1)));
+                this.generator = NestedLoops(NextPermutation, Generate(2UL, n => n + 1).Take(Math.Max(0, this.valueSet.Count - 1)));
                 Reset();
             }
 
-            [MemberNotNull(nameof(_generatorIterator))]
+            [MemberNotNull(nameof(generatorIterator))]
             public void Reset()
             {
-                _current = null;
-                _generatorIterator?.Dispose();
+                this.current = null;
+                this.generatorIterator?.Dispose();
                 // restore lexographic ordering of the permutation indexes
-                for (var i = 0; i < _permutation.Length; i++)
-                    _permutation[i] = i;
+                for (var i = 0; i < this.permutation.Length; i++)
+                    this.permutation[i] = i;
                 // start a new iteration over the nested loop generator
-                _generatorIterator = _generator.GetEnumerator();
+                this.generatorIterator = this.generator.GetEnumerator();
                 // we must advance the nested loop iterator to the initial element,
                 // this ensures that we only ever produce N!-1 calls to NextPermutation()
-                _ = _generatorIterator.MoveNext();
-                _hasMoreResults = true; // there's always at least one permutation: the original set itself
+                _ = this.generatorIterator.MoveNext();
+                this.hasMoreResults = true; // there's always at least one permutation: the original set itself
             }
 
             public IList<T> Current
             {
                 get
                 {
-                    Debug.Assert(_current is not null);
-                    return _current;
+                    Debug.Assert(this.current is not null);
+                    return this.current;
                 }
             }
 
@@ -116,12 +116,12 @@ namespace MoreLinq
 
             public bool MoveNext()
             {
-                _current = PermuteValueSet();
+                this.current = PermuteValueSet();
                 // check if more permutation left to enumerate
-                var prevResult = _hasMoreResults;
-                _hasMoreResults = _generatorIterator.MoveNext();
-                if (_hasMoreResults)
-                    _generatorIterator.Current(); // produce the next permutation ordering
+                var prevResult = this.hasMoreResults;
+                this.hasMoreResults = this.generatorIterator.MoveNext();
+                if (this.hasMoreResults)
+                    this.generatorIterator.Current(); // produce the next permutation ordering
                 // we return prevResult rather than m_HasMoreResults because there is always
                 // at least one permutation: the original set. Also, this provides a simple way
                 // to deal with the disparity between sets that have only one loop level (size 0-2)
@@ -129,7 +129,7 @@ namespace MoreLinq
                 return prevResult;
             }
 
-            void IDisposable.Dispose() => _generatorIterator.Dispose();
+            void IDisposable.Dispose() => this.generatorIterator.Dispose();
 
             /// <summary>
             /// Transposes elements in the cached permutation array to produce the next permutation
@@ -137,21 +137,21 @@ namespace MoreLinq
             void NextPermutation()
             {
                 // find the largest index j with m_Permutation[j] < m_Permutation[j+1]
-                var j = _permutation.Length - 2;
-                while (_permutation[j] > _permutation[j + 1])
+                var j = this.permutation.Length - 2;
+                while (this.permutation[j] > this.permutation[j + 1])
                     j--;
 
                 // find index k such that m_Permutation[k] is the smallest integer
                 // greater than m_Permutation[j] to the right of m_Permutation[j]
-                var k = _permutation.Length - 1;
-                while (_permutation[j] > _permutation[k])
+                var k = this.permutation.Length - 1;
+                while (this.permutation[j] > this.permutation[k])
                     k--;
 
-                (_permutation[j], _permutation[k]) = (_permutation[k], _permutation[j]);
+                (this.permutation[j], this.permutation[k]) = (this.permutation[k], this.permutation[j]);
 
                 // move the tail of the permutation after the jth position in increasing order
-                for (int x = _permutation.Length - 1, y = j + 1; x > y; x--, y++)
-                    (_permutation[x], _permutation[y]) = (_permutation[y], _permutation[x]);
+                for (int x = this.permutation.Length - 1, y = j + 1; x > y; x--, y++)
+                    (this.permutation[x], this.permutation[y]) = (this.permutation[y], this.permutation[x]);
             }
 
             /// <summary>
@@ -170,9 +170,9 @@ namespace MoreLinq
             /// <returns>Array of permuted source sequence values</returns>
             T[] PermuteValueSet()
             {
-                var permutedSet = new T[_permutation.Length];
-                for (var i = 0; i < _permutation.Length; i++)
-                    permutedSet[i] = _valueSet[_permutation[i]];
+                var permutedSet = new T[this.permutation.Length];
+                for (var i = 0; i < this.permutation.Length; i++)
+                    permutedSet[i] = this.valueSet[this.permutation[i]];
                 return permutedSet;
             }
         }

--- a/MoreLinq/Reactive/Subject.cs
+++ b/MoreLinq/Reactive/Subject.cs
@@ -23,26 +23,26 @@ namespace MoreLinq.Reactive
 
     sealed class Subject<T> : IObservable<T>, IObserver<T>
     {
-        List<IObserver<T>>? _observers;
-        bool _completed;
-        Exception? _error;
+        List<IObserver<T>>? observers;
+        bool completed;
+        Exception? error;
 
-        bool HasObservers => (_observers?.Count ?? 0) > 0;
-        List<IObserver<T>> Observers => _observers ??= [];
+        bool HasObservers => (this.observers?.Count ?? 0) > 0;
+        List<IObserver<T>> Observers => this.observers ??= [];
 
-        bool IsMuted => _completed || _error != null;
+        bool IsMuted => this.completed || this.error != null;
 
         public IDisposable Subscribe(IObserver<T> observer)
         {
             if (observer == null) throw new ArgumentNullException(nameof(observer));
 
-            if (_error != null)
+            if (this.error != null)
             {
-                observer.OnError(_error);
+                observer.OnError(this.error);
                 return Disposable.Nop;
             }
 
-            if (_completed)
+            if (this.completed)
             {
                 observer.OnCompleted();
                 return Disposable.Nop;
@@ -65,7 +65,7 @@ namespace MoreLinq.Reactive
                 {
                     if (observers[i] == observer)
                     {
-                        if (_shouldDeleteObserver)
+                        if (this.shouldDeleteObserver)
                             observers[i] = null!;
                         else
                             observers.RemoveAt(i);
@@ -75,7 +75,7 @@ namespace MoreLinq.Reactive
             });
         }
 
-        bool _shouldDeleteObserver; // delete (null) or remove an observer?
+        bool shouldDeleteObserver; // delete (null) or remove an observer?
 
         public void OnNext(T value)
         {
@@ -89,7 +89,7 @@ namespace MoreLinq.Reactive
             // instead of being removed from the list of observers. The actual
             // removal is then deferred until after the iteration is complete.
 
-            _shouldDeleteObserver = true;
+            this.shouldDeleteObserver = true;
 
             try
             {
@@ -104,7 +104,7 @@ namespace MoreLinq.Reactive
             }
             finally
             {
-                _shouldDeleteObserver = false;
+                this.shouldDeleteObserver = false;
 
                 // Remove any observers that were marked for deletion during
                 // iteration.
@@ -114,10 +114,10 @@ namespace MoreLinq.Reactive
         }
 
         public void OnError(Exception error) =>
-            OnFinality(ref _error, error, (observer, err) => observer.OnError(err));
+            OnFinality(ref this.error, error, (observer, err) => observer.OnError(err));
 
         public void OnCompleted() =>
-            OnFinality(ref _completed, true, (observer, _) => observer.OnCompleted());
+            OnFinality(ref this.completed, true, (observer, _) => observer.OnCompleted());
 
         void OnFinality<TState>(ref TState? state, TState value, Action<IObserver<T>, TState> action)
         {
@@ -130,8 +130,8 @@ namespace MoreLinq.Reactive
             // to be called so release the list of observers of this subject.
             // The list of observers will be garbage once this method returns.
 
-            var observers = _observers;
-            _observers = null;
+            var observers = this.observers;
+            this.observers = null;
 
             if (observers == null)
                 return;

--- a/MoreLinq/Return.cs
+++ b/MoreLinq/Return.cs
@@ -34,24 +34,24 @@ namespace MoreLinq
 
         sealed class SingleElementList<T>(T item) : IList<T>, IReadOnlyList<T>
         {
-            readonly T _item = item;
+            readonly T item = item;
 
             public int Count       => 1;
             public bool IsReadOnly => true;
 
             public T this[int index]
             {
-                get => index == 0 ? _item : throw new ArgumentOutOfRangeException(nameof(index));
+                get => index == 0 ? this.item : throw new ArgumentOutOfRangeException(nameof(index));
                 set => throw ReadOnlyException();
             }
 
-            public IEnumerator<T> GetEnumerator() { yield return _item; }
+            public IEnumerator<T> GetEnumerator() { yield return this.item; }
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
             public int IndexOf(T item) => Contains(item) ? 0 : -1;
-            public bool Contains(T item) => EqualityComparer<T>.Default.Equals(_item, item);
+            public bool Contains(T item) => EqualityComparer<T>.Default.Equals(this.item, item);
 
-            public void CopyTo(T[] array, int arrayIndex) => array[arrayIndex] = _item;
+            public void CopyTo(T[] array, int arrayIndex) => array[arrayIndex] = this.item;
 
             // Following methods are unsupported as this is a read-only list.
 

--- a/MoreLinq/ReverseComparer.cs
+++ b/MoreLinq/ReverseComparer.cs
@@ -21,7 +21,7 @@ namespace MoreLinq
 
     sealed class ReverseComparer<T>(IComparer<T>? underlying) : IComparer<T>
     {
-        readonly IComparer<T> _underlying = underlying ?? Comparer<T>.Default;
+        readonly IComparer<T> underlying = underlying ?? Comparer<T>.Default;
 
         public int Compare
 #if NETCOREAPP3_1_OR_GREATER
@@ -30,7 +30,7 @@ namespace MoreLinq
             (T x, T y)
 #endif
         {
-            var result = _underlying.Compare(x, y);
+            var result = this.underlying.Compare(x, y);
             return result < 0 ? 1 : result > 0 ? -1 : 0;
         }
     }

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -132,16 +132,16 @@ namespace MoreLinq
 
             sealed class SubsetEnumerator : IEnumerator<IList<T>>
             {
-                readonly IList<T> _set;   // the original set of elements
-                readonly T[] _subset;     // the current subset to return
-                readonly int[] _indices;  // indices into the original set
+                readonly IList<T> set;    // the original set of elements
+                readonly T[] subset;      // the current subset to return
+                readonly int[] indices;   // indices into the original set
 
-                bool _continue;  // termination indicator, set when all subsets have been produced
+                bool @continue;  // termination indicator, set when all subsets have been produced
 
-                int _prevSwapIndex;       // previous swap index (upper index)
-                int _currSwapIndex;       // current swap index (lower index)
-                int _subsetSize;          // size of the subset being produced
-                int _setSize;             // size of the original set (sequence)
+                int prevSwapIndex;        // previous swap index (upper index)
+                int currSwapIndex;        // current swap index (lower index)
+                int subsetSize;           // size of the subset being produced
+                int setSize;              // size of the original set (sequence)
 
                 public SubsetEnumerator(IList<T> set, int subsetSize)
                 {
@@ -150,53 +150,54 @@ namespace MoreLinq
                         throw new ArgumentOutOfRangeException(nameof(subsetSize), "Subset size must be <= sequence.Count()");
 
                     // initialize set arrays...
-                    _set = set;
-                    _subset = new T[subsetSize];
-                    _indices = new int[subsetSize];
+                    this.set = set;
+                    this.subset = new T[subsetSize];
+                    this.indices = new int[subsetSize];
                     // initialize index counters...
                     Reset();
                 }
 
                 public void Reset()
                 {
-                    _prevSwapIndex = _subset.Length;
-                    _currSwapIndex = -1;
-                    _subsetSize = _subset.Length;
-                    _setSize = _set.Count;
-                    _continue = true;
+                    this.prevSwapIndex = this.subset.Length;
+                    this.currSwapIndex = -1;
+                    this.subsetSize = this.subset.Length;
+                    this.setSize = this.set.Count;
+                    this.@continue = true;
                 }
 
-                public IList<T> Current => (IList<T>)_subset.Clone();
+                public IList<T> Current => (IList<T>)this.subset.Clone();
 
                 object IEnumerator.Current => Current;
 
                 public bool MoveNext()
                 {
-                    if (!_continue)
+                    if (!this.@continue)
                         return false;
 
-                    if (_currSwapIndex == -1)
+                    if (this.currSwapIndex == -1)
                     {
-                        _currSwapIndex = 0;
-                        _prevSwapIndex = _subsetSize;
+                        this.currSwapIndex = 0;
+                        this.prevSwapIndex = this.subsetSize;
                     }
                     else
                     {
-                        if (_currSwapIndex < _setSize - _prevSwapIndex)
+                        if (this.currSwapIndex < this.setSize - this.prevSwapIndex)
                         {
-                            _prevSwapIndex = 0;
+                            this.prevSwapIndex = 0;
                         }
-                        _prevSwapIndex++;
-                        _currSwapIndex = _indices[_subsetSize - _prevSwapIndex];
+                        this.prevSwapIndex++;
+                        this.currSwapIndex = this.indices[this.subsetSize - this.prevSwapIndex];
                     }
 
-                    for (var j = 1; j <= _prevSwapIndex; j++)
-                        _indices[_subsetSize + j - _prevSwapIndex - 1] = _currSwapIndex + j;
+                    for (var j = 1; j <= this.prevSwapIndex; j++)
+                        this.indices[this.subsetSize + j - this.prevSwapIndex - 1] = this.currSwapIndex + j;
 
                     ExtractSubset();
 
-                    // ........................................ count of items excluded from the subset
-                    _continue = _indices is [var i, ..] && i != _setSize - _subsetSize + 1;
+                    this.@continue = this.indices is [var i, ..]
+                                     // .... count of items excluded from the subset
+                                     && i != this.setSize - this.subsetSize + 1;
 
                     return true;
                 }
@@ -205,13 +206,13 @@ namespace MoreLinq
 
                 void ExtractSubset()
                 {
-                    for (var i = 0; i < _subsetSize; i++)
-                        _subset[i] = _set[_indices[i] - 1];
+                    for (var i = 0; i < this.subsetSize; i++)
+                        this.subset[i] = this.set[this.indices[i] - 1];
                 }
             }
 
-            readonly IEnumerable<T> _sequence;
-            readonly int _subsetSize;
+            readonly IEnumerable<T> sequence;
+            readonly int subsetSize;
 
             public SubsetGenerator(IEnumerable<T> sequence, int subsetSize)
             {
@@ -219,8 +220,8 @@ namespace MoreLinq
                     throw new ArgumentNullException(nameof(sequence));
                 if (subsetSize < 0)
                     throw new ArgumentOutOfRangeException(nameof(subsetSize), "{subsetSize} must be between 0 and set.Count()");
-                _subsetSize = subsetSize;
-                _sequence = sequence;
+                this.subsetSize = subsetSize;
+                this.sequence = sequence;
             }
 
             /// <summary>
@@ -232,7 +233,7 @@ namespace MoreLinq
 
             public IEnumerator<IList<T>> GetEnumerator()
             {
-                return new SubsetEnumerator(_sequence.ToList(), _subsetSize);
+                return new SubsetEnumerator(this.sequence.ToList(), this.subsetSize);
             }
 
             IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }


### PR DESCRIPTION
There was a time when prefixing field names with underscore (`_`) aided in visual inspection and avoided accidents from ambiguity, but static code analysers have changed the game and [primary constructors](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors#primary-constructors) have blurred the lines further so this PR:

- sets the rules for field names to be simple and without the underscore
- requires `this` qualification for fields
- makes it consistent for entire code base and enforces the rules to maintain the consistency
