### PR TITLE
Simplify collection initialization with expressions

### DIFF
--- a/MoreLinq.Test.Aot/ToDataTableTest.cs
+++ b/MoreLinq.Test.Aot/ToDataTableTest.cs
@@ -45,9 +45,8 @@ namespace MoreLinq.Test.Aot
         readonly ImmutableArray<TestObject> testObjects;
 
         public ToDataTableTest() =>
-            this.testObjects = Enumerable.Range(0, 3)
-                                         .Select(i => new TestObject(i))
-                                         .ToImmutableArray();
+            this.testObjects = [..from i in Enumerable.Range(0, 3)
+                                  select new TestObject(i)];
 
         [TestMethod]
         public void ToDataTableNullMemberExpressionMethod()

--- a/MoreLinq.Test/AggregateTest.cs
+++ b/MoreLinq.Test/AggregateTest.cs
@@ -51,9 +51,8 @@ namespace MoreLinq.Test
             {
                 Source = source,
                 Expectation = sum,
-                Instantiation = m.MakeGenericMethod(Enumerable.Repeat(typeof(int), m.GetGenericArguments().Length - 1)
-                                                              .Append(typeof(int[])) // TResult
-                                                              .ToArray()),
+                Instantiation = m.MakeGenericMethod([..Enumerable.Repeat(typeof(int), m.GetGenericArguments().Length - 1)
+                                                                 .Append(typeof(int[]))]), // TResult
             }
             into m
             let rst = m.Instantiation.GetParameters().Last().ParameterType

--- a/MoreLinq.Test/BacksertTest.cs
+++ b/MoreLinq.Test/BacksertTest.cs
@@ -57,7 +57,7 @@ namespace MoreLinq.Test
             using var test1 = seq1.AsTestingSequence();
             using var test2 = seq2.AsTestingSequence();
 
-            return test1.Backsert(test2, index).ToArray();
+            return [..test1.Backsert(test2, index)];
         }
     }
 }

--- a/MoreLinq.Test/CartesianTest.cs
+++ b/MoreLinq.Test/CartesianTest.cs
@@ -17,6 +17,7 @@
 
 namespace MoreLinq.Test
 {
+    using System;
     using NUnit.Framework;
 
     /// <summary>
@@ -122,14 +123,14 @@ namespace MoreLinq.Test
             var sequenceA = Enumerable.Range(0, 5);
             var sequenceB = Enumerable.Range(0, 5);
 
-            var expectedSet = new[]
-            {
-                Enumerable.Repeat(false, 5).ToArray(),
-                Enumerable.Repeat(false, 5).ToArray(),
-                Enumerable.Repeat(false, 5).ToArray(),
-                Enumerable.Repeat(false, 5).ToArray(),
-                Enumerable.Repeat(false, 5).ToArray()
-            };
+            bool[][] expectedSet =
+            [
+                [..Enumerable.Repeat(false, 5)],
+                [..Enumerable.Repeat(false, 5)],
+                [..Enumerable.Repeat(false, 5)],
+                [..Enumerable.Repeat(false, 5)],
+                [..Enumerable.Repeat(false, 5)],
+            ];
 
             using var tsA = sequenceA.AsTestingSequence();
             using var tsB = sequenceB.AsTestingSequence();

--- a/MoreLinq.Test/FullGroupJoinTest.cs
+++ b/MoreLinq.Test/FullGroupJoinTest.cs
@@ -126,8 +126,8 @@ namespace MoreLinq.Test
             // Order of joined elements is preserved
             foreach (var (key, first, second) in result)
             {
-                first.AssertSequenceEqual(listA.Where(t => t.Item1 == key).ToArray());
-                second.AssertSequenceEqual(listB.Where(t => t.Item1 == key).ToArray());
+                first.AssertSequenceEqual([..from t in listA where t.Item1 == key select t]);
+                second.AssertSequenceEqual([..from t in listB where t.Item1 == key select t]);
             }
         }
 

