### PR TITLE
Pin to .NET SDK 8.0.2xx

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestFeature"
+    "version": "8.0.200",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
This PR pins the solution to .NET SDK 8.0.2xx. Up to now, the roll-forward policy was latest feature, but .NET SDK 8.0.300 introduces a regressions which causes compilation to fail due to the following code analysis errors:

    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(1,1): error IDE0240: Nullable directive is redundant (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0240)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(45,17): error IDE0010: Populate switch (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(69,21): error IDE0010: Populate switch (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(81,37): error IDE0010: Populate switch (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0010)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(86,45): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(92,45): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(98,45): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(104,45): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(113,33): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(119,29): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(133,37): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(139,33): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(145,29): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(155,33): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(161,29): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(170,17): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)
    bld\ExtensionsGenerator\obj\Debug\net8.0\DocoptNet\DocoptNet.CodeGeneration.SourceGenerator\ProgramArguments.cs(176,13): error IDE0058: Expression value is never used (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0058)

To avoid being subjected to future regressions, it seems safer to roll-forward to latest patch only.
