### PR TITLE
Update .NET SDK to 9.0.300, including dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "9.0.200",
+      "version": "9.0.300",
       "dotnetRuntimeVersions": "8.0.14, 6.0.36"
     },
     "ghcr.io/devcontainers/features/common-utils:2": {

--- a/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
+++ b/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24562.1" />
     <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.14.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.6.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.8.2">
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.1" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.7.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="MSTest.Analyzers" Version="3.9.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
+++ b/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.24562.1" />
-    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.24562.1" />
+    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.25277.3" />
+    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.25277.3" />
     <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.14.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.1" />

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net471'">
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.5" />
     <Compile Remove="Async\*.cs" />
   </ItemGroup>
 

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.5" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "9.0.300",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 9.0.300 and updates all system-related dependencies to their latest versions.