### PR TITLE
Update .NET SDK to 10.0.100, including dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,8 +27,8 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "9.0.300",
-      "dotnetRuntimeVersions": "8.0.14"
+      "version": "10.0.100",
+      "dotnetRuntimeVersions": "8.0.14, 9.0.11"
     },
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": false,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
   SKIP_TEST_BUILD: true
 
 jobs:

--- a/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
+++ b/MoreLinq.Test.Aot/MoreLinq.Test.Aot.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <OutputType>exe</OutputType>
     <IsPackable>false</IsPackable>
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.Engine" Version="1.0.0-alpha.25277.3" />
-    <PackageReference Include="MSTest.SourceGeneration" Version="1.0.0-alpha.25277.3" />
-    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.1" />
-    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.7.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.9.1">
+    <PackageReference Include="MSTest.Engine" Version="2.0.0-alpha.25561.4" />
+    <PackageReference Include="MSTest.SourceGeneration" Version="2.0.0-alpha.25561.4" />
+    <PackageReference Include="Microsoft.CodeCoverage.MSBuild" Version="18.1.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="MSTest.Analyzers" Version="4.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MoreLinq.Test.Aot/ToDataTableTest.cs
+++ b/MoreLinq.Test.Aot/ToDataTableTest.cs
@@ -56,7 +56,7 @@ namespace MoreLinq.Test.Aot
             [UnconditionalSuppressMessage("Aot", "IL2026")]
             void Act() => _ = this.testObjects.ToDataTable(expression!);
 
-            var e = Assert.ThrowsException<ArgumentException>(Act);
+            var e = Assert.Throws<ArgumentException>(Act);
             Assert.AreEqual("expressions", e.ParamName);
         }
 
@@ -69,7 +69,7 @@ namespace MoreLinq.Test.Aot
             [UnconditionalSuppressMessage("Aot", "IL2026")]
             void Act() => _ = this.testObjects.ToDataTable(dt);
 
-            var e = Assert.ThrowsException<ArgumentException>(Act);
+            var e = Assert.Throws<ArgumentException>(Act);
             Assert.AreEqual("table", e.ParamName);
         }
 
@@ -82,7 +82,7 @@ namespace MoreLinq.Test.Aot
             [UnconditionalSuppressMessage("Aot", "IL2026")]
             void Act() => _ = this.testObjects.ToDataTable(dt, t => t.AString);
 
-            var e = Assert.ThrowsException<ArgumentException>(Act);
+            var e = Assert.Throws<ArgumentException>(Act);
             Assert.AreEqual("table", e.ParamName);
         }
 
@@ -91,12 +91,11 @@ namespace MoreLinq.Test.Aot
             [UnconditionalSuppressMessage("Aot", "IL2026")]
             void Act() => _ = this.testObjects.ToDataTable(expression);
 
-            var e = Assert.ThrowsException<ArgumentException>(Act);
+            var e = Assert.Throws<ArgumentException>(Act);
             Assert.AreEqual("expressions", e.ParamName);
             var innerException = e.InnerException;
             Assert.IsNotNull(innerException);
-            Assert.IsInstanceOfType<ArgumentException>(innerException);
-            Assert.AreEqual("lambda", ((ArgumentException)innerException).ParamName);
+            Assert.AreEqual("lambda", Assert.IsInstanceOfType<ArgumentException>(innerException).ParamName);
         }
 
         [TestMethod]
@@ -146,7 +145,7 @@ namespace MoreLinq.Test.Aot
             Assert.AreEqual("ANullableDecimal", dt.Columns[1].Caption);
             Assert.AreEqual(typeof(decimal), dt.Columns[1].DataType);
 
-            Assert.AreEqual(4, dt.Columns.Count);
+            Assert.HasCount(4, dt.Columns);
         }
 
         [TestMethod]
@@ -157,7 +156,7 @@ namespace MoreLinq.Test.Aot
 
             var dt = Act();
 
-            Assert.AreEqual(this.testObjects.Length, dt.Rows.Count);
+            Assert.HasCount(this.testObjects.Length, dt.Rows);
         }
 
         [TestMethod]