--- a/MoreLinq.Test/MaximaTest.cs
+++ b/MoreLinq.Test/MaximaTest.cs
@@ -213,7 +213,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMaxima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Maxima(s => s.Length).Take(count).ToArray();
+                return [..strings.Maxima(s => s.Length).Take(count)];
             }
 
             [TestCase(0, 0, ExpectedResult = new string[0]                         )]
@@ -227,9 +227,8 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMaximaPerComparer(int count, int index)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
-                              .Take(count)
-                              .ToArray();
+                return [..strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
+                                 .Take(count)];
             }
         }
 
@@ -242,7 +241,7 @@ namespace MoreLinq.Test
             public string[] TakeLastReturnsMaxima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Maxima(s => s.Length).TakeLast(count).ToArray();
+                return [..strings.Maxima(s => s.Length).TakeLast(count)];
             }
 
             [TestCase(0, 0, ExpectedResult = new string[0]                         )]
@@ -256,9 +255,8 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMaximaPerComparer(int count, int index)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
-                              .TakeLast(count)
-                              .ToArray();
+                return [..strings.Maxima(s => s[index], Comparable<char>.DescendingOrderComparer)
+                                 .TakeLast(count)];
             }
         }
     }

--- a/MoreLinq.Test/MinimaTest.cs
+++ b/MoreLinq.Test/MinimaTest.cs
@@ -212,7 +212,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMinima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Minima(s => s.Length).Take(count).ToArray();
+                return [..strings.Minima(s => s.Length).Take(count)];
             }
 
             [TestCase(0, ExpectedResult = new string[0]             )]
@@ -222,9 +222,8 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMinimaPerComparer(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                              .Take(count)
-                              .ToArray();
+                return [..strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
+                                 .Take(count)];
             }
         }
 
@@ -240,7 +239,7 @@ namespace MoreLinq.Test
             public string[] ReturnsMinima(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Minima(s => s.Length).TakeLast(count).ToArray();
+                return [..strings.Minima(s => s.Length).TakeLast(count)];
             }
 
             [TestCase(0, ExpectedResult = new string[0]             )]
@@ -250,9 +249,8 @@ namespace MoreLinq.Test
             public string[] WithComparerReturnsMinimaPerComparer(int count)
             {
                 using var strings = SampleData.Strings.AsTestingSequence();
-                return strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
-                              .TakeLast(count)
-                              .ToArray();
+                return [..strings.Minima(s => s.Length, Comparable<int>.DescendingOrderComparer)
+                                 .TakeLast(count)];
             }
         }
     }

--- a/MoreLinq.Test/NullArgumentTest.cs
+++ b/MoreLinq.Test/NullArgumentTest.cs
@@ -103,7 +103,7 @@ namespace MoreLinq.Test
                     _ => throw new NotImplementedException("NullArgumentTest.InstantiateType")
                 };
 
-            return definition.MakeGenericMethod(typeArguments.ToArray());
+            return definition.MakeGenericMethod([..typeArguments]);
         }
 
         static bool IsReferenceType(ParameterInfo parameter) =>

--- a/MoreLinq.Test/PrependTest.cs
+++ b/MoreLinq.Test/PrependTest.cs
@@ -60,7 +60,7 @@ namespace MoreLinq.Test
         [TestCaseSource(nameof(PrependManySource))]
         public int[] PrependMany(int[] head, int[] tail)
         {
-            return tail.Aggregate(head.AsEnumerable(), MoreEnumerable.Prepend).ToArray();
+            return [..tail.Aggregate(head.AsEnumerable(), MoreEnumerable.Prepend)];
         }
 
         public static IEnumerable<TestCaseData> PrependManySource =>

--- a/MoreLinq.Test/RepeatTest.cs
+++ b/MoreLinq.Test/RepeatTest.cs
@@ -46,7 +46,7 @@ namespace MoreLinq.Test
 
             int[] result;
             using (var ts = sequence.AsTestingSequence())
-                result = ts.Repeat(repeatCount).ToArray();
+                result = [..ts.Repeat(repeatCount)];
 
             var expectedResult = Enumerable.Empty<int>();
             for (var i = 0; i < repeatCount; i++)
