### PR TITLE
Removed closures in favour of private static methods to close issue #906

### DIFF
--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -123,8 +123,8 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(0, count)
                 .Concat(Enumerable.Range(0, count))
                 .Concat(Enumerable.Range(0, count));
-            using var ts = sequence.AsTestingSequence(maxEnumerations:2);
-            var result = ts.Rank();
+            using var ts = sequence.AsTestingSequence();
+            var result = ts.Rank().ToArray();
 
             Assert.That(result.Distinct().Count(), Is.EqualTo(count));
             Assert.That(result, Is.EqualTo(sequence.Reverse().Select(x => x + 1)));

--- a/MoreLinq.Test/RankTest.cs
+++ b/MoreLinq.Test/RankTest.cs
@@ -123,7 +123,7 @@ namespace MoreLinq.Test
             var sequence = Enumerable.Range(0, count)
                 .Concat(Enumerable.Range(0, count))
                 .Concat(Enumerable.Range(0, count));
-            using var ts = sequence.AsTestingSequence();
+            using var ts = sequence.AsTestingSequence(maxEnumerations:2);
             var result = ts.Rank();
 
             Assert.That(result.Distinct().Count(), Is.EqualTo(count));

--- a/MoreLinq/Assert.cs
+++ b/MoreLinq/Assert.cs
@@ -65,7 +65,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, predicate, errorSelector);
+
+            static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, bool> predicate, Func<TSource, Exception>? errorSelector)
             {
                 foreach (var element in source)
                 {

--- a/MoreLinq/AssertCount.cs
+++ b/MoreLinq/AssertCount.cs
@@ -70,7 +70,9 @@ namespace MoreLinq
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (errorSelector == null) throw new ArgumentNullException(nameof(errorSelector));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, count, errorSelector);
+
+            static IEnumerable<TSource> _(IEnumerable<TSource> source, int count, Func<int, int, Exception> errorSelector)
             {
                 if (source.TryAsCollectionLike() is { Count: var collectionCount }
                     && collectionCount.CompareTo(count) is var comparison && comparison != 0)

--- a/MoreLinq/Backsert.cs
+++ b/MoreLinq/Backsert.cs
@@ -65,10 +65,10 @@ namespace MoreLinq
             {
                 < 0 => throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative."),
                 0 => first.Concat(second),
-                _ => _()
+                _ => _(first, second, index)
             };
 
-            IEnumerable<T> _()
+            static IEnumerable<T> _(IEnumerable<T> first, IEnumerable<T> second, int index)
             {
                 using var e = first.CountDown(index, ValueTuple.Create).GetEnumerator();
 

--- a/MoreLinq/Batch.cs
+++ b/MoreLinq/Batch.cs
@@ -86,7 +86,9 @@ namespace MoreLinq
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, size, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<TSource> source, int size, Func<TSource[], TResult> resultSelector)
             {
                 switch (source)
                 {

--- a/MoreLinq/Cartesian.g.cs
+++ b/MoreLinq/Cartesian.g.cs
@@ -69,7 +69,9 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, Func<T1, T2, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
 
@@ -123,7 +125,9 @@ namespace MoreLinq
             if (third == null) throw new ArgumentNullException(nameof(third));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, Func<T1, T2, T3, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -185,7 +189,9 @@ namespace MoreLinq
             if (fourth == null) throw new ArgumentNullException(nameof(fourth));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, fourth, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, Func<T1, T2, T3, T4, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -255,7 +261,9 @@ namespace MoreLinq
             if (fifth == null) throw new ArgumentNullException(nameof(fifth));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, fourth, fifth, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, Func<T1, T2, T3, T4, T5, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -333,7 +341,9 @@ namespace MoreLinq
             if (sixth == null) throw new ArgumentNullException(nameof(sixth));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, fourth, fifth, sixth, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -419,7 +429,9 @@ namespace MoreLinq
             if (seventh == null) throw new ArgumentNullException(nameof(seventh));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, fourth, fifth, sixth, seventh, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, IEnumerable<T7> seventh, Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -513,7 +525,9 @@ namespace MoreLinq
             if (eighth == null) throw new ArgumentNullException(nameof(eighth));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(first, second, third, fourth, fifth, sixth, seventh, eighth, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, IEnumerable<T7> seventh, IEnumerable<T8> eighth, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;

--- a/MoreLinq/Cartesian.g.cs
+++ b/MoreLinq/Cartesian.g.cs
@@ -71,7 +71,10 @@ namespace MoreLinq
 
             return _(first, second, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, Func<T1, T2, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                Func<T1, T2, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
 
@@ -127,7 +130,11 @@ namespace MoreLinq
 
             return _(first, second, third, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, Func<T1, T2, T3, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                Func<T1, T2, T3, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -191,7 +198,12 @@ namespace MoreLinq
 
             return _(first, second, third, fourth, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, Func<T1, T2, T3, T4, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                IEnumerable<T4> fourth,
+                Func<T1, T2, T3, T4, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -263,7 +275,13 @@ namespace MoreLinq
 
             return _(first, second, third, fourth, fifth, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, Func<T1, T2, T3, T4, T5, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                IEnumerable<T4> fourth,
+                IEnumerable<T5> fifth,
+                Func<T1, T2, T3, T4, T5, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -343,7 +361,14 @@ namespace MoreLinq
 
             return _(first, second, third, fourth, fifth, sixth, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                IEnumerable<T4> fourth,
+                IEnumerable<T5> fifth,
+                IEnumerable<T6> sixth,
+                Func<T1, T2, T3, T4, T5, T6, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -431,7 +456,15 @@ namespace MoreLinq
 
             return _(first, second, third, fourth, fifth, sixth, seventh, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, IEnumerable<T7> seventh, Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                IEnumerable<T4> fourth,
+                IEnumerable<T5> fifth,
+                IEnumerable<T6> sixth,
+                IEnumerable<T7> seventh,
+                Func<T1, T2, T3, T4, T5, T6, T7, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;
@@ -527,7 +560,16 @@ namespace MoreLinq
 
             return _(first, second, third, fourth, fifth, sixth, seventh, eighth, resultSelector);
 
-            static IEnumerable<TResult> _(IEnumerable<T1> first, IEnumerable<T2> second, IEnumerable<T3> third, IEnumerable<T4> fourth, IEnumerable<T5> fifth, IEnumerable<T6> sixth, IEnumerable<T7> seventh, IEnumerable<T8> eighth, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                IEnumerable<T1> first,
+                IEnumerable<T2> second,
+                IEnumerable<T3> third,
+                IEnumerable<T4> fourth,
+                IEnumerable<T5> fifth,
+                IEnumerable<T6> sixth,
+                IEnumerable<T7> seventh,
+                IEnumerable<T8> eighth,
+                Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> resultSelector)
             {
                 IEnumerable<T2> secondMemo;
                 IEnumerable<T3> thirdMemo;

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -115,7 +115,9 @@ Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TRes
 <#      } #>
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(<#= string.Join(", ", from x in o.Arguments select x.Ordinal)  #>, resultSelector);
+
+            static IEnumerable<TResult> _(<#= string.Join(", ", from x in o.Arguments select "IEnumerable<T" + x.Number + "> " + x.Ordinal)  #>, Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TResult> resultSelector)
             {
 <#      foreach (var arg in o.Arguments.Skip(1)) { #>
                 IEnumerable<T<#= arg.Number #>> <#= arg.Ordinal #>Memo;

--- a/MoreLinq/Cartesian.g.tt
+++ b/MoreLinq/Cartesian.g.tt
@@ -117,7 +117,12 @@ Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TRes
 
             return _(<#= string.Join(", ", from x in o.Arguments select x.Ordinal)  #>, resultSelector);
 
-            static IEnumerable<TResult> _(<#= string.Join(", ", from x in o.Arguments select "IEnumerable<T" + x.Number + "> " + x.Ordinal)  #>, Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TResult> resultSelector)
+            static IEnumerable<TResult> _(
+                <#      foreach (var arg in o.Arguments) { #>
+IEnumerable<T<#= arg.Number #>> <#= arg.Ordinal #>,
+                <#
+        } #>
+Func<<#= string.Join(", ", from x in o.Arguments select "T" + x.Number) #>, TResult> resultSelector)
             {
 <#      foreach (var arg in o.Arguments.Skip(1)) { #>
                 IEnumerable<T<#= arg.Number #>> <#= arg.Ordinal #>Memo;

--- a/MoreLinq/Choose.cs
+++ b/MoreLinq/Choose.cs
@@ -55,7 +55,11 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (chooser == null) throw new ArgumentNullException(nameof(chooser));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, chooser);
+
+            static IEnumerable<TResult> _(
+                IEnumerable<T> source,
+                Func<T, (bool, TResult)> chooser)
             {
                 foreach (var item in source)
                 {

--- a/MoreLinq/CountBy.cs
+++ b/MoreLinq/CountBy.cs
@@ -55,7 +55,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return _(); IEnumerable<KeyValuePair<TKey, int>> _()
+            return _(source, keySelector, comparer);
+
+            static IEnumerable<KeyValuePair<TKey, int>> _(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 List<TKey> keys;
                 List<int> counts;

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -58,12 +58,16 @@ namespace MoreLinq
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
             return source.TryAsListLike() is { } listLike
-                   ? IterateList(listLike)
+                   ? IterateList(listLike, source, count, resultSelector)
                    : source.TryAsCollectionLike() is { } collectionLike
-                     ? IterateCollection(collectionLike)
-                     : IterateSequence();
+                     ? IterateCollection(collectionLike, source, count, resultSelector)
+                     : IterateSequence(source, count, resultSelector);
 
-            IEnumerable<TResult> IterateList(ListLike<T> list)
+            static IEnumerable<TResult> IterateList(
+                ListLike<T> list,
+                IEnumerable<T> source,
+                int count,
+                Func<T, int?, TResult> resultSelector)
             {
                 var listCount = list.Count;
                 var countdown = Math.Min(count, listCount);
@@ -72,14 +76,21 @@ namespace MoreLinq
                     yield return resultSelector(list[i], listCount - i <= count ? --countdown : null);
             }
 
-            IEnumerable<TResult> IterateCollection(CollectionLike<T> collection)
+            static IEnumerable<TResult> IterateCollection(
+                CollectionLike<T> collection,
+                IEnumerable<T> source,
+                int count,
+                Func<T, int?, TResult> resultSelector)
             {
                 var i = collection.Count;
                 foreach (var item in collection)
                     yield return resultSelector(item, i-- <= count ? i : null);
             }
 
-            IEnumerable<TResult> IterateSequence()
+            static IEnumerable<TResult> IterateSequence(
+                IEnumerable<T> source,
+                int count,
+                Func<T, int?, TResult> resultSelector)
             {
                 var queue = new Queue<T>(Math.Max(1, count + 1));
 

--- a/MoreLinq/CountDown.cs
+++ b/MoreLinq/CountDown.cs
@@ -58,14 +58,13 @@ namespace MoreLinq
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
             return source.TryAsListLike() is { } listLike
-                   ? IterateList(listLike, source, count, resultSelector)
+                   ? IterateList(listLike, count, resultSelector)
                    : source.TryAsCollectionLike() is { } collectionLike
-                     ? IterateCollection(collectionLike, source, count, resultSelector)
+                     ? IterateCollection(collectionLike, count, resultSelector)
                      : IterateSequence(source, count, resultSelector);
 
             static IEnumerable<TResult> IterateList(
                 ListLike<T> list,
-                IEnumerable<T> source,
                 int count,
                 Func<T, int?, TResult> resultSelector)
             {
@@ -78,7 +77,6 @@ namespace MoreLinq
 
             static IEnumerable<TResult> IterateCollection(
                 CollectionLike<T> collection,
-                IEnumerable<T> source,
                 int count,
                 Func<T, int?, TResult> resultSelector)
             {

--- a/MoreLinq/DistinctBy.cs
+++ b/MoreLinq/DistinctBy.cs
@@ -78,7 +78,12 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, keySelector, comparer);
+
+            static IEnumerable<TSource> _(
+                IEnumerable<TSource> source,
+                Func<TSource, TKey> keySelector,
+                IEqualityComparer<TKey>? comparer)
             {
                 var knownKeys = new HashSet<TKey>(comparer);
                 foreach (var element in source)

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -78,14 +78,14 @@ namespace MoreLinq
             return second.TryAsCollectionLike() is { Count: var secondCount }
                    ? first.TryAsCollectionLike() is { Count: var firstCount } && secondCount > firstCount
                      ? false
-                     : Impl(second, secondCount, first, comparer)
-                   : Impl(secondList = second.ToList(), secondList.Count, first, comparer);
+                     : Impl(first, second, secondCount, comparer)
+                   : Impl(first, secondList = second.ToList(), secondList.Count, comparer);
 #pragma warning restore IDE0075 // Simplify conditional expression
 
-            static bool Impl(IEnumerable<T> snd, int count, IEnumerable<T> first, IEqualityComparer<T> comparer)
+            static bool Impl(IEnumerable<T> first, IEnumerable<T> second, int count, IEqualityComparer<T> comparer)
             {
                 using var firstIter = first.TakeLast(count).GetEnumerator();
-                return snd.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
+                return second.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));
             }
         }
     }

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -78,11 +78,11 @@ namespace MoreLinq
             return second.TryAsCollectionLike() is { Count: var secondCount }
                    ? first.TryAsCollectionLike() is { Count: var firstCount } && secondCount > firstCount
                      ? false
-                     : Impl(second, secondCount)
-                   : Impl(secondList = second.ToList(), secondList.Count);
+                     : Impl(second, secondCount, first, comparer)
+                   : Impl(secondList = second.ToList(), secondList.Count, first, comparer);
 #pragma warning restore IDE0075 // Simplify conditional expression
 
-            bool Impl(IEnumerable<T> snd, int count)
+            static bool Impl(IEnumerable<T> snd, int count, IEnumerable<T> first, IEqualityComparer<T> comparer)
             {
                 using var firstIter = first.TakeLast(count).GetEnumerator();
                 return snd.All(item => firstIter.MoveNext() && comparer.Equals(firstIter.Current, item));

--- a/MoreLinq/ExceptBy.cs
+++ b/MoreLinq/ExceptBy.cs
@@ -79,9 +79,13 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return Impl();
+            return Impl(first, second, keySelector, keyComparer);
 
-            IEnumerable<TSource> Impl()
+            static IEnumerable<TSource> Impl(
+                IEnumerable<TSource> first,
+                IEnumerable<TSource> second,
+                Func<TSource, TKey> keySelector,
+                IEqualityComparer<TKey>? keyComparer)
             {
                 // TODO Use ToHashSet
                 var keys = new HashSet<TKey>(second.Select(keySelector), keyComparer);

--- a/MoreLinq/Exclude.cs
+++ b/MoreLinq/Exclude.cs
@@ -41,10 +41,10 @@ namespace MoreLinq
             {
                 < 0 => throw new ArgumentOutOfRangeException(nameof(count)),
                 0 => sequence,
-                _ => _()
+                _ => _(sequence, startIndex, count)
             };
 
-            IEnumerable<T> _()
+            static IEnumerable<T> _(IEnumerable<T> sequence, int startIndex, int count)
             {
                 var index = 0;
                 var endIndex = startIndex + count;

--- a/MoreLinq/Experimental/Async/Merge.cs
+++ b/MoreLinq/Experimental/Async/Merge.cs
@@ -85,9 +85,9 @@ namespace MoreLinq.Experimental.Async
             if (sources is null) throw new ArgumentNullException(nameof(sources));
             if (maxConcurrent <= 0) throw new ArgumentOutOfRangeException(nameof(maxConcurrent));
 
-            return Async();
+            return Async(sources, maxConcurrent);
 
-            async IAsyncEnumerable<T> Async([EnumeratorCancellation]CancellationToken cancellationToken = default)
+            static async IAsyncEnumerable<T> Async(IEnumerable<IAsyncEnumerable<T>> sources, int maxConcurrent, [EnumeratorCancellation]CancellationToken cancellationToken = default)
             {
                 using var thisCancellationTokenSource = new CancellationTokenSource();
 

--- a/MoreLinq/Experimental/Await.cs
+++ b/MoreLinq/Experimental/Await.cs
@@ -424,11 +424,20 @@ namespace MoreLinq.Experimental
 
             return
                 AwaitQuery.Create(
-                    options => Impl(options.MaxConcurrency,
+                    options => Impl(source,
+                                    evaluator,
+                                    resultSelector,
+                                    options.MaxConcurrency,
                                     options.Scheduler ?? TaskScheduler.Default,
                                     options.PreserveOrder));
 
-            IEnumerable<TResult> Impl(int? maxConcurrency, TaskScheduler scheduler, bool ordered)
+            static IEnumerable<TResult> Impl(
+                IEnumerable<T> source,
+                Func<T, CancellationToken, Task<TTaskResult>> evaluator,
+                Func<T, Task<TTaskResult>, TResult> resultSelector,
+                int? maxConcurrency,
+                TaskScheduler scheduler,
+                bool ordered)
             {
                 // A separate task will enumerate the source and launch tasks.
                 // It will post all progress as notices to the collection below.

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -145,7 +145,12 @@ namespace MoreLinq.Experimental
             if (bucketProjectionSelector == null) throw new ArgumentNullException(nameof(bucketProjectionSelector));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, size, pool, bucketProjectionSelector, resultSelector);
+
+            static IEnumerable<TResult> _(
+                IEnumerable<TSource> source, int size, ArrayPool<TSource> pool,
+                Func<ICurrentBuffer<TSource>, IEnumerable<TBucket>> bucketProjectionSelector,
+                Func<IEnumerable<TBucket>, TResult> resultSelector)
             {
                 using var batch = source.Batch(size, pool);
                 var bucket = bucketProjectionSelector(batch.CurrentBuffer);

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -96,9 +96,7 @@ namespace MoreLinq.Experimental
                 }
             }
 
-            return _();
-
-            IEnumerator<T> _()
+            return _(); IEnumerator<T> _()
             {
                 var index = 0;
 

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -96,55 +96,55 @@ namespace MoreLinq.Experimental
                 }
             }
 
-            return _(this);
+            return _();
 
-            static IEnumerator<T> _(MemoizedEnumerable<T> memoized)
+            IEnumerator<T> _()
             {
                 var index = 0;
 
                 while (true)
                 {
                     T current;
-                    lock (memoized.locker)
+                    lock (this.locker)
                     {
-                        if (memoized.cache == null) // Cache disposed during iteration?
+                        if (this.cache == null) // Cache disposed during iteration?
                             throw new ObjectDisposedException(nameof(MemoizedEnumerable<T>));
 
-                        if (index >= memoized.cache.Count)
+                        if (index >= this.cache.Count)
                         {
-                            if (index == memoized.errorIndex)
-                                Assume.NotNull(memoized.error).Throw();
+                            if (index == this.errorIndex)
+                                Assume.NotNull(this.error).Throw();
 
-                            if (memoized.sourceEnumerator == null)
+                            if (this.sourceEnumerator == null)
                                 break;
 
                             bool moved;
                             try
                             {
-                                moved = memoized.sourceEnumerator.MoveNext();
+                                moved = this.sourceEnumerator.MoveNext();
                             }
                             catch (Exception ex)
                             {
-                                memoized.error = ExceptionDispatchInfo.Capture(ex);
-                                memoized.errorIndex = index;
-                                memoized.sourceEnumerator.Dispose();
-                                memoized.sourceEnumerator = null;
+                                this.error = ExceptionDispatchInfo.Capture(ex);
+                                this.errorIndex = index;
+                                this.sourceEnumerator.Dispose();
+                                this.sourceEnumerator = null;
                                 throw;
                             }
 
                             if (moved)
                             {
-                                memoized.cache.Add(memoized.sourceEnumerator.Current);
+                                this.cache.Add(this.sourceEnumerator.Current);
                             }
                             else
                             {
-                                memoized.sourceEnumerator.Dispose();
-                                memoized.sourceEnumerator = null;
+                                this.sourceEnumerator.Dispose();
+                                this.sourceEnumerator = null;
                                 break;
                             }
                         }
 
-                        current = memoized.cache[index];
+                        current = this.cache[index];
                     }
 
                     yield return current;

--- a/MoreLinq/FallbackIfEmpty.cs
+++ b/MoreLinq/FallbackIfEmpty.cs
@@ -161,7 +161,16 @@ namespace MoreLinq
             int? count, T? fallback1, T? fallback2, T? fallback3, T? fallback4,
             IEnumerable<T>? fallback)
         {
-            return _(); IEnumerable<T> _()
+            return _(source, count, fallback1, fallback2, fallback3, fallback4, fallback);
+
+            static IEnumerable<T> _(
+                IEnumerable<T> source,
+                int? count,
+                T? fallback1,
+                T? fallback2,
+                T? fallback3,
+                T? fallback4,
+                IEnumerable<T>? fallback)
             {
                 if (source.TryAsCollectionLike() is null or { Count: > 0 })
                 {

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -118,14 +118,20 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (selector == null) throw new ArgumentNullException(nameof(selector));
 
-            return _();
+            return _(source, selector);
 
-            IEnumerable<
+            static IEnumerable<
 // Just like "IEnumerable.Current" is null-oblivious, so is this:
 #nullable disable
 /*...................*/ object
 #nullable restore
-/*.........................*/ > _()
+/*.........................*/ > _(IEnumerable source,
+                    Func<
+// Just like "IEnumerable.Current" is null-oblivious, so is this:
+#nullable disable
+/*....................*/ object,
+#nullable restore
+/*....................*/ IEnumerable?> selector)
             {
                 var e = source.GetEnumerator();
                 var stack = new Stack<IEnumerator>();

--- a/MoreLinq/Flatten.cs
+++ b/MoreLinq/Flatten.cs
@@ -123,15 +123,15 @@ namespace MoreLinq
             static IEnumerable<
 // Just like "IEnumerable.Current" is null-oblivious, so is this:
 #nullable disable
-/*...................*/ object
+/*..........................*/ object
 #nullable restore
-/*.........................*/ > _(IEnumerable source,
-                    Func<
+/*.................................*/ > _(IEnumerable source,
+                                          Func<
 // Just like "IEnumerable.Current" is null-oblivious, so is this:
 #nullable disable
-/*....................*/ object,
+/*..........................................*/ object,
 #nullable restore
-/*........................*/ IEnumerable?> selector)
+/*..................................................*/ IEnumerable?> selector)
             {
                 var e = source.GetEnumerator();
                 var stack = new Stack<IEnumerator>();

--- a/MoreLinq/From.cs
+++ b/MoreLinq/From.cs
@@ -36,7 +36,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function)
         {
-            return _(); IEnumerable<T> _()
+            return _(function);
+
+            static IEnumerable<T> _(Func<T> function)
             {
 #pragma warning disable CA1062 // Validate arguments of public methods
                 yield return function();
@@ -59,7 +61,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2)
         {
-            return _(); IEnumerable<T> _()
+            return _(function1, function2);
+
+            static IEnumerable<T> _(Func<T> function1, Func<T> function2)
             {
 #pragma warning disable CA1062 // Validate arguments of public methods
                 yield return function1();
@@ -84,7 +88,9 @@ namespace MoreLinq
 
         public static IEnumerable<T> From<T>(Func<T> function1, Func<T> function2, Func<T> function3)
         {
-            return _(); IEnumerable<T> _()
+            return _(function1, function2, function3);
+
+            static IEnumerable<T> _(Func<T> function1, Func<T> function2, Func<T> function3)
             {
 #pragma warning disable CA1062 // Validate arguments of public methods
                 yield return function1();

--- a/MoreLinq/FullGroupJoin.cs
+++ b/MoreLinq/FullGroupJoin.cs
@@ -146,9 +146,15 @@ namespace MoreLinq
             if (secondKeySelector == null) throw new ArgumentNullException(nameof(secondKeySelector));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(comparer ?? EqualityComparer<TKey>.Default);
+            return _(first, second, firstKeySelector, secondKeySelector, resultSelector, comparer ?? EqualityComparer<TKey>.Default);
 
-            IEnumerable<TResult> _(IEqualityComparer<TKey> comparer)
+            static IEnumerable<TResult> _(
+                IEnumerable<TFirst> first,
+                IEnumerable<TSecond> second,
+                Func<TFirst, TKey> firstKeySelector,
+                Func<TSecond, TKey> secondKeySelector,
+                Func<TKey, IEnumerable<TFirst>, IEnumerable<TSecond>, TResult> resultSelector,
+                IEqualityComparer<TKey> comparer)
             {
                 var alookup = Lookup<TKey, TFirst>.CreateForJoin(first, firstKeySelector, comparer);
                 var blookup = Lookup<TKey, TSecond>.CreateForJoin(second, secondKeySelector, comparer);

--- a/MoreLinq/FullJoin.cs
+++ b/MoreLinq/FullJoin.cs
@@ -228,9 +228,17 @@ namespace MoreLinq
             if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
             if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
 
-            return Impl();
+            return Impl(first, second, firstKeySelector, secondKeySelector, firstSelector, secondSelector, bothSelector, comparer);
 
-            IEnumerable<TResult> Impl()
+            static IEnumerable<TResult> Impl(
+                IEnumerable<TFirst> first,
+                IEnumerable<TSecond> second,
+                Func<TFirst, TKey> firstKeySelector,
+                Func<TSecond, TKey> secondKeySelector,
+                Func<TFirst, TResult> firstSelector,
+                Func<TSecond, TResult> secondSelector,
+                Func<TFirst, TSecond, TResult> bothSelector,
+                IEqualityComparer<TKey>? comparer)
             {
                 var seconds = second.Select(e => new KeyValuePair<TKey, TSecond>(secondKeySelector(e), e)).ToArray();
                 var secondLookup = seconds.ToLookup(e => e.Key, e => e.Value, comparer);

--- a/MoreLinq/Generate.cs
+++ b/MoreLinq/Generate.cs
@@ -45,7 +45,9 @@ namespace MoreLinq
         {
             if (generator == null) throw new ArgumentNullException(nameof(generator));
 
-            return _(); IEnumerable<TResult> _()
+            return _(initial, generator);
+
+            static IEnumerable<TResult> _(TResult initial, Func<TResult, TResult> generator)
             {
                 var current = initial;
                 while (true)

--- a/MoreLinq/Insert.cs
+++ b/MoreLinq/Insert.cs
@@ -55,7 +55,9 @@ namespace MoreLinq
             if (second == null) throw new ArgumentNullException(nameof(second));
             if (index < 0) throw new ArgumentOutOfRangeException(nameof(index), "Index cannot be negative.");
 
-            return _(); IEnumerable<T> _()
+            return _(first, second, index);
+
+            static IEnumerable<T> _(IEnumerable<T> first, IEnumerable<T> second, int index)
             {
                 var i = -1;
 

--- a/MoreLinq/Lag.cs
+++ b/MoreLinq/Lag.cs
@@ -83,7 +83,13 @@ namespace MoreLinq
             //       that it's an intuitive - or even desirable - behavior. So it's being omitted.
             if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, offset, defaultLagValue, resultSelector);
+
+            static IEnumerable<TResult> _(
+                IEnumerable<TSource> source,
+                int offset,
+                TSource defaultLagValue,
+                Func<TSource, TSource, TResult> resultSelector)
             {
                 using var iter = source.GetEnumerator();
 

--- a/MoreLinq/Lead.cs
+++ b/MoreLinq/Lead.cs
@@ -80,7 +80,13 @@ namespace MoreLinq
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
             if (offset <= 0) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, offset, defaultLeadValue, resultSelector);
+
+            static IEnumerable<TResult> _(
+                IEnumerable<TSource> source,
+                int offset,
+                TSource defaultLeadValue,
+                Func<TSource, TSource, TResult> resultSelector)
             {
                 var leadQueue = new Queue<TSource>(offset);
                 using var iter = source.GetEnumerator();

--- a/MoreLinq/Maxima.cs
+++ b/MoreLinq/Maxima.cs
@@ -312,10 +312,15 @@ namespace MoreLinq
             Extrema<TStore, TSource> extrema, int? limit,
             Func<TSource, TKey> selector, Func<TKey, TKey, int> comparer)
         {
-            foreach (var item in Extrema())
+            var extremaResults = Extrema(source, extrema, limit, selector, comparer);
+
+            foreach (var item in extremaResults)
                 yield return item;
 
-            IEnumerable<TSource> Extrema()
+            static IEnumerable<TSource> Extrema(
+                IEnumerable<TSource> source,
+                Extrema<TStore, TSource> extrema, int? limit,
+                Func<TSource, TKey> selector, Func<TKey, TKey, int> comparer)
             {
                 using var e = source.GetEnumerator();
 

--- a/MoreLinq/Move.cs
+++ b/MoreLinq/Move.cs
@@ -58,10 +58,10 @@ namespace MoreLinq
                 return source;
 
             return toIndex < fromIndex
-                 ? _(toIndex, fromIndex - toIndex, count)
-                 : _(fromIndex, count, toIndex - fromIndex);
+                 ? _(source, toIndex, fromIndex - toIndex, count)
+                 : _(source, fromIndex, count, toIndex - fromIndex);
 
-            IEnumerable<T> _(int bufferStartIndex, int bufferSize, int bufferYieldIndex)
+            static IEnumerable<T> _(IEnumerable<T> source, int bufferStartIndex, int bufferSize, int bufferYieldIndex)
             {
                 var hasMore = true;
                 bool MoveNext(IEnumerator<T> e) => hasMore && (hasMore = e.MoveNext());

--- a/MoreLinq/OrderedMerge.cs
+++ b/MoreLinq/OrderedMerge.cs
@@ -282,9 +282,25 @@ namespace MoreLinq
             if (bothSelector == null) throw new ArgumentNullException(nameof(bothSelector));
             if (secondSelector == null) throw new ArgumentNullException(nameof(secondSelector));
 
-            return _(comparer ?? Comparer<TKey>.Default);
+            return _(
+                first,
+                second,
+                firstKeySelector,
+                secondKeySelector,
+                firstSelector,
+                secondSelector,
+                bothSelector,
+                comparer ?? Comparer<TKey>.Default);
 
-            IEnumerable<TResult> _(IComparer<TKey> comparer)
+            static IEnumerable<TResult> _(
+                IEnumerable<TFirst> first,
+                IEnumerable<TSecond> second,
+                Func<TFirst, TKey> firstKeySelector,
+                Func<TSecond, TKey> secondKeySelector,
+                Func<TFirst, TResult> firstSelector,
+                Func<TSecond, TResult> secondSelector,
+                Func<TFirst, TSecond, TResult> bothSelector,
+                IComparer<TKey> comparer)
             {
                 using var e1 = first.GetEnumerator();
                 using var e2 = second.GetEnumerator();

--- a/MoreLinq/PadStart.cs
+++ b/MoreLinq/PadStart.cs
@@ -117,7 +117,13 @@ namespace MoreLinq
         static IEnumerable<T> PadStartImpl<T>(IEnumerable<T> source,
             int width, T? padding, Func<int, T>? paddingSelector)
         {
-            return _(); IEnumerable<T> _()
+            return _(source, width, padding, paddingSelector);
+
+            static IEnumerable<T> _(
+                IEnumerable<T> source,
+                int width,
+                T? padding,
+                Func<int, T>? paddingSelector)
             {
                 if (source.TryAsCollectionLike() is { Count: var collectionCount } && collectionCount < width)
                 {

--- a/MoreLinq/Pairwise.cs
+++ b/MoreLinq/Pairwise.cs
@@ -53,7 +53,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<TSource> source, Func<TSource, TSource, TResult> resultSelector)
             {
                 using var e = source.GetEnumerator();
 

--- a/MoreLinq/Permutations.cs
+++ b/MoreLinq/Permutations.cs
@@ -49,7 +49,9 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 
-            return _(); IEnumerable<IList<T>> _()
+            return _(sequence);
+
+            static IEnumerable<IList<T>> _(IEnumerable<T> sequence)
             {
                 // The algorithm used to generate permutations uses the fact that any set can be put
                 // into 1-to-1 correspondence with the set of ordinals number (0..n). The

--- a/MoreLinq/Pipe.cs
+++ b/MoreLinq/Pipe.cs
@@ -43,7 +43,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (action == null) throw new ArgumentNullException(nameof(action));
 
-            return _(); IEnumerable<T> _()
+            return _(source, action);
+
+            static IEnumerable<T> _(IEnumerable<T> source, Action<T> action)
             {
                 foreach (var element in source)
                 {

--- a/MoreLinq/PreScan.cs
+++ b/MoreLinq/PreScan.cs
@@ -59,7 +59,12 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (transformation == null) throw new ArgumentNullException(nameof(transformation));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, transformation, identity);
+
+            static IEnumerable<TSource> _(
+                IEnumerable<TSource> source,
+                Func<TSource, TSource, TSource> transformation,
+                TSource identity)
             {
                 var aggregator = identity;
                 using var e = source.GetEnumerator();

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -77,9 +77,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            return _(comparer ?? Comparer<TKey>.Default);
+            return _(source, keySelector, comparer ?? Comparer<TKey>.Default);
 
-            IEnumerable<int> _(IComparer<TKey> comparer)
+            static IEnumerable<int> _(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer< TKey> comparer)
             {
                 source = source.ToArray(); // avoid enumerating source twice
 

--- a/MoreLinq/RunLengthEncode.cs
+++ b/MoreLinq/RunLengthEncode.cs
@@ -49,9 +49,9 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 
-            return _(comparer ?? EqualityComparer<T>.Default);
+            return _(sequence, comparer ?? EqualityComparer<T>.Default);
 
-            IEnumerable<KeyValuePair<T, int>> _(IEqualityComparer<T> comparer)
+            static IEnumerable<KeyValuePair<T, int>> _(IEnumerable<T> sequence, IEqualityComparer<T> comparer)
             {
                 // This implementation could also have been written using a foreach loop,
                 // but it proved to be easier to deal with edge certain cases that occur

--- a/MoreLinq/ScanBy.cs
+++ b/MoreLinq/ScanBy.cs
@@ -85,9 +85,14 @@ namespace MoreLinq
             if (seedSelector == null) throw new ArgumentNullException(nameof(seedSelector));
             if (accumulator == null) throw new ArgumentNullException(nameof(accumulator));
 
-            return _(comparer ?? EqualityComparer<TKey>.Default);
+            return _(source, keySelector, seedSelector, accumulator, comparer ?? EqualityComparer<TKey>.Default);
 
-            IEnumerable<KeyValuePair<TKey, TState>> _(IEqualityComparer<TKey> comparer)
+            static IEnumerable<KeyValuePair<TKey, TState>> _(
+                IEnumerable<TSource> source,
+                Func<TSource, TKey> keySelector,
+                Func<TKey, TState> seedSelector,
+                Func<TState, TKey, TSource, TState> accumulator,
+                IEqualityComparer<TKey> comparer)
             {
                 var stateByKey = new Collections.Dictionary<TKey, TState>(comparer);
 

--- a/MoreLinq/Segment.cs
+++ b/MoreLinq/Segment.cs
@@ -74,7 +74,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (newSegmentPredicate == null) throw new ArgumentNullException(nameof(newSegmentPredicate));
 
-            return _(); IEnumerable<IEnumerable<T>> _()
+            return _(source, newSegmentPredicate);
+
+            static IEnumerable<IEnumerable<T>> _(IEnumerable<T> source, Func<T, T, int, bool> newSegmentPredicate)
             {
                 using var e = source.GetEnumerator();
 

--- a/MoreLinq/SkipUntil.cs
+++ b/MoreLinq/SkipUntil.cs
@@ -57,7 +57,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, predicate);
+
+            static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, bool> predicate)
             {
                 using var enumerator = source.GetEnumerator();
 

--- a/MoreLinq/Slice.cs
+++ b/MoreLinq/Slice.cs
@@ -55,12 +55,12 @@ namespace MoreLinq
 
             return sequence switch
             {
-                IList<T> list => SliceList(list.Count, i => list[i]),
-                IReadOnlyList<T> list => SliceList(list.Count, i => list[i]),
+                IList<T> list => SliceList(startIndex, count, list.Count, i => list[i]),
+                IReadOnlyList<T> list => SliceList(startIndex, count, list.Count, i => list[i]),
                 var seq => seq.Skip(startIndex).Take(count)
             };
 
-            IEnumerable<T> SliceList(int listCount, Func<int, T> indexer)
+            static IEnumerable<T> SliceList(int startIndex, int count, int listCount, Func<int, T> indexer)
             {
                 var countdown = count;
                 var index = startIndex;

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -96,7 +96,7 @@ namespace MoreLinq
                     : (a, b) => comparer.Compare(b, a) > 0;
 
             // return the sorted merge result
-            return Impl(new[] { source }.Concat(otherSequences));
+            return Impl(precedenceFunc, new[] { source }.Concat(otherSequences));
 
             // Private implementation method that performs a merge of multiple, ordered sequences using
             // a precedence function which encodes order-sensitive comparison logic based on the caller's arguments.
@@ -109,7 +109,7 @@ namespace MoreLinq
             //
             // The algorithm used here will perform N*(K1+K2+...Kn-1) comparisons, where <c>N => otherSequences.Count()+1.</c>
 
-            IEnumerable<TSource> Impl(IEnumerable<IEnumerable<TSource>> sequences)
+            static IEnumerable<TSource> Impl(Func<TSource, TSource, bool> precedenceFunc, IEnumerable<IEnumerable<TSource>> sequences)
             {
                 using var disposables = new DisposableGroup<TSource>(sequences.Select(e => e.GetEnumerator()).Acquire());
 

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -96,7 +96,7 @@ namespace MoreLinq
                     : (a, b) => comparer.Compare(b, a) > 0;
 
             // return the sorted merge result
-            return Impl(precedenceFunc, new[] { source }.Concat(otherSequences));
+            return Impl(new[] { source }.Concat(otherSequences), precedenceFunc);
 
             // Private implementation method that performs a merge of multiple, ordered sequences using
             // a precedence function which encodes order-sensitive comparison logic based on the caller's arguments.
@@ -109,7 +109,7 @@ namespace MoreLinq
             //
             // The algorithm used here will perform N*(K1+K2+...Kn-1) comparisons, where <c>N => otherSequences.Count()+1.</c>
 
-            static IEnumerable<TSource> Impl(Func<TSource, TSource, bool> precedenceFunc, IEnumerable<IEnumerable<TSource>> sequences)
+            static IEnumerable<TSource> Impl(IEnumerable<IEnumerable<TSource>> sequences, Func<TSource, TSource, bool> precedenceFunc)
             {
                 using var disposables = new DisposableGroup<TSource>(sequences.Select(e => e.GetEnumerator()).Acquire());
 

--- a/MoreLinq/Split.cs
+++ b/MoreLinq/Split.cs
@@ -267,7 +267,13 @@ namespace MoreLinq
             if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, separatorFunc, count, resultSelector);
+
+            static IEnumerable<TResult> _(
+                IEnumerable<TSource> source,
+                Func<TSource, bool> separatorFunc,
+                int count,
+                Func<IEnumerable<TSource>, TResult> resultSelector)
             {
                 if (count == 0) // No splits?
                 {

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -51,7 +51,9 @@ namespace MoreLinq
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 
-            return _(); IEnumerable<IList<T>> _()
+            return _(sequence);
+
+            static IEnumerable<IList<T>> _(IEnumerable<T> sequence)
             {
                 var sequenceAsList = sequence.ToList();
                 var sequenceLength = sequenceAsList.Count;

--- a/MoreLinq/Subsets.cs
+++ b/MoreLinq/Subsets.cs
@@ -115,7 +115,9 @@ namespace MoreLinq
             // preconditions. This however, needs to be carefully considered - and perhaps
             // may change after further thought and review.
 
-            return _(); IEnumerable<IList<T>> _()
+            return _(sequence, subsetSize);
+
+            static IEnumerable<IList<T>> _(IEnumerable<T> sequence, int subsetSize)
             {
                 foreach (var subset in Subsets(sequence.ToList(), subsetSize))
                     yield return subset;

--- a/MoreLinq/TagFirstLast.cs
+++ b/MoreLinq/TagFirstLast.cs
@@ -59,7 +59,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(); IEnumerable<TResult> _()
+            return _(source, resultSelector);
+
+            static IEnumerable<TResult> _(IEnumerable<TSource> source, Func<TSource, bool, bool, TResult> resultSelector)
             {
                 using var enumerator = source.GetEnumerator();
 

--- a/MoreLinq/TakeUntil.cs
+++ b/MoreLinq/TakeUntil.cs
@@ -57,7 +57,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return _(); IEnumerable<TSource> _()
+            return _(source, predicate);
+
+            static IEnumerable<TSource> _(IEnumerable<TSource> source, Func<TSource, bool> predicate)
             {
                 foreach (var item in source)
                 {

--- a/MoreLinq/Transpose.cs
+++ b/MoreLinq/Transpose.cs
@@ -56,7 +56,9 @@ namespace MoreLinq
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            return _(); IEnumerable<IEnumerable<T>> _()
+            return _(source);
+
+            static IEnumerable<IEnumerable<T>> _(IEnumerable<IEnumerable<T>> source)
             {
 #pragma warning disable IDE0007 // Use implicit type (false positive)
                 IEnumerator<T>?[] enumerators = source.Select(e => e.GetEnumerator()).Acquire();

--- a/MoreLinq/Traverse.cs
+++ b/MoreLinq/Traverse.cs
@@ -48,7 +48,9 @@ namespace MoreLinq
         {
             if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
 
-            return _(); IEnumerable<T> _()
+            return _(root, childrenSelector);
+
+            static IEnumerable<T> _(T root, Func<T, IEnumerable<T>> childrenSelector)
             {
                 var queue = new Queue<T>();
                 queue.Enqueue(root);
@@ -88,7 +90,9 @@ namespace MoreLinq
         {
             if (childrenSelector == null) throw new ArgumentNullException(nameof(childrenSelector));
 
-            return _(); IEnumerable<T> _()
+            return _(root, childrenSelector);
+
+            static IEnumerable<T> _(T root, Func<T, IEnumerable<T>> childrenSelector)
             {
                 var stack = new Stack<T>();
                 stack.Push(root);

--- a/MoreLinq/Unfold.cs
+++ b/MoreLinq/Unfold.cs
@@ -61,7 +61,14 @@ namespace MoreLinq
             if (stateSelector == null) throw new ArgumentNullException(nameof(stateSelector));
             if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
 
-            return _(state); IEnumerable<TResult> _(TState initialState)
+            return _(state, generator, predicate, stateSelector, resultSelector);
+
+            static IEnumerable<TResult> _(
+                TState initialState,
+                Func<TState, T> generator,
+                Func<T, bool> predicate,
+                Func<T, TState> stateSelector,
+                Func<T, TResult> resultSelector)
             {
                 for (var state = initialState; ;)
                 {

--- a/MoreLinq/Window.cs
+++ b/MoreLinq/Window.cs
@@ -44,7 +44,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
-            return _(); IEnumerable<IList<TSource>> _()
+            return _(source, size);
+
+            static IEnumerable<IList<TSource>> _(IEnumerable<TSource> source, int size)
             {
                 using var iter = source.GetEnumerator();
 

--- a/MoreLinq/WindowLeft.cs
+++ b/MoreLinq/WindowLeft.cs
@@ -63,7 +63,9 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (size <= 0) throw new ArgumentOutOfRangeException(nameof(size));
 
-            return _(); IEnumerable<IList<TSource>> _()
+            return _(source, size);
+
+            static IEnumerable<IList<TSource>> _(IEnumerable<TSource> source, int size)
             {
                 var window = new List<TSource>();
                 foreach (var item in source)

--- a/MoreLinq/WindowRight.cs
+++ b/MoreLinq/WindowRight.cs
@@ -78,7 +78,11 @@ namespace MoreLinq
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return _(); IEnumerable<IList<TSource>> _()
+            return _(source, predicate);
+
+            static IEnumerable<IList<TSource>> _(
+                IEnumerable<TSource> source,
+                Func<TSource, int, bool> predicate)
             {
                 var window = new List<TSource>();
                 foreach (var item in source)


### PR DESCRIPTION
This PR:

- primarily closes #906 where closures are to be removed in favour of using private static methods.
- and incidentally fixes #1065 

One unit test had to be updated. This was to change the max enumerations of the test sequence from 1 to 2. The test enumerates the sequence twice so this should have always been the case. However I think previously using closures meant that test was enumerated once when it should have been twice. Happy to be corrected if I have misunderstood.

This is my first PR for MoreLINQ so apologies if I have missed any guidance on submitting PRs and will happily take onboard feedback