### PR TITLE
Use `EqualityComparer<T>.Create` from .NET 8

### DIFF
--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -87,8 +87,8 @@ namespace MoreLinq.Test
 
             Assert.That(first.EndsWith(second), Is.False);
             Assert.That(first.EndsWith(second, null), Is.False);
-            Assert.That(first.EndsWith(second, EqualityComparer.Create<int>(delegate { return false; })), Is.False);
-            Assert.That(first.EndsWith(second, EqualityComparer.Create<int>(delegate { return true; })), Is.True);
+            Assert.That(first.EndsWith(second, EqualityComparer<int>.Create(delegate { return false; })), Is.False);
+            Assert.That(first.EndsWith(second, EqualityComparer<int>.Create(delegate { return true; })), Is.True);
         }
 
         [TestCase(SourceKind.BreakingCollection)]

--- a/MoreLinq.Test/EqualityComparer.cs
+++ b/MoreLinq.Test/EqualityComparer.cs
@@ -15,22 +15,27 @@
 // limitations under the License.
 #endregion
 
+#if !NET8_0_OR_GREATER
+
 namespace MoreLinq.Test
 {
     using System;
     using System.Collections.Generic;
 
-    static class EqualityComparer
+    static class EqualityComparer<T>
     {
+        public static System.Collections.Generic.EqualityComparer<T>
+            Default => System.Collections.Generic.EqualityComparer<T>.Default;
+
         /// <summary>
         /// Creates an <see cref="IEqualityComparer{T}"/> given a
         /// <see cref="Func{T,T,Boolean}"/>.
         /// </summary>
 
-        public static IEqualityComparer<T> Create<T>(Func<T?, T?, bool> comparer) =>
-            new DelegatingComparer<T>(comparer);
+        public static IEqualityComparer<T> Create(Func<T?, T?, bool> comparer) =>
+            new DelegatingComparer(comparer);
 
-        sealed class DelegatingComparer<T> : IEqualityComparer<T>
+        sealed class DelegatingComparer : IEqualityComparer<T>
         {
             readonly Func<T?, T?, bool> comparer;
             readonly Func<T, int> hasher;
@@ -49,3 +54,5 @@ namespace MoreLinq.Test
         }
     }
 }
+
+#endif

--- a/MoreLinq.Test/PermutationsTest.cs
+++ b/MoreLinq.Test/PermutationsTest.cs
@@ -200,7 +200,7 @@ namespace MoreLinq.Test
         static class SequenceEqualityComparer<T>
         {
             public static readonly IEqualityComparer<IEnumerable<T>> Instance =
-                EqualityComparer.Create<IEnumerable<T>>((x, y) => x is { } sx && y is { } sy && sx.SequenceEqual(sy));
+                EqualityComparer<IEnumerable<T>>.Create((x, y) => x is { } sx && y is { } sy && sx.SequenceEqual(sy));
         }
     }
 }

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -87,8 +87,8 @@ namespace MoreLinq.Test
 
             Assert.That(first.StartsWith(second), Is.False);
             Assert.That(first.StartsWith(second, null), Is.False);
-            Assert.That(first.StartsWith(second, EqualityComparer.Create<int>(delegate { return false; })), Is.False);
-            Assert.That(first.StartsWith(second, EqualityComparer.Create<int>(delegate { return true; })), Is.True);
+            Assert.That(first.StartsWith(second, EqualityComparer<int>.Create(delegate { return false; })), Is.False);
+            Assert.That(first.StartsWith(second, EqualityComparer<int>.Create(delegate { return true; })), Is.True);
         }
 
         [TestCase(SourceKind.BreakingCollection)]


### PR DESCRIPTION
This PR leverages [`EqualityComparer<T>.Create`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.create?view=net-8.0#system-collections-generic-equalitycomparer-1-create(system-func((-0-0-system-boolean))-system-func((-0-system-int32)))) that was introduced in .NET 8.
