### PR TITLE
Drop target for .NET 6 that's no longer supported

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "9.0.200",
-      "dotnetRuntimeVersions": "8.0.14, 6.0.36"
+      "dotnetRuntimeVersions": "8.0.14"
     },
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": false,

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net9.0;net8.0;net6.0;net471</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net471</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType Condition="'$(TargetFramework)' == 'net471'">Exe</OutputType>

--- a/MoreLinq.shfbproj
+++ b/MoreLinq.shfbproj
@@ -31,8 +31,8 @@
     <BuildAssemblerVerbosity>OnlyWarningsAndErrors</BuildAssemblerVerbosity>
     <SaveComponentCacheCapacity>100</SaveComponentCacheCapacity>
     <DocumentationSources>
-      <DocumentationSource sourceFile="MoreLinq\bin\Release\net6.0\MoreLinq.dll" />
-      <DocumentationSource sourceFile="MoreLinq\bin\Release\net6.0\MoreLinq.xml" />
+      <DocumentationSource sourceFile="MoreLinq\bin\Release\net8.0\MoreLinq.dll" />
+      <DocumentationSource sourceFile="MoreLinq\bin\Release\net8.0\MoreLinq.xml" />
     </DocumentationSources>
     <HelpFileFormat>Website</HelpFileFormat>
     <CopyrightHref>http://www.apache.org/licenses/LICENSE-2.0</CopyrightHref>

--- a/MoreLinq/CompatibilitySuppressions.xml
+++ b/MoreLinq/CompatibilitySuppressions.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.ToDictionary``2(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``1}},System.Collections.Generic.IEqualityComparer{``0})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.ToDictionary``2(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{``0,``1}})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.ToDictionary``2(System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}},System.Collections.Generic.IEqualityComparer{``0})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.ToDictionary``2(System.Collections.Generic.IEnumerable{System.ValueTuple{``0,``1}})</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.SequenceException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
-    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Left>lib/netstandard2.1/MoreLinq.dll</Left>
     <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
@@ -83,36 +83,85 @@
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
     <Left>lib/netstandard2.1/MoreLinq.dll</Left>
-    <Right>lib/net6.0/MoreLinq.dll</Right>
+    <Right>lib/net8.0/MoreLinq.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0008</DiagnosticId>
+    <Target>T:MoreLinq.OrderByDirection</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IEqualityComparer{``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.DistinctBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.MaxBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1},System.Collections.Generic.IComparer{``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:MoreLinq.MoreEnumerable.MinBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})</Target>
+    <Left>lib/net6.0/MoreLinq.dll</Left>
+    <Right>lib/netstandard2.1/MoreLinq.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
 </Suppressions>

--- a/MoreLinq/MoreLinq.csproj
+++ b/MoreLinq/MoreLinq.csproj
@@ -122,7 +122,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>4.4.1</VersionPrefix>
     <Authors>MoreLINQ Developers.</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MoreLinq</AssemblyName>
@@ -214,7 +214,7 @@
     <DefineConstants>$(DefineConstants);MORELINQ</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0' ">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <DefineConstants>$(DefineConstants);NO_STATIC_ABSTRACTS</DefineConstants>
   </PropertyGroup>
 
@@ -222,7 +222,7 @@
     <DefineConstants>$(DefineConstants);NO_STATIC_ABSTRACTS;NO_ASYNC_STREAMS;NO_BUFFERS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);DYNAMIC_CODE_FALLBACK</DefineConstants>
   </PropertyGroup>
 

--- a/test.cmd
+++ b/test.cmd
@@ -16,8 +16,6 @@ call :clean ^
   && call :test net9.0 Release ^
   && call :test net8.0 Debug ^
   && call :test net8.0 Release ^
-  && call :test net6.0 Debug ^
-  && call :test net6.0 Release ^
   && call :test net471 Debug ^
   && call :test net471 Release ^
   && call :report-cover ^

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in net6.0 net8.0 net9.0; do
+for f in net8.0 net9.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"


### PR DESCRIPTION
This PR drops the [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) run-time target that's no longer supported. It reached end-of-life on November 12, 2024.