@@ -94,7 +94,7 @@ namespace MoreLinq.Test
 
             int[] result;
             using (var ts = sequence.AsTestingSequence())
-                result = ts.Repeat().Take(takeCount).ToArray();
+                result = [..ts.Repeat().Take(takeCount)];
 
             var expectedResult = Enumerable.Empty<int>();
             for (var i = 0; i < repeatCount; i++)

--- a/MoreLinq.Test/SkipUntilTest.cs
+++ b/MoreLinq.Test/SkipUntilTest.cs
@@ -77,7 +77,7 @@ namespace MoreLinq.Test
         public int[] TestSkipUntil(int[] source, int min)
         {
             using var ts = source.AsTestingSequence();
-            return ts.SkipUntil(v => v >= min).ToArray();
+            return [..ts.SkipUntil(v => v >= min)];
         }
     }
 }

--- a/MoreLinq.Test/SplitTest.cs
+++ b/MoreLinq.Test/SplitTest.cs
@@ -25,14 +25,14 @@ namespace MoreLinq.Test
         [Test]
         public void SplitWithSeparatorAndResultTransformation()
         {
-            var result = "the quick brown fox".ToCharArray().Split(' ', chars => new string(chars.ToArray()));
+            var result = "the quick brown fox".ToCharArray().Split(' ', chars => new string([..chars]));
             result.AssertSequenceEqual("the", "quick", "brown", "fox");
         }
 
         [Test]
         public void SplitUptoMaxCount()
         {
-            var result = "the quick brown fox".ToCharArray().Split(' ', 2, chars => new string(chars.ToArray()));
+            var result = "the quick brown fox".ToCharArray().Split(' ', 2, chars => new string([..chars]));
             result.AssertSequenceEqual("the", "quick", "brown fox");
         }
 

--- a/MoreLinq.Test/TestExtensions.cs
+++ b/MoreLinq.Test/TestExtensions.cs
@@ -97,10 +97,12 @@ namespace MoreLinq.Test
             sourceKind switch
             {
                 SourceKind.Sequence => input.Select(x => x),
+#pragma warning disable IDE0028 // Simplify collection initialization (would change semantics)
                 SourceKind.BreakingList => new BreakingList<T>(input),
                 SourceKind.BreakingReadOnlyList => new BreakingReadOnlyList<T>(input),
                 SourceKind.BreakingCollection => new BreakingCollection<T>(input),
                 SourceKind.BreakingReadOnlyCollection => new BreakingReadOnlyCollection<T>(input),
+#pragma warning restore IDE0028 // Simplify collection initialization
                 _ => throw new ArgumentException(null, nameof(sourceKind))
             };
     }

--- a/MoreLinq.Test/ToDataTableTest.cs
+++ b/MoreLinq.Test/ToDataTableTest.cs
@@ -44,9 +44,22 @@ namespace MoreLinq.Test
         readonly ImmutableArray<TestObject> testObjects;
 
         public ToDataTableTest() =>
-            this.testObjects = Enumerable.Range(0, 3)
-                                         .Select(i => new TestObject(i))
-                                         .ToImmutableArray();
+            this.testObjects =
+#if NET8_0_OR_GREATER
+                [..
+#else
+#pragma warning disable IDE0303 // Use array creation expression
+                ImmutableArray.CreateRange(
+#pragma warning restore IDE0303 // Use array creation expression
+#endif
+                    from i in Enumerable.Range(0, 3)
+                    select new TestObject(i)
+#if NET8_0_OR_GREATER
+                ]
+#else
+                )
+#endif
+                ;
 
         [Test]
         public void ToDataTableNullMemberExpressionMethod()

--- a/MoreLinq.Test/WindowLeftTest.cs
+++ b/MoreLinq.Test/WindowLeftTest.cs
@@ -93,7 +93,7 @@ namespace MoreLinq.Test
 
             IList<int>[] result;
             using (var ts = sequence.AsTestingSequence())
-                result = ts.WindowLeft(1).ToArray();
+                result = [..ts.WindowLeft(1)];
 
             // number of windows should be equal to the source sequence length
             Assert.That(result.Length, Is.EqualTo(count));

