### PR TITLE
Update .NET SDK to 8.0.400, including dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,28 +3,32 @@
   "isRoot": true,
   "tools": {
     "dotnet-t4": {
-      "version": "2.3.0",
+      "version": "3.0.0",
       "commands": [
         "t4"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.11",
+      "version": "5.3.9",
       "commands": [
         "reportgenerator"
-      ]
+      ],
+      "rollForward": false
     },
     "meziantou.framework.nugetpackagevalidation.tool": {
-      "version": "1.0.14",
+      "version": "1.0.16",
       "commands": [
         "meziantou.validate-nuget-package"
-      ]
+      ],
+      "rollForward": false
     },
     "powershell": {
-      "version": "7.4.0",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
+++ b/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.24266.1" />
-    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24266.1" />
-    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.10.4" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.4" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.3.1">
+    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.24460.4" />
+    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24460.4" />
+    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.12.4" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.Analyzers" Version="3.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MoreLinq.Test.Aot/ToDataTableTest.cs
+++ b/MoreLinq.Test.Aot/ToDataTableTest.cs
@@ -15,7 +15,7 @@
 // limitations under the License.
 #endregion
 
-namespace MoreLinq.Test
+namespace MoreLinq.Test.Aot
 {
     using System;
     using System.Collections;

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -26,20 +26,20 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnitLite" Version="4.1.0" />
+    <PackageReference Include="NUnitLite" Version="4.2.2" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net471'">

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -119,7 +119,7 @@
     <Copyright>$([System.Text.RegularExpressions.Regex]::Replace($(Copyright), `\s+`, ` `).Trim())</Copyright>
     <AssemblyTitle>MoreLINQ</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>4.3.0</VersionPrefix>
+    <VersionPrefix>4.3.1</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -126,6 +126,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MoreLinq</AssemblyName>
     <OutputType>Library</OutputType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -150,7 +150,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/bld/ExtensionsGenerator/.editorconfig
+++ b/bld/ExtensionsGenerator/.editorconfig
@@ -1,0 +1,2 @@
+[ProgramArguments.cs]
+dotnet_analyzer_diagnostic.category-Style.severity = suggestion

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "8.0.400",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 8.0.400 and updates all dependencies to their latest versions.

It closes #1073 by adding an `.editorconfig` to the **MoreLinq.ExtensionsGenerator** project so style issues are not flagged as warnings, which were appearing in code generated by [docopt.net](https://www.nuget.org/packages/docopt.net).

