### PR TITLE
Update .NET SDK to 9, including dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,12 @@ jobs:
       with:
         global-json-file: global.json
 
-    - name: Setup .NET SDK 6.0
+    - name: Setup .NET SDK 6.0, 8.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          6.0.x
+          8.0.x
 
     - name: .NET Information
       run: dotnet --info

--- a/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
+++ b/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.24460.4" />
-    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24460.4" />
-    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.12.4" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.4" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.6.0">
+    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.24562.1" />
+    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24562.1" />
+    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.13.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="MSTest.Analyzers" Version="3.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MoreLinq.Test.Aot/ToDataTableTest.cs
+++ b/MoreLinq.Test.Aot/ToDataTableTest.cs
@@ -19,7 +19,7 @@ namespace MoreLinq.Test.Aot
 {
     using System;
     using System.Collections;
-    using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Data;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
@@ -42,12 +42,12 @@ namespace MoreLinq.Test.Aot
             public override string ToString() => nameof(TestObject);
         }
 
-        readonly IReadOnlyCollection<TestObject> testObjects;
+        readonly ImmutableArray<TestObject> testObjects;
 
         public ToDataTableTest() =>
             this.testObjects = Enumerable.Range(0, 3)
                                          .Select(i => new TestObject(i))
-                                         .ToArray();
+                                         .ToImmutableArray();
 
         [TestMethod]
         public void ToDataTableNullMemberExpressionMethod()
@@ -158,7 +158,7 @@ namespace MoreLinq.Test.Aot
 
             var dt = Act();
 
-            Assert.AreEqual(this.testObjects.Count, dt.Rows.Count);
+            Assert.AreEqual(this.testObjects.Length, dt.Rows.Count);
         }
 
         [TestMethod]

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net8.0;net6.0;net471</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;net471</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType Condition="'$(TargetFramework)' == 'net471'">Exe</OutputType>
@@ -32,14 +32,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnitLite" Version="4.3.1" />
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net471'">
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
     <Compile Remove="Async\*.cs" />
   </ItemGroup>
 

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -19,7 +19,7 @@ namespace MoreLinq.Test
 {
     using System;
     using System.Collections;
-    using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Data;
     using System.Linq.Expressions;
     using NUnit.Framework;
@@ -41,12 +41,12 @@ namespace MoreLinq.Test
             public override string ToString() => nameof(TestObject);
         }
 
-        readonly IReadOnlyCollection<TestObject> testObjects;
+        readonly ImmutableArray<TestObject> testObjects;
 
         public ToDataTableTest() =>
             this.testObjects = Enumerable.Range(0, 3)
                                          .Select(i => new TestObject(i))
-                                         .ToArray();
+                                         .ToImmutableArray();
 
         [Test]
         public void ToDataTableNullMemberExpressionMethod()
@@ -135,7 +135,7 @@ namespace MoreLinq.Test
         public void ToDataTableContainsAllElements()
         {
             var dt = this.testObjects.ToDataTable();
-            Assert.That(dt.Rows.Count, Is.EqualTo(this.testObjects.Count));
+            Assert.That(dt.Rows.Count, Is.EqualTo(this.testObjects.Length));
         }
 
         [Test]

