### PR TITLE
Refactor `Subsets` core into an iterator method

### DIFF
--- a/MoreLinq.Test/SubsetTest.cs
+++ b/MoreLinq.Test/SubsetTest.cs
@@ -193,5 +193,29 @@ namespace MoreLinq.Test
             foreach (var subset in result)
                 Assert.That(subset, Is.EqualTo(expectedSubsets[index++]));
         }
+
+        [Test(Description = "https://github.com/morelinq/MoreLINQ/issues/1047")]
+        public void TestEnumeratorCurrentReturnsSameReferenceOnEachAccess()
+        {
+            var source = Seq(1, 2, 3, 4, 5);
+
+            using var e = source.Subsets(3).GetEnumerator();
+            var moved = e.MoveNext();
+            var first = e.Current;
+            var second = e.Current;
+
+            Assert.That(moved, Is.True);
+            Assert.That(first, Is.SameAs(second));
+        }
+
+        [Test]
+        public void TestEachSubsetInstanceIsUnique()
+        {
+            var source = Seq(1, 2, 3, 4, 5);
+
+            var subsets = source.Subsets(2).ToArray();
+
+            Assert.That(subsets[0], Is.Not.SameAs(subsets[1]));
+        }
     }
 }


### PR DESCRIPTION
This PR refactors the implementation of `Subsets` into a simpler iterator method. As a by-product, it:

- fixes #1047
- removes [redundant allocations](https://github.com/morelinq/MoreLINQ/blob/a263661f61ffc11ecad07f3a6f8fe2418a68f774/MoreLinq/Subsets.cs#L236) when called via `Subsets()` overload