--- a/MoreLinq.Test/WindowRightTest.cs
+++ b/MoreLinq.Test/WindowRightTest.cs
@@ -93,7 +93,7 @@ namespace MoreLinq.Test
 
             IList<int>[] result;
             using (var ts = sequence.AsTestingSequence())
-                result = ts.WindowRight(1).ToArray();
+                result = [..ts.WindowRight(1)];
 
             // number of windows should be equal to the source sequence length
             Assert.That(result.Length, Is.EqualTo(count));

--- a/MoreLinq.Test/ZipLongestTest.cs
+++ b/MoreLinq.Test/ZipLongestTest.cs
@@ -45,7 +45,7 @@ namespace MoreLinq.Test
         {
             using var ts1 = first.AsTestingSequence();
             using var ts2 = second.AsTestingSequence();
-            return ts1.ZipLongest(ts2, Tuple.Create).ToArray();
+            return [..ts1.ZipLongest(ts2, Tuple.Create)];
         }
 
         [Test]

--- a/MoreLinq/EndsWith.cs
+++ b/MoreLinq/EndsWith.cs
@@ -75,7 +75,7 @@ namespace MoreLinq
             return second.TryAsCollectionLike() is { Count: var secondCount }
                    ? first.TryAsCollectionLike() is not { Count: var firstCount } || secondCount <= firstCount
                      && EndsWith(second, secondCount)
-                   : EndsWith(secondList = second.ToList(), secondList.Count);
+                   : EndsWith(secondList = [..second], secondList.Count);
 
             bool EndsWith(IEnumerable<T> second, int count) =>
                 first.TakeLast(count).SequenceEqual(second, comparer);

--- a/MoreLinq/Experimental/Memoize.cs
+++ b/MoreLinq/Experimental/Memoize.cs
@@ -58,7 +58,9 @@ namespace MoreLinq.Experimental
                 ICollection<T> => source,
                 IReadOnlyCollection<T> => source,
                 MemoizedEnumerable<T> => source,
+#pragma warning disable IDE0306 // Simplify collection initialization (would change semantics)
                 _ => new MemoizedEnumerable<T>(source),
+#pragma warning restore IDE0306 // Simplify collection initialization
             };
     }
 

--- a/MoreLinq/Rank.cs
+++ b/MoreLinq/Rank.cs
@@ -81,7 +81,9 @@ namespace MoreLinq
 
             static IEnumerable<int> _(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
             {
+#pragma warning disable IDE0305 // Simplify collection initialization (could be less optimal)
                 source = source.ToArray(); // avoid enumerating source twice
+#pragma warning restore IDE0305 // Simplify collection initialization
 
                 var rankDictionary = new Collections.Dictionary<TSource, int>(EqualityComparer<TSource>.Default);
                 var i = 1;

--- a/MoreLinq/SortedMerge.cs
+++ b/MoreLinq/SortedMerge.cs
@@ -158,7 +158,7 @@ namespace MoreLinq
 
         sealed class DisposableGroup<T>(IEnumerable<IEnumerator<T>> iterators) : IDisposable
         {
-            public List<IEnumerator<T>> Iterators { get; } = new(iterators);
+            public List<IEnumerator<T>> Iterators { get; } = [..iterators];
 
             public IEnumerator<T> this[int index] => Iterators[index];
 

--- a/MoreLinq/ToDataTable.cs
+++ b/MoreLinq/ToDataTable.cs
@@ -171,7 +171,7 @@ namespace MoreLinq
                 throw new ArgumentException("One of the supplied expressions was null.", nameof(expressions));
             try
             {
-                return expressions.Select(GetAccessedMember).ToArray();
+                return [..from e in expressions select GetAccessedMember(e)];
             }
             catch (ArgumentException e)
             {


### PR DESCRIPTION
This PR uses collection expressions to simplify collection initialization:

- [IDE0028](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0028)
- [IDE0303](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0303)
- [IDE0305](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0305)
- [IDE0306](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0306)