### PR TITLE
Remove .NET 6 runtime installation on all CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,10 +49,8 @@ install:
 - pwsh: ./eclint.ps1 -TrimTrailingWhitespace -Verbose
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
-- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 6.0.11 -SkipNonVersionedFiles }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 8.0.11 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
-- sh: ./tools/dotnet-install.sh --runtime dotnet --version 6.0.11 --skip-non-versioned-files
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 8.0.11 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:


### PR DESCRIPTION
This is a follow-up to PR #1104.