### PR TITLE
Drop conditional testing on Mono

### DIFF
--- a/MoreLinq.Test/TransposeTest.cs
+++ b/MoreLinq.Test/TransposeTest.cs
@@ -58,7 +58,7 @@ namespace MoreLinq.Test
             using var row3 = TestingSequence.Of(30, 31, 32, 33);
             using var matrix = TestingSequence.Of(row1, row2, row3);
 
-            AssertMatrix(expectations, matrix.Transpose());
+            Assert.That(matrix.Transpose(), Is.EqualTo(expectations));
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace MoreLinq.Test
             using var row4 = TestingSequence.Of(30, 31, 32);
             using var matrix = TestingSequence.Of(row1, row2, row3, row4);
 
-            AssertMatrix(expectations, matrix.Transpose());
+            Assert.That(matrix.Transpose(), Is.EqualTo(expectations));
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace MoreLinq.Test
                 [32, 243, 3125]
             };
 
-            AssertMatrix(expectations, result);
+            Assert.That(result, Is.EqualTo(expectations));
         }
 
         [Test]
@@ -139,7 +139,7 @@ namespace MoreLinq.Test
                 [32,      3125]
             };
 
-            AssertMatrix(expectations, result);
+            Assert.That(result, Is.EqualTo(expectations));
         }
 
         [Test]
@@ -206,19 +206,6 @@ namespace MoreLinq.Test
             }
 
             return true;
-        }
-
-        static void AssertMatrix<T>(IEnumerable<IEnumerable<T>> expectation, IEnumerable<IEnumerable<T>> result)
-        {
-            // necessary because NUnitLite 3.6.1 (.NET 4.5) for Mono don't assert nested enumerables
-
-            var resultList = result.ToList();
-            var expectationList = expectation.ToList();
-
-            Assert.That(resultList.Count, Is.EqualTo(expectationList.Count));
-
-            expectationList.Zip(resultList, ValueTuple.Create)
-                           .ForEach(t => t.Item1.AssertSequenceEqual(t.Item2));
         }
     }
 }

--- a/test.sh
+++ b/test.sh
@@ -23,13 +23,5 @@ dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.x
                        -reporttypes:Html\;TextSummary \
                        -targetdir:MoreLinq.Test/TestResults/reports
 cat MoreLinq.Test/TestResults/reports/Summary.txt
-if [[ -z `which mono 2>/dev/null` ]]; then
-    echo>&2 NOTE! Mono does not appear to be installed so unit tests
-    echo>&2 against the Mono runtime will be skipped.
-else
-    for c in $configs; do
-        mono MoreLinq.Test/bin/$c/net471/MoreLinq.Test.exe
-    done
-fi
 dotnet publish MoreLinq.Test.Aot
 "$(find MoreLinq.Test.Aot -type d -name publish)/MoreLinq.Test.Aot"


### PR DESCRIPTION
This PR drops testing on Mono, which was there for historical reasons when it was the go-to option for running & using .NET Framework assemblies on non-Windows platforms. This changed with .NET (Core), which now runs on many non-Windows platforms. Also:

> Microsoft maintains a modern fork of [Mono runtime in the dotnet/runtime repo](https://github.com/dotnet/runtime/tree/main/src/mono) and has been progressively moving workloads to that fork. That work is now complete, and we recommend that active Mono users and maintainers of Mono-based app frameworks migrate to [.NET](https://github.com/dotnet/core) which includes work from this fork.

