### PR TITLE
Drop CI build matrix & testing on macOS images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-22.04, macos-11]
+        os: [windows-2022, ubuntu-22.04]
 
     steps:
 
@@ -81,7 +81,7 @@ jobs:
       if: runner.os == 'Windows'
       run: call pack.cmd
 
-    - name: Build & Pack (Linux/macOS)
+    - name: Build & Pack (Linux)
       if: runner.os != 'Windows'
       run: ./pack.sh
 
@@ -109,7 +109,7 @@ jobs:
       if: runner.os == 'Windows'
       run: call test.cmd
 
-    - name: Test (Linux/macOS)
+    - name: Test (Linux)
       if: runner.os != 'Windows'
       run: ./test.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: '{build}'
 image:
 - Visual Studio 2022
 - Ubuntu1804
-- macos-bigsur
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
@@ -38,12 +37,6 @@ for:
       - image: Ubuntu1804
   environment:
     IMAGE_NAME: ubuntu-18.04
--
-  matrix:
-    only:
-      - image: macos-bigsur
-  environment:
-    IMAGE_NAME: macos
 install:
 - npm install -g eclint
 - git rm .editorconfig


### PR DESCRIPTION
This PR removes building & testing on macOS from CI pipelines.

The macOS machines on CI platforms seems to fail often, adds to the overall CI checks times and brings little benefit. It was historically interesting for testing against Mono on macOS and validating compatibility of tools/binaries used in Bash scripts.

This can always be revived if needed.
