### PR TITLE
Update NuGet package validation tool to latest version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "meziantou.framework.nugetpackagevalidation.tool": {
-      "version": "1.0.12",
+      "version": "1.0.14",
       "commands": [
         "meziantou.validate-nuget-package"
       ]


### PR DESCRIPTION
This PR updates the [Meziantou.Framework.NuGetPackageValidation.Tool](https://www.nuget.org/packages/meziantou.framework.nugetpackagevalidation.tool) package to its [latest version (1.0.14)](https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool/1.0.14) so that .NET 7 is not required.