@@ -171,7 +170,7 @@ namespace MoreLinq.Test.Aot
             Assert.AreEqual("AString", dt.Columns[0].Caption);
             Assert.AreEqual(typeof(string), dt.Columns[0].DataType);
 
-            Assert.AreEqual(1, dt.Columns.Count);
+            Assert.HasCount(1, dt.Columns);
         }
 
         [TestMethod]
@@ -195,7 +194,7 @@ namespace MoreLinq.Test.Aot
             Act();
 
             var rows = dt.Rows.Cast<DataRow>().ToArray();
-            Assert.AreEqual(vars.Length, rows.Length);
+            Assert.HasCount(vars.Length, rows);
             CollectionAssert.AreEqual(vars.Select(e => e.Key).ToArray(), rows.Select(r => r["Name"]).ToArray());
             CollectionAssert.AreEqual(vars.Select(e => e.Value).ToArray(), rows.Select(r => r["Value"]).ToArray());
         }
@@ -218,7 +217,7 @@ namespace MoreLinq.Test.Aot
 
             var points = Act();
 
-            Assert.AreEqual(3, points.Columns.Count);
+            Assert.HasCount(3, points.Columns);
             var x = points.Columns["X"];
             var y = points.Columns["Y"];
             var empty = points.Columns["IsEmpty"];
@@ -228,7 +227,7 @@ namespace MoreLinq.Test.Aot
             var row = points.Rows.Cast<DataRow>().Single();
             Assert.AreEqual(12, row[x]);
             Assert.AreEqual(34, row[y]);
-            Assert.AreEqual(row[empty], false);
+            Assert.IsFalse(row[empty] as bool?);
         }
     }
 }

--- a/MoreLinq.Test/Async/AsyncEnumerable.cs
+++ b/MoreLinq.Test/Async/AsyncEnumerable.cs
@@ -21,6 +21,7 @@ namespace MoreLinq.Test.Async
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using LinqEnumerable = System.Linq.AsyncEnumerable;
 
@@ -45,68 +46,35 @@ namespace MoreLinq.Test.Async
         public static ValueTask<bool> AnyAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.AnyAsync(source, predicate);
 
-        public static IAsyncEnumerable<TSource> AsEnumerable<TSource>(this IAsyncEnumerable<TSource> source) =>
-            LinqEnumerable.AsAsyncEnumerable(source);
+        public static ValueTask<float?> AverageAsync(this IAsyncEnumerable<float?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<double> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<long?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<decimal?> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<int?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<double?> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double?> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<double?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<float> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<decimal?> AverageAsync(this IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<double?> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long?> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<long> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<float?> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float?> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<int> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<double> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<double> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<double?> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int?> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
+        public static ValueTask<float> AverageAsync(this IAsyncEnumerable<float> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
-        public static ValueTask<decimal> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
-
-        public static ValueTask<double> AverageAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double> selector) =>
-            LinqEnumerable.AverageAsync(source, selector);
-
-        public static ValueTask<float?> AverageAsync(this IAsyncEnumerable<float?> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<long?> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<int?> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double?> AverageAsync(this IAsyncEnumerable<double?> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<decimal?> AverageAsync(this IAsyncEnumerable<decimal?> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<long> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<int> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<double> AverageAsync(this IAsyncEnumerable<double> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<float> AverageAsync(this IAsyncEnumerable<float> source) =>
-            LinqEnumerable.AverageAsync(source);
-
-        public static ValueTask<decimal> AverageAsync(this IAsyncEnumerable<decimal> source) =>
-            LinqEnumerable.AverageAsync(source);
+        public static ValueTask<decimal> AverageAsync(this IAsyncEnumerable<decimal> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.AverageAsync(source, cancellationToken);
 
         public static IAsyncEnumerable<TResult> Cast<TResult>(this IAsyncEnumerable<object> source) =>
             LinqEnumerable.Cast<TResult>(source);
@@ -126,7 +94,7 @@ namespace MoreLinq.Test.Async
         public static ValueTask<int> CountAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.CountAsync(source);
 
-        public static IAsyncEnumerable<TSource> DefaultIfEmpty<TSource>(this IAsyncEnumerable<TSource> source) =>
+        public static IAsyncEnumerable<TSource?> DefaultIfEmpty<TSource>(this IAsyncEnumerable<TSource> source) =>
             LinqEnumerable.DefaultIfEmpty(source);
 
         public static IAsyncEnumerable<TSource> DefaultIfEmpty<TSource>(this IAsyncEnumerable<TSource> source, TSource defaultValue) =>
@@ -165,34 +133,34 @@ namespace MoreLinq.Test.Async
         public static ValueTask<TSource?> FirstOrDefaultAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.FirstOrDefaultAsync(source, predicate);
 
-        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IAsyncEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
             LinqEnumerable.GroupBy(source, keySelector, resultSelector, comparer);
 
-        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IAsyncEnumerable<TSource>, TResult> resultSelector) =>
+        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector) =>
             LinqEnumerable.GroupBy(source, keySelector, resultSelector);
 
-        public static IAsyncEnumerable<IAsyncGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
+        public static IAsyncEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) =>
             LinqEnumerable.GroupBy(source, keySelector, elementSelector, comparer);
 
-        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IAsyncEnumerable<TElement>, TResult> resultSelector) =>
+        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector) =>
             LinqEnumerable.GroupBy(source, keySelector, elementSelector, resultSelector);
 
-        public static IAsyncEnumerable<IAsyncGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
+        public static IAsyncEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) =>
             LinqEnumerable.GroupBy(source, keySelector, comparer);
 
-        public static IAsyncEnumerable<IAsyncGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
+        public static IAsyncEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
             LinqEnumerable.GroupBy(source, keySelector);
 
-        public static IAsyncEnumerable<IAsyncGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
+        public static IAsyncEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) =>
             LinqEnumerable.GroupBy(source, keySelector, elementSelector);
 
