### PR TITLE
Remove testing against .NET 7 (near end-of-life)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,6 @@ jobs:
       with:
         global-json-file: global.json
 
-    - name: Setup .NET SDK 7.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-
     - name: Setup .NET SDK 6.0
       uses: actions/setup-dotnet@v3
       with:

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net8.0;net7.0;net6.0;net471</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net471</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType Condition="'$(TargetFramework)' == 'net471'">Exe</OutputType>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,10 +52,8 @@ install:
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 6.0.11 -SkipNonVersionedFiles }
-- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 7.0.14 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 6.0.11 --skip-non-versioned-files
-- sh: ./tools/dotnet-install.sh --runtime dotnet --version 7.0.14 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/test.cmd
+++ b/test.cmd
@@ -10,8 +10,6 @@ if %SKIP_TEST_BUILD%==false call build || exit /b 1
 call :clean ^
   && call :test net8.0 Debug ^
   && call :test net8.0 Release ^
-  && call :test net7.0 Debug ^
-  && call :test net7.0 Release ^
   && call :test net6.0 Debug ^
   && call :test net6.0 Release ^
   && call :test net471 Debug ^

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in net6.0 net7.0 net8.0; do
+for f in net6.0 net8.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"


### PR DESCRIPTION
This PR removes testing against [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) (STS), which reaches [end-of-life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) next week, on May 14, 2024.