### PR TITLE
Fix style errors: IDE0028, IDE0290, IDE0300 & IDE0301

### DIFF
--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -97,7 +97,9 @@ namespace MoreLinq.Test
             into t
             select new TestCaseData(t.Method, t.Args).SetName(t.Name).Returns(t.Expectation);
 
-        [TestCaseSource(nameof(AccumulatorsTestSource), new object[] { nameof(Accumulators), 10 })]
+#pragma warning disable NUnit1018 // Parameter count does not match (false negative)
+        [TestCaseSource(nameof(AccumulatorsTestSource), [nameof(Accumulators), 10])]
+#pragma warning restore NUnit1018 // Parameter count does not match
         public object? Accumulators(MethodInfo method, object[] args) =>
             method.Invoke(null, args);
 

--- a/MoreLinq.Test/BacksertTest.cs
+++ b/MoreLinq.Test/BacksertTest.cs
@@ -32,7 +32,7 @@ namespace MoreLinq.Test
         [Test]
         public void BacksertWithNegativeIndex()
         {
-            Assert.That(() => Enumerable.Range(1, 10).Backsert(new[] { 97, 98, 99 }, -1),
+            Assert.That(() => Enumerable.Range(1, 10).Backsert([97, 98, 99], -1),
                         Throws.ArgumentOutOfRangeException("index"));
         }
 

--- a/MoreLinq.Test/CountDownTest.cs
+++ b/MoreLinq.Test/CountDownTest.cs
@@ -150,12 +150,9 @@ namespace MoreLinq.Test
             /// for another.
             /// </summary>
 
-            abstract class Sequence<T> : IEnumerable<T>
+            abstract class Sequence<T>(Func<IEnumerator<T>, IEnumerator<T>>? em) : IEnumerable<T>
             {
-                readonly Func<IEnumerator<T>, IEnumerator<T>> em;
-
-                protected Sequence(Func<IEnumerator<T>, IEnumerator<T>>? em) =>
-                    this.em = em ?? (e => e);
+                readonly Func<IEnumerator<T>, IEnumerator<T>> em = em ?? (e => e);
 
                 public IEnumerator<T> GetEnumerator() =>
                     this.em(Items.GetEnumerator());

--- a/MoreLinq.Test/EndsWithTest.cs
+++ b/MoreLinq.Test/EndsWithTest.cs
@@ -52,13 +52,13 @@ namespace MoreLinq.Test
         [Test]
         public void EndsWithReturnsTrueIfBothEmpty()
         {
-            Assert.That(new int[0].EndsWith(new int[0]), Is.True);
+            Assert.That(new int[0].EndsWith([]), Is.True);
         }
 
         [Test]
         public void EndsWithReturnsFalseIfOnlyFirstIsEmpty()
         {
-            Assert.That(new int[0].EndsWith(new[] { 1, 2, 3 }), Is.False);
+            Assert.That(new int[0].EndsWith([1, 2, 3]), Is.False);
         }
 
         [TestCase("", "", ExpectedResult = true)]

--- a/MoreLinq.Test/Enumerable.cs
+++ b/MoreLinq.Test/Enumerable.cs
@@ -145,7 +145,9 @@ namespace MoreLinq.Test
             LinqEnumerable.ElementAtOrDefault(source, index);
 
         public static IEnumerable<TResult> Empty<TResult>() =>
+#pragma warning disable IDE0301 // Simplify collection initialization
             LinqEnumerable.Empty<TResult>();
+#pragma warning restore IDE0301 // Simplify collection initialization
 
         public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second) =>
             LinqEnumerable.Except(first, second);

--- a/MoreLinq.Test/InsertTest.cs
+++ b/MoreLinq.Test/InsertTest.cs
@@ -25,7 +25,7 @@ namespace MoreLinq.Test
         [Test]
         public void InsertWithNegativeIndex()
         {
-            Assert.That(() => Enumerable.Range(1, 10).Insert(new[] { 97, 98, 99 }, -1),
+            Assert.That(() => Enumerable.Range(1, 10).Insert([97, 98, 99], -1),
                         Throws.ArgumentOutOfRangeException("index"));
         }
 

--- a/MoreLinq.Test/ReturnTest.cs
+++ b/MoreLinq.Test/ReturnTest.cs
@@ -148,7 +148,9 @@ namespace MoreLinq.Test
             }
             select new TestCaseData(ma.Action).SetName($"{testName}({ma.MethodName})");
 
-        [TestCaseSource(nameof(UnsupportedActions), new object[] { nameof(TestUnsupportedMethodShouldThrow) })]
+#pragma warning disable NUnit1018 // Parameter count does not match (false negative)
+        [TestCaseSource(nameof(UnsupportedActions), [nameof(TestUnsupportedMethodShouldThrow)])]
+#pragma warning restore NUnit1018 // Parameter count does not match
         public void TestUnsupportedMethodShouldThrow(Action unsupportedAction)
         {
             Assert.That(() => unsupportedAction(), Throws.InstanceOf<NotSupportedException>());

--- a/MoreLinq.Test/SampleData.cs
+++ b/MoreLinq.Test/SampleData.cs
@@ -25,15 +25,11 @@ namespace MoreLinq.Test
     /// </summary>
     static class SampleData
     {
-        internal static readonly ReadOnlyCollection<string> Strings = new(new[]
-        {
-            "ax", "hello", "world", "aa", "ab", "ay", "az"
-        });
+        internal static readonly ReadOnlyCollection<string>
+            Strings = new(["ax", "hello", "world", "aa", "ab", "ay", "az"]);
 
-        internal static readonly ReadOnlyCollection<int> Values = new(new[]
-        {
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-        });
+        internal static readonly ReadOnlyCollection<int>
+            Values = new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         internal static readonly Func<int, int, int> Plus = (a, b) => a + b;
         internal static readonly Func<int, int, int> Mul = (a, b) => a * b;

--- a/MoreLinq.Test/Scope.cs
+++ b/MoreLinq.Test/Scope.cs
@@ -19,12 +19,9 @@ namespace MoreLinq.Test
 {
     using System;
 
-    abstract class Scope<T> : IDisposable
+    abstract class Scope<T>(T current) : IDisposable
     {
-        readonly T old;
-
-        protected Scope(T current) => this.old = current;
-        public virtual void Dispose() => Restore(this.old);
+        public virtual void Dispose() => Restore(current);
         protected abstract void Restore(T old);
     }
 }

--- a/MoreLinq.Test/StartsWithTest.cs
+++ b/MoreLinq.Test/StartsWithTest.cs
@@ -52,13 +52,13 @@ namespace MoreLinq.Test
         [Test]
         public void StartsWithReturnsTrueIfBothEmpty()
         {
-            Assert.That(new int[0].StartsWith(new int[0]), Is.True);
+            Assert.That(new int[0].StartsWith([]), Is.True);
         }
 
         [Test]
         public void StartsWithReturnsFalseIfOnlyFirstIsEmpty()
         {
-            Assert.That(new int[0].StartsWith(new[] { 1, 2, 3 }), Is.False);
+            Assert.That(new int[0].StartsWith([1, 2, 3]), Is.False);
         }
 
         [TestCase("", "", ExpectedResult = true)]

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -33,22 +33,19 @@ namespace MoreLinq.Test
 
     static class SourceKinds
     {
-        public static readonly IEnumerable<SourceKind> Sequence = new[]
-        {
-            SourceKind.Sequence,
-        };
+        public static readonly IEnumerable<SourceKind> Sequence = [
+            SourceKind.Sequence
+        ];
 
-        public static readonly IEnumerable<SourceKind> Collection = new[]
-        {
+        public static readonly IEnumerable<SourceKind> Collection = [
             SourceKind.BreakingCollection,
             SourceKind.BreakingReadOnlyCollection
-        };
+        ];
 
-        public static readonly IEnumerable<SourceKind> List = new[]
-        {
+        public static readonly IEnumerable<SourceKind> List = [
             SourceKind.BreakingList,
             SourceKind.BreakingReadOnlyList
-        };
+        ];
     }
 
     static partial class TestExtensions

--- a/MoreLinq.Test/TraverseTest.cs
+++ b/MoreLinq.Test/TraverseTest.cs
@@ -38,7 +38,7 @@ namespace MoreLinq.Test
         [Test]
         public void TraverseDepthFirstPreservesChildrenOrder()
         {
-            var res = MoreEnumerable.TraverseDepthFirst(0, i => i == 0 ? Enumerable.Range(1, 10) : Enumerable.Empty<int>());
+            var res = MoreEnumerable.TraverseDepthFirst(0, i => i == 0 ? Enumerable.Range(1, 10) : []);
             res.AssertSequenceEqual(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         }
 
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
         [Test]
         public void TraverseBreadthFirstPreservesChildrenOrder()
         {
-            var res = MoreEnumerable.TraverseBreadthFirst(0, i => i == 0 ? Enumerable.Range(1, 10) : Enumerable.Empty<int>());
+            var res = MoreEnumerable.TraverseBreadthFirst(0, i => i == 0 ? Enumerable.Range(1, 10) : []);
             res.AssertSequenceEqual(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         }
 

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -19,7 +19,6 @@ namespace MoreLinq
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     // Inspiration & credit: http://stackoverflow.com/a/13503860/6682
     static partial class MoreEnumerable
@@ -162,7 +161,7 @@ namespace MoreLinq
                     if (alookup.Contains(b.Key))
                         continue;
                     // We can skip the lookup because we are iterating over keys not found in the first sequence
-                    yield return resultSelector(b.Key, Enumerable.Empty<TFirst>(), b);
+                    yield return resultSelector(b.Key, [], b);
                 }
             }
         }

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -232,7 +232,7 @@ namespace MoreLinq
             public IEnumerable<T> Take(int count) =>
                 count switch
                 {
-                    0 => Enumerable.Empty<T>(),
+                    0 => [],
                     1 => ExtremaBy(source, Extremum.First, 1    , selector, comparer),
                     _ => ExtremaBy(source, Extrema.First , count, selector, comparer)
                 };
@@ -240,7 +240,7 @@ namespace MoreLinq
             public IEnumerable<T> TakeLast(int count) =>
                 count switch
                 {
-                    0 => Enumerable.Empty<T>(),
+                    0 => [],
                     1 => ExtremaBy(source, Extremum.Last, 1    , selector, comparer),
                     _ => ExtremaBy(source, Extrema.Last , count, selector, comparer)
                 };
@@ -290,7 +290,7 @@ namespace MoreLinq
                 public override void Restart(ref (bool, T) store) => store = default;
 
                 public override IEnumerable<T> GetEnumerable((bool, T) store) =>
-                    store is (true, var item) ? Enumerable.Repeat(item, 1) : Enumerable.Empty<T>();
+                    store is (true, var item) ? [item] : [];
 
                 public override void Add(ref (bool, T) store, int? limit, T item)
                 {
@@ -320,7 +320,7 @@ namespace MoreLinq
                 using var e = source.GetEnumerator();
 
                 if (!e.MoveNext())
-                    return new List<TSource>();
+                    return [];
 
                 var store = extrema.New();
                 extrema.Add(ref store, limit, e.Current);

--- a/MoreLinq/Partition.cs
+++ b/MoreLinq/Partition.cs
@@ -351,12 +351,7 @@ namespace MoreLinq
 
             List<IGrouping<TKey, TElement>>? etc = null;
 
-            var groups = new[]
-            {
-                Enumerable.Empty<TElement>(),
-                Enumerable.Empty<TElement>(),
-                Enumerable.Empty<TElement>(),
-            };
+            var groups = new IEnumerable<TElement>[] { [], [], [] };
 
             foreach (var e in source)
             {

--- a/MoreLinq/TakeLast.cs
+++ b/MoreLinq/TakeLast.cs
@@ -54,7 +54,7 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            return count < 1 ? Enumerable.Empty<TSource>()
+            return count < 1 ? []
                  : source.CountDown(count, (e, cd) => (Element: e, Countdown: cd))
                          .SkipWhile(e => e.Countdown == null)
                          .Select(e => e.Element);

--- a/bld/ExtensionsGenerator/Program.cs
+++ b/bld/ExtensionsGenerator/Program.cs
@@ -357,11 +357,9 @@ static TypeKey CreateTypeKey(TypeSyntax root, Func<string, TypeKey?> abbreviator
 // - Each type parameter (recursively)
 //
 
-abstract class TypeKey : IComparable<TypeKey>
+abstract class TypeKey(string name) : IComparable<TypeKey>
 {
-    protected TypeKey(string name) => Name = name;
-
-    public string Name { get; }
+    public string Name { get; } = name;
     public abstract ImmutableList<TypeKey> Parameters { get; }
 
     public virtual int CompareTo(TypeKey? other)
@@ -383,18 +381,15 @@ abstract class TypeKey : IComparable<TypeKey>
 sealed class SimpleTypeKey(string name) : TypeKey(name)
 {
     public override string ToString() => Name;
-    public override ImmutableList<TypeKey> Parameters => ImmutableList<TypeKey>.Empty;
+    public override ImmutableList<TypeKey> Parameters => [];
 }
 
-abstract class ParameterizedTypeKey : TypeKey
+abstract class ParameterizedTypeKey(string name, ImmutableList<TypeKey> parameters) : TypeKey(name)
 {
     protected ParameterizedTypeKey(string name, TypeKey parameter) :
         this(name, [parameter]) { }
 
-    protected ParameterizedTypeKey(string name, ImmutableList<TypeKey> parameters) :
-        base(name) => Parameters = parameters;
-
-    public override ImmutableList<TypeKey> Parameters { get; }
+    public override ImmutableList<TypeKey> Parameters { get; } = parameters;
 }
 
 sealed class GenericTypeKey(string name, ImmutableList<TypeKey> parameters) :


### PR DESCRIPTION
This PR addresses the following style warnings/errors:

- [IDE0028: Use primary constructor](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028)
- [IDE0290: Use primary constructor](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0290)
- [IDE0300: Collection initialization can be simplified](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0300)
- [IDE0301: Collection initialization can be simplified](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0301)