-        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IAsyncEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+        public static IAsyncEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
             LinqEnumerable.GroupBy(source, keySelector, elementSelector, resultSelector, comparer);
 
-        public static IAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IAsyncEnumerable<TInner>, TResult> resultSelector) =>
+        public static IAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector) =>
             LinqEnumerable.GroupJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector);
 
-        public static IAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IAsyncEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
+        public static IAsyncEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IAsyncEnumerable<TOuter> outer, IAsyncEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer) =>
             LinqEnumerable.GroupJoin(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
 
         public static IAsyncEnumerable<TSource> Intersect<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second) =>
@@ -225,137 +193,11 @@ namespace MoreLinq.Test.Async
         public static ValueTask<long> LongCountAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate) =>
             LinqEnumerable.LongCountAsync(source, predicate);
 
-        public static ValueTask<double> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
+        public static ValueTask<TSource?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, IComparer<TSource>? comparer = null, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.MaxAsync(source, comparer, cancellationToken);
 
-        public static ValueTask<int> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<long> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<decimal?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<decimal> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<int?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int?> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<long?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long?> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<float?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float?> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<TResult> MaxAsync<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<double?> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double?> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<TSource> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<float> MaxAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float> selector) =>
-            LinqEnumerable.MaxAsync(source, selector);
-
-        public static ValueTask<float?> MaxAsync(this IAsyncEnumerable<float?> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<long?> MaxAsync(this IAsyncEnumerable<long?> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<int?> MaxAsync(this IAsyncEnumerable<int?> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<double?> MaxAsync(this IAsyncEnumerable<double?> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<decimal?> MaxAsync(this IAsyncEnumerable<decimal?> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<long> MaxAsync(this IAsyncEnumerable<long> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<int> MaxAsync(this IAsyncEnumerable<int> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<double> MaxAsync(this IAsyncEnumerable<double> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<decimal> MaxAsync(this IAsyncEnumerable<decimal> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<float> MaxAsync(this IAsyncEnumerable<float> source) =>
-            LinqEnumerable.MaxAsync(source);
-
-        public static ValueTask<int> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<long> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<decimal?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<double?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double?> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<TResult> MinAsync<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, TResult> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<long?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long?> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<float?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float?> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<float> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<decimal> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<int?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int?> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<TSource> MinAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<double> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double> selector) =>
-            LinqEnumerable.MinAsync(source, selector);
-
-        public static ValueTask<float?> MinAsync(this IAsyncEnumerable<float?> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<long?> MinAsync(this IAsyncEnumerable<long?> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<int?> MinAsync(this IAsyncEnumerable<int?> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<double?> MinAsync(this IAsyncEnumerable<double?> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<decimal?> MinAsync(this IAsyncEnumerable<decimal?> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<long> MinAsync(this IAsyncEnumerable<long> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<int> MinAsync(this IAsyncEnumerable<int> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<double> MinAsync(this IAsyncEnumerable<double> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<decimal> MinAsync(this IAsyncEnumerable<decimal> source) =>
-            LinqEnumerable.MinAsync(source);
-
-        public static ValueTask<float> MinAsync(this IAsyncEnumerable<float> source) =>
-            LinqEnumerable.MinAsync(source);
+        public static ValueTask<TSource?> MinAsync<TSource>(this IAsyncEnumerable<TSource> source, IComparer<TSource>? comparer = null, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.MinAsync(source, comparer, cancellationToken);
 
         public static IAsyncEnumerable<TResult> OfType<TResult>(this IAsyncEnumerable<object> source) =>
             LinqEnumerable.OfType<TResult>(source);
@@ -396,7 +238,7 @@ namespace MoreLinq.Test.Async
         public static IAsyncEnumerable<TResult> SelectMany<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, int, IAsyncEnumerable<TResult>> selector) =>
             LinqEnumerable.SelectMany(source, selector);
 
-        public static IAsyncEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, int, IAsyncEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector) =>
+        public static IAsyncEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, int, IAsyncEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, CancellationToken, ValueTask<TResult>> resultSelector) =>
             LinqEnumerable.SelectMany(source, collectionSelector, resultSelector);
 
         public static ValueTask<bool> SequenceEqualAsync<TSource>(this IAsyncEnumerable<TSource> first, IAsyncEnumerable<TSource> second, IEqualityComparer<TSource> comparer) =>
@@ -426,65 +268,35 @@ namespace MoreLinq.Test.Async
         public static IAsyncEnumerable<TSource> SkipWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate) =>
             LinqEnumerable.SkipWhile(source, predicate);
 
-        public static ValueTask<int?> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int?> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<float?> SumAsync(this IAsyncEnumerable<float?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<int> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<long?> SumAsync(this IAsyncEnumerable<long?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<long> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<int?> SumAsync(this IAsyncEnumerable<int?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<decimal?> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal?> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<double?> SumAsync(this IAsyncEnumerable<double?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<float> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<decimal?> SumAsync(this IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<float?> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, float?> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<float> SumAsync(this IAsyncEnumerable<float> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<double> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<long> SumAsync(this IAsyncEnumerable<long> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<long?> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, long?> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<int> SumAsync(this IAsyncEnumerable<int> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<decimal> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, decimal> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
+        public static ValueTask<double> SumAsync(this IAsyncEnumerable<double> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
-        public static ValueTask<double?> SumAsync<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, double?> selector) =>
-            LinqEnumerable.SumAsync(source, selector);
-
-        public static ValueTask<float?> SumAsync(this IAsyncEnumerable<float?> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<long?> SumAsync(this IAsyncEnumerable<long?> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<int?> SumAsync(this IAsyncEnumerable<int?> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<double?> SumAsync(this IAsyncEnumerable<double?> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<decimal?> SumAsync(this IAsyncEnumerable<decimal?> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<float> SumAsync(this IAsyncEnumerable<float> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<long> SumAsync(this IAsyncEnumerable<long> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<int> SumAsync(this IAsyncEnumerable<int> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<double> SumAsync(this IAsyncEnumerable<double> source) =>
-            LinqEnumerable.SumAsync(source);
-
-        public static ValueTask<decimal> SumAsync(this IAsyncEnumerable<decimal> source) =>
-            LinqEnumerable.SumAsync(source);
+        public static ValueTask<decimal> SumAsync(this IAsyncEnumerable<decimal> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.SumAsync(source, cancellationToken);
 
         public static IAsyncEnumerable<TSource> Take<TSource>(this IAsyncEnumerable<TSource> source, int count) =>
             LinqEnumerable.Take(source, count);
@@ -526,8 +338,8 @@ namespace MoreLinq.Test.Async
             where TKey : notnull =>
             LinqEnumerable.ToDictionaryAsync(source, keySelector, elementSelector, comparer);
 
-        public static ValueTask<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source) =>
-            LinqEnumerable.ToListAsync(source);
+        public static ValueTask<List<TSource>> ToListAsync<TSource>(this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default) =>
+            LinqEnumerable.ToListAsync(source, cancellationToken);
 
         public static ValueTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector) =>
             LinqEnumerable.ToLookupAsync(source, keySelector);

--- a/MoreLinq.Test/MoreLinq.Test.csproj
+++ b/MoreLinq.Test/MoreLinq.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>MoreLinq.Test</AssemblyTitle>
-    <TargetFrameworks>net9.0;net8.0;net471</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0;net471</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>MoreLinq.Test</AssemblyName>
     <OutputType Condition="'$(TargetFramework)' == 'net471'">Exe</OutputType>
@@ -37,18 +37,18 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Reactive" Version="6.0.1" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net471'">
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <Compile Remove="Program.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.0" />
     <Compile Remove="Async\*.cs" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 - Ubuntu1804
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
   SKIP_TEST_BUILD: true
 skip_commits:
   files:
@@ -50,8 +50,10 @@ install:
 - git reset --hard
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -JSonFile global.json }
 - ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 8.0.11 -SkipNonVersionedFiles }
+- ps: if ($isWindows) { tools\dotnet-install.ps1 -Runtime dotnet -Version 9.0.11 -SkipNonVersionedFiles }
 - sh: ./tools/dotnet-install.sh --jsonfile global.json
 - sh: ./tools/dotnet-install.sh --runtime dotnet --version 8.0.11 --skip-non-versioned-files
+- sh: ./tools/dotnet-install.sh --runtime dotnet --version 9.0.11 --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
+++ b/bld/ExtensionsGenerator/MoreLinq.ExtensionsGenerator.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/test.cmd
+++ b/test.cmd
@@ -12,6 +12,8 @@ call :test-aot net8.0 && call :test-aot net9.0
 exit /b %ERRORLEVEL%
 :test-all
 call :clean ^
+  && call :test net10.0 Debug ^
+  && call :test net10.0 Release ^
   && call :test net9.0 Debug ^
   && call :test net9.0 Release ^
   && call :test net8.0 Debug ^
@@ -20,7 +22,8 @@ call :clean ^
   && call :test net471 Release ^
   && call :report-cover ^
   && call :test-aot net8.0 ^
-  && call :test-aot net9.0
+  && call :test-aot net9.0 ^
+  && call :test-aot net10.0
 exit /b %ERRORLEVEL%
 
 :clean

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ if [[ -z "$1" ]]; then
 else
     configs="$1"
 fi
-for f in net8.0 net9.0; do
+for f in net8.0 net9.0 net10.0; do
     for c in $configs; do
         dotnet test --no-build -c $c -f $f --settings MoreLinq.Test/coverlet.runsettings MoreLinq.Test
         TEST_RESULTS_DIR="$(ls -dc MoreLinq.Test/TestResults/* | head -1)"
@@ -23,7 +23,7 @@ dotnet reportgenerator -reports:MoreLinq.Test/TestResults/coverage-*.opencover.x
                        -reporttypes:Html\;TextSummary \
                        -targetdir:MoreLinq.Test/TestResults/reports
 cat MoreLinq.Test/TestResults/reports/Summary.txt
-for f in net8.0 net9.0; do
+for f in net8.0 net9.0 net10.0; do
     dotnet publish -f $f MoreLinq.Test.Aot
     "$(find MoreLinq.Test.Aot -type d -name publish | grep -F $f)/MoreLinq.Test.Aot"
 done


### PR DESCRIPTION
This PR updates the solution to use .NET SDK 10.0.100 and updates all dependencies to their latest versions.

It also adds .NET 10 testing as a target and updates code needed to compile and run with updated dependencies.
