### PR TITLE
Cleanup NUnit1030

### DIFF
--- a/MoreLinq.Test/.editorconfig
+++ b/MoreLinq.Test/.editorconfig
@@ -41,8 +41,5 @@ dotnet_diagnostic.CA1861.severity = none
 # IDE0022: Use expression/block body for methods
 dotnet_diagnostic.IDE0022.severity = none
 
-# NUnit1030: The type of parameter provided by the TestCaseSource does not match the type of the parameter in the Test method
-dotnet_diagnostic.NUnit1030.severity = suggestion
-
 # Nunit1029: The number of parameters provided by the TestCaseSource does not match the number of parameters in the Test method
 dotnet_diagnostic.NUnit1029.severity = suggestion

--- a/MoreLinq.Test/PadStartTest.cs
+++ b/MoreLinq.Test/PadStartTest.cs
@@ -20,19 +20,19 @@ namespace MoreLinq.Test
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using NUnit.Framework.Interfaces;
 
     [TestFixture]
     public class PadStartTest
     {
-        static readonly IEnumerable<ITestCaseData> PadStartWithNegativeWidthCases =
-            from e in new (string Name, TestDelegate Delegate)[]
-            {
-                ("DefaultPadding" , static () => new object[0].PadStart(-1)),
-                ("Padding"        , static () => new object[0].PadStart(-1, -2)),
-                ("PaddingSelector", static () => new object[0].PadStart(-1, BreakingFunc.Of<int, int>())),
-            }
-            select new TestCaseData(e.Delegate).SetName(e.Name);
+        static IEnumerable<TestDelegate> PadStartWithNegativeWidthCases()
+        {
+            return
+            [
+                static () => Array.Empty<object>().PadStart(-1),
+                static () => Array.Empty<object>().PadStart(-1, -2),
+                static () => Array.Empty<object>().PadStart(-1, BreakingFunc.Of<int, int>())
+            ];
+        }
 
         [TestCaseSource(nameof(PadStartWithNegativeWidthCases))]
         public void PadStartWithNegativeWidth(TestDelegate @delegate)

--- a/MoreLinq.Test/PadTest.cs
+++ b/MoreLinq.Test/PadTest.cs
@@ -20,19 +20,19 @@ namespace MoreLinq.Test
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using NUnit.Framework.Interfaces;
 
     [TestFixture]
     public class PadTest
     {
-        static readonly IEnumerable<ITestCaseData> PadNegativeWidthCases =
-            from e in new (string Name, TestDelegate Delegate)[]
-            {
-                ("DefaultPadding" , static () => new object[0].Pad(-1)),
-                ("Padding"        , static () => new object[0].Pad(-1, -2)),
-                ("PaddingSelector", static () => new object[0].Pad(-1, BreakingFunc.Of<int, int>())),
-            }
-            select new TestCaseData(e.Delegate).SetName(e.Name);
+        static IEnumerable<TestDelegate> PadNegativeWidthCases()
+        {
+            return
+            [
+                static () => Array.Empty<object>().Pad(-1),
+                static () => Array.Empty<object>().Pad(-1, -2),
+                static () => Array.Empty<object>().Pad(-1, BreakingFunc.Of<int, int>())
+            ];
+        }
 
         [TestCaseSource(nameof(PadNegativeWidthCases))]
         public void PadNegativeWidth(TestDelegate @delegate)

--- a/MoreLinq.Test/ReturnTest.cs
+++ b/MoreLinq.Test/ReturnTest.cs
@@ -20,7 +20,6 @@ namespace MoreLinq.Test
     using System;
     using System.Collections.Generic;
     using NUnit.Framework;
-    using NUnit.Framework.Interfaces;
 
     public class ReturnTest
     {
@@ -136,21 +135,20 @@ namespace MoreLinq.Test
             Assert.That(SomeSingleton.List.IndexOf(new object()), Is.EqualTo(-1));
         }
 
-        static IEnumerable<ITestCaseData> UnsupportedActions(string testName) =>
-            from ma in new (string MethodName, Action Action)[]
-            {
-                ("Add"     , () => SomeSingleton.List.Add(new object())),
-                ("Clear"   ,       SomeSingleton.Collection.Clear),
-                ("Remove"  , () => SomeSingleton.Collection.Remove(SomeSingleton.Item)),
-                ("RemoveAt", () => SomeSingleton.List.RemoveAt(0)),
-                ("Insert"  , () => SomeSingleton.List.Insert(0, new object())),
-                ("Index"   , () => SomeSingleton.List[0] = new object()),
-            }
-            select new TestCaseData(ma.Action).SetName($"{testName}({ma.MethodName})");
+        static IEnumerable<Action> UnsupportedActions()
+        {
+            return
+            [
+                () => SomeSingleton.List.Add(new object()),
+                SomeSingleton.Collection.Clear,
+                () => SomeSingleton.Collection.Remove(SomeSingleton.Item),
+                () => SomeSingleton.List.RemoveAt(0),
+                () => SomeSingleton.List.Insert(0, new object()),
+                () => SomeSingleton.List[0] = new object(),
+            ];
+        }
 
-#pragma warning disable NUnit1018 // Parameter count does not match (false negative)
-        [TestCaseSource(nameof(UnsupportedActions), [nameof(TestUnsupportedMethodShouldThrow)])]
-#pragma warning restore NUnit1018 // Parameter count does not match
+        [TestCaseSource(nameof(UnsupportedActions))]
         public void TestUnsupportedMethodShouldThrow(Action unsupportedAction)
         {
             Assert.That(() => unsupportedAction(), Throws.InstanceOf<NotSupportedException>());


### PR DESCRIPTION
Fixes the NUnit1030 warnings.

More details are available in [Issue #1024](https://github.com/morelinq/MoreLINQ/issues/1024).