--- a/MoreLinq/Experimental/Batch.cs
+++ b/MoreLinq/Experimental/Batch.cs
@@ -246,12 +246,12 @@ namespace MoreLinq.Experimental
 
             public bool UpdateWithNext()
             {
-                if (this.rental is { Current: var (array, _) } rental)
+                if (this.rental is { } rental)
                 {
                     Debug.Assert(this.pool is not null);
                     if (this.rented)
                     {
-                        this.pool.Return(array);
+                        this.pool.Return(this.array);
                         this.rented = false;
                     }
 
@@ -279,12 +279,12 @@ namespace MoreLinq.Experimental
 
             public void Dispose()
             {
-                if (this.rental is { Current: var (array, _) } enumerator)
+                if (this.rental is { } rental)
                 {
                     Debug.Assert(this.pool is not null);
                     if (this.rented)
-                        this.pool.Return(array);
-                    enumerator.Dispose();
+                        this.pool.Return(this.array);
+                    rental.Dispose();
                     this.array = [];
                     this.count = 0;
                     this.rental = null;

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -164,7 +164,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -156,7 +156,9 @@ namespace MoreLinq
             return table;
         }
 
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
         static MemberInfo[] PrepareMemberInfos<T>(ICollection<Expression<Func<T, object?>>> expressions)
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
         {
             if (expressions.Count == 0)
                 return [];

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,8 +49,10 @@ install:
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 6.0.11 -SkipNonVersionedFiles }
+- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 8.0.11 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 6.0.11 --skip-non-versioned-files
+- sh: ./tools/dotnet-install.sh --runtime dotnet --version 8.0.11 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,7 @@ popd & exit /b %ERRORLEVEL%
 
 :main
 setlocal
+set MSBUILDTERMINALLOGGER=off
 for %%i in (dotnet.exe) do set dotnet=%%~dpnx$PATH:i
 if "%dotnet%"=="" goto :nodotnet
 if "%1"=="docs" shift & goto :docs
@@ -27,7 +28,14 @@ exit /b 2
 
 :codegen
 echo | set /p=Generating extensions wrappers (%1)...
-dotnet run --project bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- %2 %3 %4 %5 %6 %7 %8 %9 > "%temp%\%~nx1" ^
+dotnet build bld\ExtensionsGenerator\MoreLinq.ExtensionsGenerator.csproj -c Release >build.log 2>&1 || (
+    echo Failed!
+    type build.log
+    del build.log
+    exit /b 1
+)
+del build.log
+dotnet bld\ExtensionsGenerator\bin\Release\MoreLinq.ExtensionsGenerator.dll %2 %3 %4 %5 %6 %7 %8 %9 > "%temp%\%~nx1" ^
   && move "%temp%\%~nx1" "%~dp1" > nul ^
   && echo Done.
 exit /b %ERRORLEVEL%

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
+export MSBUILDTERMINALLOGGER=off
 dotnet restore
 dotnet tool restore
 codegen() {
     dest="$1"
     printf "Generating extensions wrappers (%s)..." "$1"
     shift
-    dotnet run --project bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release -- "$@" > "$dest"
+    dotnet build bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj -c Release >build.log || (
+        printf "Failed!\n"
+        cat build.log
+        rm build.log
+        exit 1
+    )
+    dotnet bld/ExtensionsGenerator/bin/Release/MoreLinq.ExtensionsGenerator.dll "$@" > "$dest"
     printf "Done.\n"
 }
 codegen MoreLinq/Extensions.g.cs -x "[/\\\\]ToDataTable\.cs$" -u System.Linq -u System.Collections MoreLinq

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "9.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/test.cmd
+++ b/test.cmd
@@ -21,7 +21,8 @@ call :clean ^
   && call :test net471 Debug ^
   && call :test net471 Release ^
   && call :report-cover ^
-  && call :test-aot
+  && call :test-aot net8.0 ^
+  && call :test-aot net9.0
 exit /b %ERRORLEVEL%
 
 :clean

--- a/test.cmd
+++ b/test.cmd
@@ -8,10 +8,12 @@ setlocal
 if not defined SKIP_TEST_BUILD set SKIP_TEST_BUILD=false
 if %SKIP_TEST_BUILD%==false call build || exit /b 1
 if not "%~1"=="aot" goto :test-all
-call :test-aot
+call :test-aot net8.0 && call :test-aot net9.0
 exit /b %ERRORLEVEL%
 :test-all
 call :clean ^
+  && call :test net9.0 Debug ^
+  && call :test net9.0 Release ^
   && call :test net8.0 Debug ^
   && call :test net8.0 Release ^
   && call :test net6.0 Debug ^
@@ -60,10 +62,10 @@ exit /b %ERRORLEVEL%
 :test-aot
 setlocal
 cd MoreLinq.Test.Aot
-dotnet publish
+dotnet publish -f %1
 if not ERRORLEVEL==0 exit /b %ERRORLEVEL%
 set AOT_TEST_PUBLISH_DIR=
-for /f %%d in ('dir /ad /s /b publish') do if not defined AOT_TEST_PUBLISH_DIR set AOT_TEST_PUBLISH_DIR=%%~d
+for /f %%d in ('cmd /c "dir /ad /s /b publish | findstr /c:%1"') do if not defined AOT_TEST_PUBLISH_DIR set AOT_TEST_PUBLISH_DIR=%%~d
 if not defined AOT_TEST_PUBLISH_DIR (
     echo>&2 Published binary directory not found!
     exit /b 1

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 cd "$(dirname "$0")"
 if [[ "${SKIP_TEST_BUILD:=false}" == "false" ]]; then
     ./build.sh $c
@@ -12,7 +12,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in net6.0 net8.0; do
+for f in net6.0 net8.0 net9.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"
@@ -23,5 +23,7 @@ dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.x
                        -reporttypes:Html\;TextSummary \
                        -targetdir:MoreLinq.Test/TestResults/reports
 cat MoreLinq.Test/TestResults/reports/Summary.txt
-dotnet publish MoreLinq.Test.Aot
-"$(find MoreLinq.Test.Aot -type d -name publish)/MoreLinq.Test.Aot"
+for f in net8.0 net9.0; do
+    dotnet publish -f $f MoreLinq.Test.Aot
+    "$(find MoreLinq.Test.Aot -type d -name publish | grep -F $f)/MoreLinq.Test.Aot"
+done


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 9.0.100 and updates all dependencies to their latest versions.

It also adds .NET 9 testing as a target and updates code needed to compile and run on .NET 9.
